### PR TITLE
Fixes small bug in MCMCProcessor printout

### DIFF
--- a/mcmc/MCMCProcessor.cpp
+++ b/mcmc/MCMCProcessor.cpp
@@ -2304,10 +2304,9 @@ void MCMCProcessor::ScanInput() {
   MACH3LOG_INFO("# useful entries in tree: \033[1;32m {} \033[0m ", nDraw);
   MACH3LOG_INFO("# XSec params:  \033[1;32m {} starting at {} \033[0m ", nParam[kXSecPar] - nFlux, ParamTypeStartPos[kXSecPar]);
   MACH3LOG_INFO("# Flux params:   {}", nFlux);
-  MACH3LOG_INFO("# Flux params:   {}", nFlux);
-  MACH3LOG_INFO("# ND params:    \033[1;32m {} starting at {} \033[0m ", nParam[kNDPar] - nFlux, ParamTypeStartPos[kNDPar]);
-  MACH3LOG_INFO("# FD params:    \033[1;32m {} starting at {} \033[0m ", nParam[kFDDetPar] - nFlux, ParamTypeStartPos[kFDDetPar]);
-  MACH3LOG_INFO("# Osc params:   \033[1;32m {} starting at {} \033[0m ", nParam[kOSCPar] - nFlux, ParamTypeStartPos[kOSCPar]);
+  MACH3LOG_INFO("# ND params:    \033[1;32m {} starting at {} \033[0m ", nParam[kNDPar], ParamTypeStartPos[kNDPar]);
+  MACH3LOG_INFO("# FD params:    \033[1;32m {} starting at {} \033[0m ", nParam[kFDDetPar], ParamTypeStartPos[kFDDetPar]);
+  MACH3LOG_INFO("# Osc params:   \033[1;32m {} starting at {} \033[0m ", nParam[kOSCPar], ParamTypeStartPos[kOSCPar]);
   MACH3LOG_INFO("************************************************");
 
   nSteps = Chain->GetMaximum("step");


### PR DESCRIPTION
# Pull request description:
Fixes small bug where the number of flux systematics was being subtracted from ALL systematics in the MCMCProcessor printout

## Changes or fixes:
-> Changes MCMC processor scanning printout

## Examples:
Old:
```bash
[09:52:48][MCMCProcessor.cpp][info] Scanning output branches...
[09:52:48][MCMCProcessor.cpp][info] # useful entries in tree:  151  
[09:52:48][MCMCProcessor.cpp][info] # XSec params:   45 starting at 0  
[09:52:48][MCMCProcessor.cpp][info] # Flux params:   100
[09:52:48][MCMCProcessor.cpp][info] # Flux params:   100
[09:52:48][MCMCProcessor.cpp][info] # ND params:     -100 starting at 0  
[09:52:48][MCMCProcessor.cpp][info] # FD params:     -100 starting at 0  
[09:52:48][MCMCProcessor.cpp][info] # Osc params:    -94 starting at 145  
```

New:
```bash
[09:52:48][MCMCProcessor.cpp][info] Scanning output branches...
[09:52:48][MCMCProcessor.cpp][info] # useful entries in tree:  151  
[09:52:48][MCMCProcessor.cpp][info] # XSec params:   45 starting at 0  
[09:52:48][MCMCProcessor.cpp][info] # Flux params:   100
[09:52:48][MCMCProcessor.cpp][info] # ND params:     0 starting at 0  
[09:52:48][MCMCProcessor.cpp][info] # FD params:     0 starting at 0  
[09:52:48][MCMCProcessor.cpp][info] # Osc params:    6 starting at 145  
```
