### PR TITLE
Feature small covariance fixes

### DIFF
--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -1186,7 +1186,14 @@ void covarianceBase::setEvalLikelihood(const int i, const bool eL) {
     MACH3LOG_ERROR("Fix this in your config file please!");
     throw;
   } else {
-    MACH3LOG_INFO("Setting {} (parameter {}) to flat prior", GetParName(i), i);
+
+    if(eL){
+      MACH3LOG_INFO("Setting {} (parameter {}) to flat prior", GetParName(i), i);
+    }
+    else{
+      // HW :: This is useful
+      MACH3LOG_INFO("Setting {} (parameter {}) to non-flat prior", GetParName(i), i);
+    }
     _fFlatPrior[i] = eL;
   }
 }

--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -1179,7 +1179,7 @@ void covarianceBase::toggleFixParameter(const int i) {
   return;
 }
 // ********************************************
-void covarianceBase::setEvalLikelihood(const int i, const bool eL) {
+void covarianceBase::setFlatPrior(const int i, const bool eL) {
 // ********************************************
   if (i > _fNumPar) {
     MACH3LOG_INFO("Can't setEvalLikelihood for Cov={}/Param={} because size of Covariance = {}", getName(), i, _fNumPar);

--- a/covariance/covarianceBase.h
+++ b/covariance/covarianceBase.h
@@ -58,7 +58,7 @@ class covarianceBase {
   }
   void setParameters(std::vector<double> pars = std::vector<double>());
   /// @brief Set if parameter should have flat prior or not
-  void setEvalLikelihood(const int i, const bool eL);
+  void setFlatPrior(const int i, const bool eL);
   
   /// @brief set branches for output file
   void SetBranches(TTree &tree, bool SaveProposal = false);
@@ -97,7 +97,7 @@ class covarianceBase {
   TMatrixDSym *getCovMatrix() { return covMatrix; }
   TMatrixDSym *getInvCovMatrix() { return invCovMatrix; }
   /// @brief Get if param has flat prior or not
-  inline bool getEvalLikelihood(const int i) { return _fFlatPrior[i]; }
+  inline bool getFlatPrior(const int i) { return _fFlatPrior[i]; }
 
   /// @brief Get name of covariance
   const char *getName() { return matrixName; }

--- a/covariance/covarianceOsc.cpp
+++ b/covariance/covarianceOsc.cpp
@@ -30,7 +30,8 @@ covarianceOsc::covarianceOsc(const char* name, const char *file)
     _fIndivStepScale[io] = fScale * (*osc_stepscale)(io);
     
     //KS: Set flat prior
-    if( (bool)((*osc_flat_prior)(io)) ) setEvalLikelihood(io, false);
+    //HW: Might as well set it for everything in case default behaviour changes
+    setEvalLikelihood(io, (*osc_flat_prior)(io));
   }
 
   kDeltaCP = -999;
@@ -166,14 +167,14 @@ void covarianceOsc::proposeStep() {
 
   covarianceBase::proposeStep();
 
-  //ETA
-  //this won't work if abs(_fPropVal) > 2pi so we should consider
-  //plonking a while here
+  // HW :: This method is a tad hacky but modular arithmetic gives me a headache.
+  //        It should now automatically set dcp to be with [-pi, pi]
   if(_fPropVal[kDeltaCP] > TMath::Pi()) {
-    _fPropVal[kDeltaCP] = (-2.*TMath::Pi() + _fPropVal[kDeltaCP]);
+    _fPropVal[kDeltaCP] = -1*TMath::Pi() + std::fmod(_fPropVal[kDeltaCP], TMath::Pi());
   } else if (_fPropVal[kDeltaCP] < -TMath::Pi()) {
-    _fPropVal[kDeltaCP] = (2.*TMath::Pi() + _fPropVal[kDeltaCP]);
+    _fPropVal[kDeltaCP] = TMath::Pi() + std::fmod(_fPropVal[kDeltaCP], TMath::Pi());
   }
+
   
   // Okay now we've done the standard steps, we can add in our nice flips
   // hierarchy flip first

--- a/covariance/covarianceOsc.cpp
+++ b/covariance/covarianceOsc.cpp
@@ -31,7 +31,7 @@ covarianceOsc::covarianceOsc(const char* name, const char *file)
     
     //KS: Set flat prior
     //HW: Might as well set it for everything in case default behaviour changes
-    setEvalLikelihood(io, (*osc_flat_prior)(io));
+    setFlatPrior(io, (*osc_flat_prior)(io));
   }
 
   kDeltaCP = -999;


### PR DESCRIPTION
Two small tweaks. 
 - I noticed oscillation parameters weren't being given the correct priors so I've just made the prior-setter fully explicit
 - delta-cp could, hypothetically be thrown outside of [-2 pi, 2pi] and not be set correctly.  I've used a bit of modular arithmetic to prevent this.

Prior Setting : 
![Screenshot 2024-06-19 at 13 46 41](https://github.com/mach3-software/MaCh3/assets/67589487/6a55e8a1-cfba-47e2-b44f-d79fb0eb0172)

dcp stays within the correct bounds

[dcp_trace.pdf](https://github.com/user-attachments/files/15901084/dcp_trace.pdf)
