### PR TITLE
Minor fixes for cmake and compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 #YAML for reading in config files
 set(YAML_CPP_VERSION 0.7.0) #KS: We need it for version.h file also define this number olny once
 set(YAML_CPP_GIT_TAG "yaml-cpp-${YAML_CPP_VERSION}")
-CPMFindPackage(
+CPMAddPackage(
     NAME yaml-cpp
     VERSION ${YAML_CPP_VERSION}
     GITHUB_REPOSITORY "jbeder/yaml-cpp"

--- a/splines/gpuSplineUtils.cu
+++ b/splines/gpuSplineUtils.cu
@@ -7,6 +7,7 @@
 
 // C i/o  for printf and others
 #include <stdio.h>
+#include <vector>
 
 // CUDA specifics
 


### PR DESCRIPTION
Enforces the downloading of the yaml-cpp package (https://github.com/cpm-cmake/CPM.cmake?tab=readme-ov-file#cpm_download_all). It could previously be found without being actually used.
Also adding a missing include in [splines/gpuSplineUtils.cu](https://github.com/mach3-software/MaCh3/compare/minor_fix?expand=1#diff-22d38a50e9089b009d3e907b5c38b5b4f1a9963fdb65833fb07bd228ddd87d18)