### PR TITLE
Smarter CUDA Samples treatment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# Pull request description:
+
+
+## Changes or fixes:
+
+
+## Examples:

--- a/.github/workflows/test-result-comment.yml
+++ b/.github/workflows/test-result-comment.yml
@@ -1,0 +1,48 @@
+#Bases on https://github.com/root-project/root/blob/master/.github/workflows/test-result-comment.yml
+
+name: Test Summary PR comment
+
+on:
+  workflow_run:
+    # do NOT use quotes: https://stackoverflow.com/a/72551795/17876693
+    workflows: [MaCh3 CI]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  comment-test-results:
+    name: Publish Test Results
+
+    if: (github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'schedule') && github.event.workflow_run.conclusion != 'skipped'
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      checks: write
+      pull-requests: write
+      actions: read
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+           mkdir -p artifacts && cd artifacts
+
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+           gh api --paginate "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -d "$name" "$name.zip"
+           done
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(NOT TARGET ROOT::ROOT)
 endif()
 
 if(ROOT_VERSION VERSION_LESS 6.18.0)
-    message(FATAL_ERROR "Using ROOT version smaller than 6.18.0, this may lead to unexpected results")
+  cmessage(FATAL_ERROR "Using ROOT version smaller than 6.18.0, this may lead to unexpected results")
 endif()
 
 #YAML for reading in config files
@@ -108,7 +108,7 @@ if(NOT DEFINED USE_PROB3)
   SET(USE_PROB3 FALSE)
 endif()
 
-# Oscillation calcualtion
+# Oscillation calculation
 # In the future which osc calc we use might be set with a flag
 SET(MaCh3_Oscillator_ENABLED "")
 if (USE_PROB3)
@@ -244,6 +244,12 @@ endif()
 #Include logger
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/Logger.cmake)
 ################################# Features ##################################
+#KS: Retrieve and print the compile options and link libraries for maximal verbose
+get_target_property(compile_options MaCh3CompilerOptions INTERFACE_COMPILE_OPTIONS)
+get_target_property(link_libraries MaCh3CompilerOptions INTERFACE_LINK_LIBRARIES)
+
+cmessage(STATUS "Compile options for MaCh3CompilerOptions: ${compile_options}")
+cmessage(STATUS "Link libraries for MaCh3CompilerOptions: ${link_libraries}")
 
 LIST(APPEND ALL_FEATURES
   DEBUG

--- a/cmake/Modules/CUDASamples.cmake
+++ b/cmake/Modules/CUDASamples.cmake
@@ -1,0 +1,33 @@
+# Variable to hold the paths once found
+set(CMAKE_CUDA_SAMPLES_PATH "")
+set(CUDASAMPLES_FOUND FALSE)
+
+#KS: List of directories to search for helper_functions.h and cuda_runtime.h
+# Please expand if needed
+set(CUDA_SAMPLE_SEARCH_PATHS
+    "${CUDAToolkit_TARGET_DIR}/samples/common/inc/"
+)
+
+# Loop over the directories and append to CMAKE_CUDA_SAMPLES_PATH if headers are found
+foreach(dir ${CUDA_SAMPLE_SEARCH_PATHS})
+    if(EXISTS "${dir}/helper_functions.h")
+        list(APPEND CMAKE_CUDA_SAMPLES_PATH ${dir})
+        set(CUDASAMPLES_FOUND TRUE)
+    endif()
+endforeach()
+
+#HW: If we're doing GPU stuff, we need the CUDA helper module
+if(NOT CUDASAMPLES_FOUND)
+    cmessage(WARNING "Adding Built-in CUDA Sample Library, it make take some time")
+    CPMAddPackage(
+        NAME cuda-samples
+        GITHUB_REPOSITORY "NVIDIA/cuda-samples"
+        GIT_TAG v12.3
+    SOURCE_SUBDIR Common
+    DOWNLOAD_ONLY YES
+    )
+    list(APPEND CMAKE_CUDA_SAMPLES_PATH ${cuda-samples_SOURCE_DIR}/Common)
+endif()
+
+cmessage(STATUS "Using the following CUDA samples paths: ${CMAKE_CUDA_SAMPLES_PATH}")
+target_include_directories(MaCh3CompilerOptions INTERFACE ${CMAKE_CUDA_SAMPLES_PATH})

--- a/cmake/Modules/CUDASetup.cmake
+++ b/cmake/Modules/CUDASetup.cmake
@@ -53,7 +53,7 @@ if(NOT MaCh3_DEBUG_ENABLED)
         "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-fpic;-Xcompiler=-O3;-Xcompiler=-Wall;-Xcompiler=-Wextra;-Xcompiler=-Werror;-Xcompiler=-Wno-error=unused-parameter>"
     )
 else()
-#CWret: -g and -G for debug flags to use cuda-gdb; slows stuff A LOT
+#CW: -g and -G for debug flags to use cuda-gdb; slows stuff A LOT
 #-pxtas-options=-v, -maxregcount=N
     target_compile_options(MaCh3CompilerOptions INTERFACE
         "$<$<COMPILE_LANGUAGE:CUDA>:-prec-sqrt=false;-use_fast_math;-Werror;cross-execution-space-call;-w>"
@@ -63,42 +63,8 @@ else()
 
     target_compile_definitions(MaCh3CompilerOptions INTERFACE "$<$<COMPILE_LANGUAGE:CUDA>:CUDA_ERROR_CHECK>")
 endif()
-
-target_link_options(MaCh3CompilerOptions INTERFACE -I$ENV{CUDAPATH}/lib64 -I$ENV{CUDAPATH}/include -I$ENV{CUDAPATH}/common/inc -I$ENV{CUDAPATH}/samples/common/inc)
-
-if(NOT DEFINED ENV{CUDAPATH})
-    cmessage(FATAL_ERROR "CUDAPATH environment variable is not defined. Please set it to the root directory of your CUDA installation.")
-endif()
-
-#if(NOT DEFINED CUDA_SAMPLES)
-#  cmessage(FATAL_ERROR "When using CUDA, CUDA_SAMPLES must be defined to point to the CUDAToolkit samples directory (should contain common/helper_functions.h).")
-#endif()
-
-# Set the CUDA samples path
-set(CMAKE_CUDA_SAMPLES_PATH
-    $ENV{CUDAPATH}/include
-    $ENV{CUDAPATH}/samples/common/inc
-)
-
-cmessage(STATUS "Using the following CUDA samples paths: ${CMAKE_CUDA_SAMPLES_PATH}")
-target_include_directories(MaCh3CompilerOptions INTERFACE ${CMAKE_CUDA_SAMPLES_PATH})
-
-#HW: If we're doing GPU stuff, we need the CUDA helper module
-if(BUILTIN_CUDASAMPLES_ENABLED )
-    cmessage("Adding Builtin CUDA Sample Library")
-    CPMAddPackage(
-        NAME cuda-samples
-        GITHUB_REPOSITORY "NVIDIA/cuda-samples"
-        GIT_TAG v12.3
-    SOURCE_SUBDIR Common
-    DOWNLOAD_ONLY YES
-    )
-# Now we add the library
-    if(cuda-samples_ADDED)
-         add_library(cuda-samples INTERFACE IMPORTED)
-         target_include_directories(cuda-samples INTERFACE ${cuda-samples_SOURCE_DIR})
-    endif()
-endif()
+target_include_directories(MaCh3CompilerOptions INTERFACE ${CUDAToolkit_INCLUDE_DIRS})
+include(${CMAKE_CURRENT_LIST_DIR}/CUDASamples.cmake)
 
 #KS: Keep this for backward compatibility
 
@@ -106,7 +72,7 @@ endif()
 #-Xcompiler "-fpic" -c
 #-prec-sqrt=false -use_fast_math
 
-#CWRET comment: could change arch here. also, prec-div is only used in (seg+khig)/2; could replace by *0.5
+#CW comment: could change arch here. also, prec-div is only used in (seg+khig)/2; could replace by *0.5
 # -prec-sqrt is not needed (no sqrts in program code!), -use_fast_math forces intrinsic
 #  tried this on GTX 660 and no speed increase, buu and P6 6c
 #  don't use fastmath!


### PR DESCRIPTION
cmake will try to find cuda samples path, only if it find them it will add include directory etc so no more issues related to path whcih desn't exist.

If cmake cannot fidn it will CPM.

Hopefully this will put the end to cuda sample problem

using native cuda samples
![cuda](https://github.com/mach3-software/MaCh3/assets/45295406/8cec5f72-931a-4f2f-9e0c-22d77910d323)
using cpm ones
<img width="855" alt="cuda2" src="https://github.com/mach3-software/MaCh3/assets/45295406/05984f8e-3dd4-4086-8b9b-e63c5ad4f62f">

Printing compile options and libraries
![image](https://github.com/mach3-software/MaCh3/assets/45295406/74eb7684-6bfd-4fd2-9af0-fb8732bce9d4)