### PR TITLE
Fix CMAKE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.la
 *.Plo
 lib/*
+
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++ PATHS ENV PATH NO_DEFAULT_PA
 
 LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
+################################## Dependencies ################################
 include(CPM)
 
 #Luke's handing cmake modules which Neutrino hep experiments might want
@@ -64,11 +65,30 @@ CPMFindPackage(
       "YAML_BUILD_SHARED_LIBS ON"
 )
 
+CPMAddPackage(
+  NAME Eigen
+  VERSION 3.2.8
+  URL https://gitlab.com/libeigen/eigen/-/archive/3.2.8/eigen-3.2.8.tar.gz
+  # Eigen's CMakelists are not intended for library use
+  DOWNLOAD_ONLY YES
+)
+
+if(Eigen_ADDED)
+  add_library(Eigen INTERFACE IMPORTED)
+  target_include_directories(Eigen INTERFACE ${Eigen_SOURCE_DIR})
+endif()
+
+################################## Oscillation ################################
+
+#If USE_PROB3 not defined turn it off by default
+if(NOT DEFINED USE_PROB3)
+  SET(USE_PROB3 FALSE)
+endif()
+
 # Oscillation calcualtion
 # In the future which osc calc we use might be set with a flag
 
-if (${USE_PROB3})
-
+if (USE_PROB3)
   CPMFindPackage(
       NAME Prob3plusplus
       VERSION 3.10.3
@@ -92,26 +112,9 @@ else()
   endif()
 endif()
 
-CPMAddPackage(
-  NAME Eigen
-  VERSION 3.2.8
-  URL https://gitlab.com/libeigen/eigen/-/archive/3.2.8/eigen-3.2.8.tar.gz
-  # Eigen's CMakelists are not intended for library use
-  DOWNLOAD_ONLY YES 
-)
-
-if(Eigen_ADDED)
-  add_library(Eigen INTERFACE IMPORTED)
-  target_include_directories(Eigen INTERFACE ${Eigen_SOURCE_DIR})
-endif()
-
 dump_cmake_variables(Prob3plusplus)
 
-# Would be good to have a check on CMAKE_CXX_STANDARD here
-if(${ROOT_CXX_STANDARD} LESS 14)
-  cmessage(WARNING "ROOT CXX STANDARD: ${ROOT_CXX_STANDARD}")
-endif()
-
+############################  Setting Flags  ####################################
 # Check the where to install 
 cmessage(STATUS "CMAKE_INSTALL_PREFIX: \"${CMAKE_INSTALL_PREFIX}\"")
 
@@ -137,7 +140,7 @@ endif()
 
 #KS: If Debug enable add debugging options if not add optimisation flags
 if(MaCh3_DEBUG_ENABLED)
-  add_compile_options(-DDEBUG)
+  add_compile_definitions(DEBUG)
 else()
   add_compile_options(-O3)
 endif()
@@ -149,23 +152,22 @@ endif()
 
 #Add MultiThread flags
 if(MaCh3_MULTITHREAD_ENABLED)
-  add_compile_options(-fopenmp -DMULTITHREAD)
-  add_link_options(-fopenmp -DMULTITHREAD)
+  add_compile_options(-fopenmp)
+  add_compile_definitions(MULTITHREAD)
 endif()
 
 if(CPU_ONLY)
-  add_compile_options(-DCPU_ONLY)
+  add_compile_definitions(CPU_ONLY)
 else()
   add_compile_options(-I${CUDA_SAMPLES}/common/inc)
   add_compile_options(-I$ENV{CUDAPATH}/targets/x86_64-linux/include)
 endif()
 
-if(${USE_PROB3})
-  add_compile_options(-DUSE_PROB3)
+if(USE_PROB3)
+  add_compile_definitions(USE_PROB3)
 endif()
 
-
-############################  c++ Compiler  ####################################
+############################  C++ Compiler  ####################################
 if (NOT DEFINED CMAKE_CXX_STANDARD OR "${CMAKE_CXX_STANDARD} " STREQUAL " ")
   SET(CMAKE_CXX_STANDARD 11)
 endif()
@@ -174,6 +176,12 @@ if(DEFINED ROOT_CXX_STANDARD AND ROOT_CXX_STANDARD GREATER CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD ${ROOT_CXX_STANDARD})
 endif()
 cmessage(STATUS "CMAKE CXX Standard: ${CMAKE_CXX_STANDARD}")
+
+if(${ROOT_CXX_STANDARD} LESS 14)
+  cmessage(WARNING "ROOT CXX STANDARD: ${ROOT_CXX_STANDARD}")
+endif()
+
+################################# Features ##################################
 
 LIST(APPEND ALL_FEATURES
   DEBUG
@@ -185,13 +193,17 @@ foreach(f ${ALL_FEATURES})
   cmessage(STATUS "     ${f}: ${MaCh3_${f}_ENABLED}")
 endforeach()
 
+################################# Build MaCh3 ##################################
+
 # Build components
 # add_subdirectory(Diagnostics)
 add_subdirectory(manager)
 add_subdirectory(throwParms)
 add_subdirectory(covariance)
 add_subdirectory(splines)
-add_subdirectory(OscClass)
+if (NOT USE_PROB3)
+  add_subdirectory(OscClass)
+endif()
 add_subdirectory(samplePDF)
 add_subdirectory(mcmc)
 #ETA - commenting out as not c++11 compatible...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,9 +138,20 @@ if(NOT DEFINED MaCh3_DEBUG_ENABLED)
   SET(MaCh3_DEBUG_ENABLED FALSE)
 endif()
 
-#KS: If Debug enable add debugging options if not add optimisation flags
+#If DEBUG_LEVEL was defined but MaCh3_DEBUG_ENABLED not, enable debug flag
+if(DEFINED DEBUG_LEVEL)
+  SET(MaCh3_DEBUG_ENABLED TRUE)
+else()
+  #If MaCh debug was enable but level not, set it to 1. In very rare cases we want to go beyond 1.
+  if(MaCh3_DEBUG_ENABLED)
+    SET(DEBUG_LEVEL 1)
+  endif()
+endif()
+
+#KS: If Debug add debugging compile flag if not add optimisation for speed
 if(MaCh3_DEBUG_ENABLED)
-  add_compile_definitions(DEBUG)
+  add_compile_definitions(DEBUG=${DEBUG_LEVEL})
+  cmessage(STATUS "Enabling DEBUG with Level: \"${DEBUG_LEVEL}\"")
 else()
   add_compile_options(-O3)
 endif()
@@ -209,6 +220,7 @@ add_subdirectory(mcmc)
 #ETA - commenting out as not c++11 compatible...
 #add_subdirectory(yaml_test)
 
+
 #This is to export the target properties of MaCh3
 #Anything that links to "MaCh3" will get all of these target properties
 if(NOT TARGET MaCh3)
@@ -220,3 +232,22 @@ if(NOT TARGET MaCh3)
   )
   cmessage(STATUS "Added target MaCh3")
 endif()
+
+############################  Install  ####################################
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  ${CMAKE_CURRENT_LIST_DIR}/cmake/Templates/MaCh3Config.cmake.in ${CMAKE_BINARY_DIR}/MaCh3Config.cmake
+  INSTALL_DESTINATION
+    /this/is/ignored/for/some/reason/thanks/kitware
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+  write_basic_package_version_file(${CMAKE_BINARY_DIR}/MaCh3ConfigVersion.cmake
+  VERSION ${MaCh3_VERSION}
+  COMPATIBILITY AnyNewerVersion)
+
+install(FILES
+    ${CMAKE_BINARY_DIR}/MaCh3Config.cmake
+    ${CMAKE_BINARY_DIR}/MaCh3ConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/MaCh3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,15 +3,26 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 # CMake version check
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)  
 
+# Try to find CUDA
+find_package(CUDAToolkit)
+# Check if CUDA was found
+if(CUDAToolkit_FOUND)
+    message(STATUS "CUDA found. Adding CUDA support.")
+    SET(MaCh3_GPU_ENABLED TRUE)
+    SET(CPU_ONLY FALSE)
+else()
+    message(STATUS "CUDA not found. Proceeding without CUDA support.")
+    SET(MaCh3_GPU_ENABLED FALSE)
+    SET(CPU_ONLY TRUE)
+endif()
+
 SET(MaCh3_VERSION 0.0.2)
-if(${CPU_ONLY})
+if(CPU_ONLY)
   project(MaCh3 VERSION ${MaCh3_VERSION} LANGUAGES CXX)
 else()
   project(MaCh3 VERSION ${MaCh3_VERSION} LANGUAGES CXX CUDA)
 endif()
-set(CMAKE_CXX_STANDARD 17)
 
-# Would be good to have a check on CMAKE_CXX_STANDARD here
 # Changes default install path to be a subdirectory of the build dir.
 # Can set build dir at configure time with -DCMAKE_INSTALL_PREFIX=/install/path
 if(CMAKE_INSTALL_PREFIX STREQUAL "" OR CMAKE_INSTALL_PREFIX STREQUAL
@@ -27,17 +38,21 @@ find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++ PATHS ENV PATH NO_DEFAULT_PA
 
 LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
-#include(CPM)
-include(${CPM_DOWNLOAD_LOCATION})
+include(CPM)
 
 #Luke's handing cmake modules which Neutrino hep experiments might want
 CPMFindPackage(
-    NAME CMakeModules
-    GIT_TAG v0.0.11
-    GITHUB_REPOSITORY NuHepMC/CMakeModules
-    DOWNLOAD_ONLY
-)
+      NAME CMakeModules
+      GIT_TAG stable
+      GITHUB_REPOSITORY NuHepMC/CMakeModules
+      DOWNLOAD_ONLY
+  )
 include(${CMakeModules_SOURCE_DIR}/NuHepMCModules.cmake)
+include(NuHepMCUtils)
+include(ROOT)
+if(NOT TARGET ROOT::ROOT)
+  cmessage(FATAL_ERROR "MaCh3 Expected dependency target: ROOT::ROOT")
+endif()
 
 #YAML for reading in config files
 CPMFindPackage(
@@ -60,28 +75,21 @@ if (${USE_PROB3})
       GITHUB_REPOSITORY "mach3-software/Prob3plusplus"
       GIT_TAG v3.10.3
   )
-
 else()
-
-  if (${CPU_ONLY})
-
+  if (CPU_ONLY)
     CPMFindPackage(
         NAME CUDAProb3
         GITHUB_REPOSITORY "mach3-software/CUDAProb3"
         GIT_TAG "feature_cleanup"
     )
-
   else()
-  
     CPMFindPackage(
         NAME CUDAProb3
         GITHUB_REPOSITORY "mach3-software/CUDAProb3"
         GIT_TAG "feature_cleanup"
-	    OPTIONS "GPU_ON ON"
+        OPTIONS "GPU_ON ON"
     )
-
   endif()
-
 endif()
 
 CPMAddPackage(
@@ -97,17 +105,7 @@ if(Eigen_ADDED)
   target_include_directories(Eigen INTERFACE ${Eigen_SOURCE_DIR})
 endif()
 
-include(NuHepMCUtils)
 dump_cmake_variables(Prob3plusplus)
-
-#Nice coloured messaged from cmake
-include(CMessage)
-
-include(ROOT)
-#Check to see if you successfully found ROOT or not
-if(NOT ROOT_FOUND)
-  cmessage(FATAL_ERROR " couldn't find ROOT dependency...")
-endif()
 
 # Would be good to have a check on CMAKE_CXX_STANDARD here
 if(${ROOT_CXX_STANDARD} LESS 14)
@@ -121,7 +119,7 @@ cmessage(STATUS "CMAKE_INSTALL_PREFIX: \"${CMAKE_INSTALL_PREFIX}\"")
 if(NOT ${CMAKE_SCRIPT_SETUP})  #Check if setup by Experiment MaCh3
   set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
   #CUDA
-  if(NOT ${CPU_ONLY})
+  if(NOT CPU_ONLY)
     include(${CMAKE_SOURCE_DIR}/cmake/CUDASetup.cmake)
   endif()
 endif()
@@ -130,21 +128,32 @@ endif()
 set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 
 #Compile and link options (Should be in experiment project but copied in case CORE is built alone) 
-add_compile_options(-I${CUDA_SAMPLES}/common/inc)
-add_compile_options(-g -O3 -Wextra)
-
-#Compile and link options (Should be in experiment project but copied in case CORE is built alone) 
 add_compile_options(-g -Wextra)
-add_compile_options(-fopenmp)
-add_link_options(-fopenmp)
 
-#If Single thread is chosen MultiThread flags are omitted
-if(NOT ${SINGLE_THREAD_ONLY})
-  add_compile_options(-DMULTITHREAD)
-  add_link_options(-DMULTITHREAD)
+#KS: If Debug is not defined disable it by default
+if(NOT DEFINED MaCh3_DEBUG_ENABLED)
+  SET(MaCh3_DEBUG_ENABLED FALSE)
 endif()
 
-if(${CPU_ONLY})
+#KS: If Debug enable add debugging options if not add optimisation flags
+if(MaCh3_DEBUG_ENABLED)
+  add_compile_options(-DDEBUG)
+else()
+  add_compile_options(-O3)
+endif()
+
+#KS: If multithreading is not defined enable it by default
+if(NOT DEFINED MaCh3_MULTITHREAD_ENABLED)
+  SET(MaCh3_MULTITHREAD_ENABLED TRUE)
+endif()
+
+#Add MultiThread flags
+if(MaCh3_MULTITHREAD_ENABLED)
+  add_compile_options(-fopenmp -DMULTITHREAD)
+  add_link_options(-fopenmp -DMULTITHREAD)
+endif()
+
+if(CPU_ONLY)
   add_compile_options(-DCPU_ONLY)
 else()
   add_compile_options(-I${CUDA_SAMPLES}/common/inc)
@@ -154,6 +163,27 @@ endif()
 if(${USE_PROB3})
   add_compile_options(-DUSE_PROB3)
 endif()
+
+
+############################  c++ Compiler  ####################################
+if (NOT DEFINED CMAKE_CXX_STANDARD OR "${CMAKE_CXX_STANDARD} " STREQUAL " ")
+  SET(CMAKE_CXX_STANDARD 11)
+endif()
+
+if(DEFINED ROOT_CXX_STANDARD AND ROOT_CXX_STANDARD GREATER CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD ${ROOT_CXX_STANDARD})
+endif()
+cmessage(STATUS "CMAKE CXX Standard: ${CMAKE_CXX_STANDARD}")
+
+LIST(APPEND ALL_FEATURES
+  DEBUG
+  MULTITHREAD
+  GPU
+  )
+cmessage(STATUS "MaCh3 Features: ")
+foreach(f ${ALL_FEATURES})
+  cmessage(STATUS "     ${f}: ${MaCh3_${f}_ENABLED}")
+endforeach()
 
 # Build components
 # add_subdirectory(Diagnostics)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ MaCh3 is ...
 
 ```
 mkdir build; cd build;
-cmake ../ [-DMaCh3_MULTITHREAD_ENABLED=<ON,OFF>] [-DMaCh3_DEBUG_ENABLED=<ON,OFF>]]
+cmake ../ [-DMaCh3_MULTITHREAD_ENABLED=<ON,OFF>] [-DMaCh3_DEBUG_ENABLED=<ON,OFF>] [-DUSE_PROB3=<ON,OFF>]
 ```
 
 ## System Requirements

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ MaCh3 is ...
 
 # How to Compile
 
+```
+mkdir build; cd build;
+cmake ../ [-DMaCh3_MULTITHREAD_ENABLED=<ON,OFF>] [-DMaCh3_DEBUG_ENABLED=<ON,OFF>]]
+```
 
 ## System Requirements
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ MaCh3 is ...
 
 ```
 mkdir build; cd build;
-cmake ../ [-DMaCh3_MULTITHREAD_ENABLED=<ON,OFF>] [-DMaCh3_DEBUG_ENABLED=<ON,OFF>] [-DUSE_PROB3=<ON,OFF>]
+cmake ../ [-DMaCh3_MULTITHREAD_ENABLED=<ON,OFF>] [-DMaCh3_DEBUG_ENABLED=<ON,OFF>] [-DUSE_PROB3=<ON,OFF>] [-DDEBUG_LEVEL=<1,2,3>]
 ```
 
 ## System Requirements

--- a/cmake/Templates/MaCh3Config.cmake.in
+++ b/cmake/Templates/MaCh3Config.cmake.in
@@ -1,0 +1,46 @@
+@PACKAGE_INIT@
+
+set(MaCh3_VERSION MaCh3_VERSION)
+
+
+set(USE_PROB3 @USE_PROB3@)
+set(CPU_ONLY @CPU_ONLY@)
+set(DEBUG_LEVEL @DEBUG_LEVEL@)
+set(MaCh3_DEBUG_ENABLED @MaCh3_DEBUG_ENABLED@)
+set(MaCh3_MULTITHREAD_ENABLED @MaCh3_MULTITHREAD_ENABLED@)
+set(MaCh3_GPU_ENABLED @MaCh3_GPU_ENABLED@)
+
+get_filename_component(MaCh3_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+message(STATUS "Adding ${MaCh3_CMAKE_DIR} to Module search path")
+message(STATUS "Adding ${MaCh3_CMAKE_DIR}/../../../cmake to Module search path")
+list(APPEND CMAKE_MODULE_PATH "${MaCh3_CMAKE_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${MaCh3_CMAKE_DIR}/../../../cmake")
+
+set(MaCh3_FOUND TRUE)
+
+include(ROOT)
+
+if(NOT TARGET ROOT::ROOT)
+  cmessage(WARNING "Expected MaCh3 to set up dependency target: ROOT::ROOT")
+  set(MaCh3_FOUND FALSE)
+  return()
+endif()
+
+
+include(${MaCh3_CMAKE_DIR}/MaCh3Targets.cmake)
+
+find_path(MaCh3_PREFIX
+NAMES bin/setup.MaCh3.sh
+PATHS ${MaCh3_CMAKE_DIR}/../
+)
+
+cmessage(STATUS "MaCh3_PREFIX: ${MaCh3_PREFIX}")
+cmessage(STATUS "MaCh3_VERSION: ${MaCh3_VERSION}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MaCh3
+  REQUIRED_VARS
+    MaCh3_PREFIX
+  VERSION_VAR
+    MaCh3_VERSION
+)

--- a/samplePDF/CMakeLists.txt
+++ b/samplePDF/CMakeLists.txt
@@ -10,7 +10,7 @@ set(SamplePDF_header_files
 	interfacePDFEbE.h
 	Structs.h )
 
-if(NOT ${CPU_ONLY})
+if(NOT CPU_ONLY)
   list(APPEND SamplePDF_implementation_files probGpu.cu)
 endif()
 
@@ -23,12 +23,12 @@ else()
   target_link_libraries(SamplePDF Splines Covariance Manager OscClass CUDAProb3Beam CUDAProb3Atmos)
 endif()
 
-if(NOT ${CPU_ONLY})
+if(NOT CPU_ONLY)
   add_library(probGpu probGpu.cu)
   set_target_properties(SamplePDF PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
   set_property(TARGET probGpu SamplePDF PROPERTY CUDA_ARCHITECTURES 35 52 60 61 70 75 80 86)
   target_link_libraries(SamplePDF probGpu)
-  target_compile_options(SamplePDF PUBLIC -DGPU_ON)
+  target_compile_definitions(SamplePDF PUBLIC GPU_ON)
 endif()
 
 set_target_properties(SamplePDF PROPERTIES 

--- a/splines/CMakeLists.txt
+++ b/splines/CMakeLists.txt
@@ -1,33 +1,31 @@
 set(Splines_header_files 
-	splineBase.h 
-	splineInterface.h 
-	splineFDBase.h 
-        SplineMonolith.h)
+    splineBase.h
+    splineInterface.h
+    splineFDBase.h
+    SplineMonolith.h)
 
 set(Splines_implementation_files 
-	splineBase.cpp 
-	splineFDBase.cpp
-	SplineMonolith.cpp
-        gpuSplineUtils.cu)
+    splineBase.cpp
+    splineFDBase.cpp
+    SplineMonolith.cpp
+    gpuSplineUtils.cu)
 
 
 set(Splines_implementation_files_CPU 
-	splineBase.cpp 
-	splineFDBase.cpp
-	SplineMonolith.cpp)
+    splineBase.cpp
+    splineFDBase.cpp
+    SplineMonolith.cpp)
 
-if(NOT ${CPU_ONLY})
-
+if(NOT CPU_ONLY)
   add_library(Splines SHARED ${Splines_implementation_files})
   target_include_directories(Splines PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
   add_library(gpuSpline gpuSplineUtils.cu)
   set_target_properties(Splines PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-  if(${CUDA_ERROR_CHECK})
-	target_compile_options(Splines PUBLIC -DCUDA_ERROR_CHECK)
+  if(MaCh3_DEBUG_ENABLED)
+    target_compile_definitions(Splines PUBLIC CUDA_ERROR_CHECK)
   endif()
   set_property(TARGET gpuSpline Splines PROPERTY CUDA_ARCHITECTURES 35 52 60 61 70 75 80 86)
   target_link_libraries(gpuSpline)
-
 else()
   add_library(Splines SHARED ${Splines_implementation_files_CPU})
   target_include_directories(Splines INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/..)


### PR DESCRIPTION
This is how it looks
<img width="1274" alt="CUDA" src="https://github.com/mach3-software/MaCh3/assets/45295406/9ff5e13c-dcff-4915-acc3-7c63285307ba">

First of all update how we handle NuHepMC/CMakeModules

Secondly make proper cmake flags to turn on multithreading.
If cmake found CUDA use GPU otheriwse don't
Add DEBUG flags. Lot of ND280 stuff is under DEBUG and it would be nice to haveu nfied option of enabling it. -O3 are turned of under debug.

Lstly make fancy list of feautres so user know what is being used
```
-- [INFO]: CMAKE CXX Standard: 17
-- [INFO]: MaCh3 Features:
-- [INFO]:      DEBUG: FALSE
-- [INFO]:      MULTITHREAD: TRUE
-- [INFO]:      GPU: FALSE
-- [INFO]: Added target MaCh
```
Proof that flags are being set correctly, note expecially -DCPU_ONLY, -DMULTITHREAD, -O3, -fopenmp 
```
[ 66%] Building CXX object covariance/CMakeFiles/Covariance.dir/covarianceBase.cpp.o
cd /mnt/home/kskwarczynski/T2K_OA/Refactor/FixCmake/build/covariance && /mnt/opt/spack/0.20/opt/spack/linux-centos7-ivybridge/gcc-8.5.0/gcc-8.5.0-3ldkfvyerauwz66ejs72hgm7bu7ccvco/bin/g++ -DCPU_ONLY -DCovariance_EXPORTS -DMULTITHREAD -I/mnt/home/kskwarczynski/T2K_OA/Refactor/FixCmake/throwParms/.. -I/mnt/home/kskwarczynski/T2K_OA/Refactor/FixCmake/manager/.. -I/mnt/home/kskwarczynski/T2K_OA/Refactor/FixCmake/build/_deps/yaml-cpp-src/include -isystem /mnt/home/share/t2k/kskwarczynski/CERN_ROOT/root-6.24.08/build_root/include -std=c++17 -pipe -fsigned-char -pthread -std=gnu++17 -fPIC -g -Wextra -O3 -fopenmp -pipe -fsigned-char -pthread -DMINUIT2_ENABLED -DROOT_FIT_FITTER_INTERFACE_ENABLED -MD -MT covariance/CMakeFiles/Covariance.dir/covarianceBase.cpp.o -MF CMakeFiles/Covariance.dir/covarianceBase.cpp.o.d -o CMakeFiles/Covariance.dir/covarianceBase.cpp.o -c /mnt/home/kskwarczynski/T2K_OA/Refactor/FixCmake/covariance/covarianceBase.cpp
```
