### PR TITLE
Bag of tricks I learned from Luke

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ else()
   project(MaCh3 VERSION ${MaCh3_VERSION} LANGUAGES CXX CUDA)
 endif()
 
-
 # Changes default install path to be a subdirectory of the build dir.
 # Can set build dir at configure time with -DCMAKE_INSTALL_PREFIX=/install/path
 if(CMAKE_INSTALL_PREFIX STREQUAL "" OR CMAKE_INSTALL_PREFIX STREQUAL
@@ -43,106 +42,23 @@ find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++ PATHS ENV PATH NO_DEFAULT_PA
 
 LIST(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 ################################## Dependencies ################################
-
-include(CPM)
-
-#Luke's handing cmake modules which Neutrino hep experiments might want
-CPMFindPackage(
-      NAME CMakeModules
-      GIT_TAG stable
-      GITHUB_REPOSITORY NuHepMC/CMakeModules
-      DOWNLOAD_ONLY
-  )
-include(${CMakeModules_SOURCE_DIR}/NuHepMCModules.cmake)
-include(NuHepMCUtils)
-
-# Check if CUDA was found
-if(MaCh3_GPU_ENABLED)
-  include(${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/CUDASetup.cmake)
-endif()
-
-include(ROOT)
-if(NOT TARGET ROOT::ROOT)
-  cmessage(FATAL_ERROR "MaCh3 Expected dependency target: ROOT::ROOT")
-endif()
-
-if(ROOT_VERSION VERSION_LESS 6.18.0)
-  cmessage(FATAL_ERROR "Using ROOT version smaller than 6.18.0, this may lead to unexpected results")
-endif()
-
-#YAML for reading in config files
-set(YAML_CPP_VERSION 0.7.0) #KS: We need it for version.h file also define this number olny once
-set(YAML_CPP_GIT_TAG "yaml-cpp-${YAML_CPP_VERSION}")
-CPMAddPackage(
-    NAME yaml-cpp
-    VERSION ${YAML_CPP_VERSION}
-    GITHUB_REPOSITORY "jbeder/yaml-cpp"
-    GIT_TAG "${YAML_CPP_GIT_TAG}"
-    OPTIONS
-      "YAML_BUILD_SHARED_LIBS ON"
-)
-
-if(NOT TARGET yaml-cpp::yaml-cpp)
-  cmessage(FATAL_ERROR "MaCh3 Expected dependency target: yaml-cpp::yaml-cpp")
-endif()
-
-#KS: Not being used right now so commenting it out.
-#CPMAddPackage(
-#  NAME Eigen
-#  VERSION 3.2.8
-#  URL https://gitlab.com/libeigen/eigen/-/archive/3.2.8/eigen-3.2.8.tar.gz
-#  # Eigen's CMakelists are not intended for library use
-#  DOWNLOAD_ONLY YES
-#)
-
-#if(Eigen_ADDED)
-#  add_library(Eigen INTERFACE IMPORTED)
-#  target_include_directories(Eigen INTERFACE ${Eigen_SOURCE_DIR})
-#endif()
-
-
-################################## Oscillation ################################
-#KS: All of these should be moved to separate cmake and be handled by osc class, keep it for now
-#If USE_PROB3 not defined turn it off by default
-if(NOT DEFINED USE_PROB3)
-  SET(USE_PROB3 FALSE)
-endif()
-
-# Oscillation calculation
-# In the future which osc calc we use might be set with a flag
-SET(MaCh3_Oscillator_ENABLED "")
-if (USE_PROB3)
-  CPMFindPackage(
-    NAME Prob3plusplus
-    VERSION 3.10.3
-    GITHUB_REPOSITORY "mach3-software/Prob3plusplus"
-    GIT_TAG v3.10.3
-  )
-  LIST(APPEND MaCh3_Oscillator_ENABLED "Prob3++")
-else()
-  CPMFindPackage(
-    NAME CUDAProb3
-    GITHUB_REPOSITORY "mach3-software/CUDAProb3"
-    GIT_TAG "feature_cleanup"
-    DOWNLOAD_ONLY YES
-  )
-  LIST(APPEND MaCh3_Oscillator_ENABLED "CUDAProb3")
-endif()
-
-#dump_cmake_variables(Prob3plusplus)
+#KS: Store some handy cmake functions
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/MaCh3Utils.cmake)
+#Loads all dependencies
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/MaCh3Dependencies.cmake)
 
 ############################  C++ Compiler  ####################################
 if (NOT DEFINED CMAKE_CXX_STANDARD OR "${CMAKE_CXX_STANDARD} " STREQUAL " ")
   SET(CMAKE_CXX_STANDARD 11)
 endif()
 
-# KS: If C++ standard is lower than C++ standar used for ROOT compilation things will go terribly wrong
+# KS: If C++ standard is lower than C++ standard used for ROOT compilation things will go terribly wrong
 if(DEFINED ROOT_CXX_STANDARD AND ROOT_CXX_STANDARD GREATER CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD ${ROOT_CXX_STANDARD})
 endif()
 cmessage(STATUS "CMAKE CXX Standard: ${CMAKE_CXX_STANDARD}")
 
-if(${ROOT_CXX_STANDARD} LESS 14)
+if(ROOT_CXX_STANDARD LESS 14)
   cmessage(WARNING "ROOT CXX STANDARD: ${ROOT_CXX_STANDARD}")
 endif()
 
@@ -171,9 +87,7 @@ target_compile_options(MaCh3CompilerOptions INTERFACE
                                                     -Woverloaded-virtual
                                                     )
 #KS: If Debug is not defined disable it by default
-if(NOT DEFINED MaCh3_DEBUG_ENABLED)
-  SET(MaCh3_DEBUG_ENABLED FALSE)
-endif()
+DefineEnabledRequiredSwitch(MaCh3_DEBUG_ENABLED FALSE)
 
 #If DEBUG_LEVEL was defined but MaCh3_DEBUG_ENABLED not, enable debug flag
 if(DEFINED DEBUG_LEVEL)
@@ -205,9 +119,7 @@ else()
 endif()
 
 #KS: If multithreading is not defined enable it by default
-if(NOT DEFINED MaCh3_MULTITHREAD_ENABLED)
-  SET(MaCh3_MULTITHREAD_ENABLED TRUE)
-endif()
+DefineEnabledRequiredSwitch(MaCh3_MULTITHREAD_ENABLED TRUE)
 
 #Add Multithread flags
 if(MaCh3_MULTITHREAD_ENABLED)
@@ -241,14 +153,6 @@ set_target_properties(MaCh3CompilerOptions PROPERTIES EXPORT_NAME CompilerOption
 install(TARGETS MaCh3CompilerOptions
     EXPORT MaCh3-targets
     LIBRARY DESTINATION lib/)
-
-#KS: Consider moving it somewhere else
-SET(MaCh3_Fitter_ENABLED "MR2T2")
-SET(MaCh3_MINUIT2_ENABLED FALSE)
-if(ROOT_CXX_FLAGS MATCHES "-DMINUIT2_ENABLED")
-  LIST(APPEND MaCh3_Fitter_ENABLED " Minuit2")
-  SET(MaCh3_MINUIT2_ENABLED TRUE)
-endif()
 
 #Include logger
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/Logger.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,8 @@ if(DEFINED ROOT_CXX_STANDARD AND ROOT_CXX_STANDARD GREATER CMAKE_CXX_STANDARD)
 endif()
 cmessage(STATUS "CMAKE CXX Standard: ${CMAKE_CXX_STANDARD}")
 
-if(ROOT_CXX_STANDARD LESS 14)
+# KS: ROOT changed cmake in 6.32, we should move avay from using Luke's hack, keep it for due to compatibility
+if(ROOT_CXX_STANDARD LESS 14 AND ROOT_VERSION VERSION_LESS 6.32.00)
   cmessage(WARNING "ROOT CXX STANDARD: ${ROOT_CXX_STANDARD}")
 endif()
 

--- a/cmake/Modules/MaCh3Dependencies.cmake
+++ b/cmake/Modules/MaCh3Dependencies.cmake
@@ -1,0 +1,96 @@
+include(CPM)
+
+#Luke's handing cmake modules which Neutrino hep experiments might want
+CPMFindPackage(
+      NAME CMakeModules
+      GIT_TAG stable
+      GITHUB_REPOSITORY NuHepMC/CMakeModules
+      DOWNLOAD_ONLY
+  )
+include(${CMakeModules_SOURCE_DIR}/NuHepMCModules.cmake)
+include(NuHepMCUtils)
+
+# Check if CUDA was found
+if(MaCh3_GPU_ENABLED)
+  include(${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/CUDASetup.cmake)
+endif()
+
+include(ROOT)
+if(NOT TARGET ROOT::ROOT)
+  cmessage(FATAL_ERROR "MaCh3 Expected dependency target: ROOT::ROOT")
+endif()
+
+if(ROOT_VERSION VERSION_LESS 6.18.0)
+  cmessage(FATAL_ERROR "Using ROOT version smaller than 6.18.0, this may lead to unexpected results")
+endif()
+
+# KS: Since ROOT 6.32.0 Minuit is turned on by default
+SET(MaCh3_MINUIT2_ENABLED FALSE)
+if(ROOT_VERSION GREATER 6.32.0 OR ROOT_CXX_FLAGS MATCHES "-DMINUIT2_ENABLED")
+  SET(MaCh3_MINUIT2_ENABLED TRUE)
+endif()
+
+#YAML for reading in config files
+set(YAML_CPP_VERSION 0.7.0) #KS: We need it for version.h file also define this number olny once
+set(YAML_CPP_GIT_TAG "yaml-cpp-${YAML_CPP_VERSION}")
+CPMAddPackage(
+    NAME yaml-cpp
+    VERSION ${YAML_CPP_VERSION}
+    GITHUB_REPOSITORY "jbeder/yaml-cpp"
+    GIT_TAG "${YAML_CPP_GIT_TAG}"
+    OPTIONS
+      "YAML_BUILD_SHARED_LIBS ON"
+)
+
+if(NOT TARGET yaml-cpp::yaml-cpp)
+  cmessage(FATAL_ERROR "MaCh3 Expected dependency target: yaml-cpp::yaml-cpp")
+endif()
+
+#KS: Not being used right now so commenting it out.
+#CPMAddPackage(
+#  NAME Eigen
+#  VERSION 3.2.8
+#  URL https://gitlab.com/libeigen/eigen/-/archive/3.2.8/eigen-3.2.8.tar.gz
+#  # Eigen's CMakelists are not intended for library use
+#  DOWNLOAD_ONLY YES
+#)
+
+#if(Eigen_ADDED)
+#  add_library(Eigen INTERFACE IMPORTED)
+#  target_include_directories(Eigen INTERFACE ${Eigen_SOURCE_DIR})
+#endif()
+
+
+SET(MaCh3_Fitter_ENABLED "MR2T2")
+LIST(APPEND MaCh3_Fitter_ENABLED " PSO")
+if(MaCh3_MINUIT2_ENABLED)
+  LIST(APPEND MaCh3_Fitter_ENABLED " Minuit2")
+endif()
+
+################################## Oscillation ################################
+#KS: All of these should be moved to separate cmake and be handled by osc class, keep it for now
+#If USE_PROB3 not defined turn it off by default
+DefineEnabledRequiredSwitch(USE_PROB3 FALSE)
+
+# Oscillation calculation
+# In the future which osc calc we use might be set with a flag
+SET(MaCh3_Oscillator_ENABLED "")
+if (USE_PROB3)
+  CPMFindPackage(
+    NAME Prob3plusplus
+    VERSION 3.10.3
+    GITHUB_REPOSITORY "mach3-software/Prob3plusplus"
+    GIT_TAG v3.10.3
+  )
+  LIST(APPEND MaCh3_Oscillator_ENABLED "Prob3++")
+else()
+  CPMFindPackage(
+    NAME CUDAProb3
+    GITHUB_REPOSITORY "mach3-software/CUDAProb3"
+    GIT_TAG "feature_cleanup"
+    DOWNLOAD_ONLY YES
+  )
+  LIST(APPEND MaCh3_Oscillator_ENABLED "CUDAProb3")
+endif()
+
+#dump_cmake_variables(Prob3plusplus)

--- a/cmake/Modules/MaCh3Dependencies.cmake
+++ b/cmake/Modules/MaCh3Dependencies.cmake
@@ -20,13 +20,13 @@ if(NOT TARGET ROOT::ROOT)
   cmessage(FATAL_ERROR "MaCh3 Expected dependency target: ROOT::ROOT")
 endif()
 
-if(ROOT_VERSION VERSION_LESS 6.18.0)
+if(ROOT_VERSION VERSION_LESS 6.18.00)
   cmessage(FATAL_ERROR "Using ROOT version smaller than 6.18.0, this may lead to unexpected results")
 endif()
 
 # KS: Since ROOT 6.32.0 Minuit is turned on by default
 SET(MaCh3_MINUIT2_ENABLED FALSE)
-if(ROOT_VERSION GREATER 6.32.0 OR ROOT_CXX_FLAGS MATCHES "-DMINUIT2_ENABLED")
+if(ROOT_VERSION GREATER_EQUAL 6.32.00 OR ROOT_CXX_FLAGS MATCHES "-DMINUIT2_ENABLED")
   SET(MaCh3_MINUIT2_ENABLED TRUE)
 endif()
 

--- a/cmake/Modules/MaCh3Utils.cmake
+++ b/cmake/Modules/MaCh3Utils.cmake
@@ -1,0 +1,12 @@
+#KS: Inspired by Nuisance code
+if(NOT COMMAND DefineEnabledRequiredSwitch)
+  function(DefineEnabledRequiredSwitch VARNAME DEFAULTVALUE)
+    if(NOT DEFINED ${VARNAME} OR "${${VARNAME}}x" STREQUAL "x")
+      SET(${VARNAME} ${DEFAULTVALUE} PARENT_SCOPE)
+      SET(${VARNAME} ${DEFAULTVALUE})
+    else()
+      SET(${VARNAME}_REQUIRED ${${VARNAME}} PARENT_SCOPE)
+      SET(${VARNAME}_REQUIRED ${${VARNAME}})
+    endif()
+  endfunction()
+endif()

--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -605,10 +605,10 @@ void covarianceBase::TransferToParam() {
   }
 }
 
-const std::vector<double> covarianceBase::getProposed() const {
+std::vector<double> covarianceBase::getProposed() const {
   std::vector<double> props(_fNumPar);
   for (int i = 0; i < _fNumPar; ++i) props[i] = _fPropVal[i];
-  return props;
+  return props; // return by value, not by reference
 }
 
 // Throw nominal values
@@ -1248,7 +1248,7 @@ double covarianceBase::MatrixVectorMultiSingle(double** _restrict_ matrix, const
 }
 
 // ********************************************
-void covarianceBase::setIndivStepScale(std::vector<double> stepscale) {
+void covarianceBase::setIndivStepScale(const std::vector<double>& stepscale) {
 // ********************************************
 
   if ((int)stepscale.size() != _fNumPar)
@@ -1283,7 +1283,7 @@ void covarianceBase::printIndivStepScale() {
 void covarianceBase::MakePosDef(TMatrixDSym *cov) {
   //DB Save original warning state and then increase it in this function to suppress 'matrix not positive definite' messages
   //Means we no longer need to overload
-  if(cov == NULL){
+  if(cov == nullptr){
     cov = &*covMatrix;
   }
 

--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -248,8 +248,10 @@ void covarianceBase::ConstructPCA() {
   #endif
 }
 
-void covarianceBase::init(const char *name, const char *file)
-{
+// ********************************************
+void covarianceBase::init(const char *name, const char *file) {
+// ********************************************
+
   // Set the covariance matrix from input ROOT file (e.g. flux, ND280, NIWG)
   TFile *infile = new TFile(file, "READ");
   if (infile->IsZombie()) {
@@ -321,12 +323,13 @@ void covarianceBase::init(const char *name, const char *file)
   delete infile;
 }
 
+// ********************************************
 // ETA
 // An init function for the YAML constructor
 // All you really need from the YAML file is the number of Systematics
 // Then get all the info from the YAML file in the covarianceXsec::ParseYAML function
-void covarianceBase::init(const std::vector<std::string>& YAMLFile)
-{
+void covarianceBase::init(const std::vector<std::string>& YAMLFile) {
+// ********************************************
   _fYAMLDoc["Systematics"] = YAML::Node(YAML::NodeType::Sequence);
   for(unsigned int i = 0; i < YAMLFile.size(); i++)
   {
@@ -427,7 +430,7 @@ void covarianceBase::init(const std::vector<std::string>& YAMLFile)
       }
       else {
         MACH3LOG_ERROR("Parameter {} not in list! Check your spelling?", key);
-        exit(5);
+        throw MaCh3Exception(__FILE__ , __LINE__ );
       }
 
       //
@@ -439,11 +442,11 @@ void covarianceBase::init(const std::vector<std::string>& YAMLFile)
         if(std::abs(Corr2 - Corr1) > FLT_EPSILON) {
           MACH3LOG_ERROR("Correlations are not equal between {} and {}", _fFancyNames[j], key);
           MACH3LOG_ERROR("Got : {} and {}", Corr2, Corr1);
-          exit(5);
+          throw MaCh3Exception(__FILE__ , __LINE__ );
         }
       } else {
         MACH3LOG_ERROR("Correlation does not appear reciprocally between {} and {}", _fFancyNames[j], key);
-        exit(5);
+        throw MaCh3Exception(__FILE__ , __LINE__ );
       }
       (*_fCovMatrix)(j, index)= (*_fCovMatrix)(index, j) = Corr1*_fError[j]*_fError[index];
     }
@@ -470,8 +473,9 @@ void covarianceBase::init(const std::vector<std::string>& YAMLFile)
   return;
 }
 
+// ********************************************
 void covarianceBase::init(TMatrixDSym* covMat) {
-
+// ********************************************
   size = covMat->GetNrows();
   _fNumPar = size;
   InvertCovMatrix = new double*[_fNumPar]();
@@ -495,8 +499,10 @@ void covarianceBase::init(TMatrixDSym* covMat) {
   MACH3LOG_INFO("Created covariance matrix named: {}", getName());
 }
 
+// ********************************************
 // Set the covariance matrix for this class
 void covarianceBase::setCovMatrix(TMatrixDSym *cov) {
+// ********************************************
   if (cov == NULL) {
     MACH3LOG_ERROR("Could not find covariance matrix you provided to setCovMatrix");
     MACH3LOG_ERROR("{}:{}", __FILE__, __LINE__);
@@ -604,11 +610,12 @@ void covarianceBase::TransferToParam() {
     _fCurrVal[i] = fParCurr_vec(i);
   }
 }
-
+// ********************************************
 std::vector<double> covarianceBase::getProposed() const {
+// ********************************************
   std::vector<double> props(_fNumPar);
   for (int i = 0; i < _fNumPar; ++i) props[i] = _fPropVal[i];
-  return props; // return by value, not by reference
+  return props;
 }
 
 // Throw nominal values

--- a/covariance/covarianceBase.h
+++ b/covariance/covarianceBase.h
@@ -84,6 +84,7 @@ class covarianceBase {
   void setParameters(const std::vector<double>& pars = {});
   /// @brief Set if parameter should have flat prior or not
   /// @param i Parameter index
+  /// @param eL bool telling if it will be flat or not
   void setFlatPrior(const int i, const bool eL);
   
   /// @brief set branches for output file
@@ -97,7 +98,7 @@ class covarianceBase {
   void setIndivStepScale(const int ParameterIndex, const double StepScale){ _fIndivStepScale.at(ParameterIndex) = StepScale; }
   /// @brief DB Function to set fIndivStepScale from a vector (Can be used from execs and inside covariance constructors)
   /// @param stepscale Vector of individual step scale, should have same
-  void setIndivStepScale(std::vector<double> stepscale);
+  void setIndivStepScale(const std::vector<double>& stepscale);
   /// @brief KS: In case someone really want to change this
   inline void setPrintLength(const unsigned int PriLen) { PrintLength = PriLen; }
 
@@ -112,7 +113,7 @@ class covarianceBase {
   /// @brief Throw the parameters according to the covariance matrix. This shouldn't be used in MCMC code ase it can break Detailed Balance;
   void throwParameters();
   /// @brief Throw nominal values
-  void throwNominal(bool nomValues = false, int seed = 0);
+  void throwNominal(const bool nomValues = false, const int seed = 0);
   /// @brief Randomly throw the parameters in their 1 sigma range
   void RandomConfiguration();
   
@@ -198,9 +199,9 @@ class covarianceBase {
   /// @brief Get total number of parameters
   inline int    GetNumParams()               {return _fNumPar;}
   virtual std::vector<double> getNominalArray();
-  const std::vector<double>& getPreFitValues(){return _fPreFitValue;}
-  const std::vector<double>& getGeneratedValues(){return _fGenerated;}
-  const std::vector<double> getProposed() const;
+  std::vector<double> getPreFitValues(){return _fPreFitValue;}
+  std::vector<double> getGeneratedValues(){return _fGenerated;}
+  std::vector<double> getProposed() const;
   /// @brief Get proposed parameter value
   /// @param i Parameter index
   inline double getParProp(const int i) { return _fPropVal[i]; }
@@ -381,7 +382,7 @@ class covarianceBase {
 
   /// @brief Make matrix positive definite by adding small values to diagonal, necessary for inverting matrix
   /// @param cov Matrix which we evaluate Positive Definitiveness
-  void MakePosDef(TMatrixDSym *cov = NULL);
+  void MakePosDef(TMatrixDSym *cov = nullptr);
 
   /// @brief HW: Finds closest possible positive definite matrix in Frobenius Norm ||.||_frob Where ||X||_frob=sqrt[sum_ij(x_ij^2)] (basically just turns an n,n matrix into vector in n^2 space then does Euclidean norm)
   void makeClosestPosDef(TMatrixDSym *cov);

--- a/covariance/covarianceXsec.cpp
+++ b/covariance/covarianceXsec.cpp
@@ -118,7 +118,6 @@ void covarianceXsec::InitXsecFromConfig() {
 	 if(param["Systematic"]["KinematicCuts"]){
 
 	   NumKinematicCuts = param["Systematic"]["KinematicCuts"].size();
-	   //std::cout << "Number of Kinematic cuts is " << NumKinematicCuts << std::endl;
 
 	   std::vector<std::string> TempKinematicStrings;
 	   std::vector<std::vector<double>> TempKinematicBounds;
@@ -128,23 +127,19 @@ void covarianceXsec::InitXsecFromConfig() {
 		 //ETA
 		 //This is a bit messy, Kinematic cuts is a list of maps
 		 //The for loop h
-		 for (YAML::const_iterator it=param["Systematic"]["KinematicCuts"][KinVar_i].begin();it!=param["Systematic"]["KinematicCuts"][KinVar_i].end();++it) {
+		 for (YAML::const_iterator it = param["Systematic"]["KinematicCuts"][KinVar_i].begin();it!=param["Systematic"]["KinematicCuts"][KinVar_i].end();++it) {
 		   TempKinematicStrings.push_back(it->first.as<std::string>());
 		   TempKinematicBounds.push_back(it->second.as<std::vector<double>>());
 		   std::vector<double> bounds = it->second.as<std::vector<double>>();
 		 }
 	   }
-
-	   _fKinematicPars.at(i) = TempKinematicStrings;
-	   _fKinematicBounds.at(i) = TempKinematicBounds;	   
-	 }
-
+        _fKinematicPars.at(i) = TempKinematicStrings;
+        _fKinematicBounds.at(i) = TempKinematicBounds;
+      }
 	 if(_fFancyNames[i].find("b_")==0) isFlux[i] = true;
 	 else isFlux[i] = false;
 	 i++;
   }
-
-
   _fSplineInterpolationType.shrink_to_fit();
   _fTargetNuclei.shrink_to_fit();
   _fNeutrinoFlavour.shrink_to_fit();
@@ -159,12 +154,12 @@ void covarianceXsec::InitXsecFromConfig() {
 covarianceXsec::~covarianceXsec() {
 // ********************************************
 
-
 }
 
 // ********************************************
 // DB Grab the Number of splines for the relevant DetID
 int covarianceXsec::GetNumSplineParamsFromDetID(const int DetID) {
+// ********************************************
   int returnVal = 0; 
   for (int i = 0; i < _fNumPar; ++i) {
     if ((GetParDetID(i) & DetID)) { //If parameter applies to required DetID
@@ -176,11 +171,11 @@ int covarianceXsec::GetNumSplineParamsFromDetID(const int DetID) {
 
   return returnVal;
 }
-// ********************************************
 
 // ********************************************
 // DB Grab the Spline Names for the relevant DetID
 const std::vector<std::string> covarianceXsec::GetSplineParsNamesFromDetID(const int DetID) {
+// ********************************************
 
   std::vector<std::string> returnVec;
   returnVec.reserve(_fNumPar);
@@ -207,13 +202,11 @@ const std::vector<std::string> covarianceXsec::GetSplineParsNamesFromDetID(const
   return returnVec;
 }
 // ********************************************
-//
-
 // ETA - this is a complete fudge for now and is only here because on
 // T2K the splines at ND280 and SK have different names... 
 // this is completely temporary and will be removed in the future
 const std::vector<std::string> covarianceXsec::GetFDSplineFileParsNamesFromDetID(const int DetID) {
-
+// ********************************************
   std::vector<std::string> returnVec;
   int FDSplineCounter = 0;
   for (int i = 0; i < _fNumPar; ++i) {
@@ -222,8 +215,6 @@ const std::vector<std::string> covarianceXsec::GetFDSplineFileParsNamesFromDetID
 	  if (strcmp(GetParamType(i), "Spline") == 0) { //If parameter is implemented as a spline
 		//This is horrible but has to be here whilst the ND and FD splines are named
 		//differently on T2K. This is easy to fix but isn't currently available.
-		//std::cout << "FDSplineIndex is " << std::endl;
-		//std::cout << "Getting FD spline name " << _fFDSplineNames[FDSplineCounter] << " compared DetID " << DetID << " with " << GetParDetID(i) << std::endl;
 		returnVec.push_back(_fFDSplineNames[FDSplineCounter]); //Append spline name
 		FDSplineCounter++;
 	  }
@@ -232,11 +223,12 @@ const std::vector<std::string> covarianceXsec::GetFDSplineFileParsNamesFromDetID
   return returnVec;
 }
 
+// ********************************************
 // ETA - this is another fudge for now and is only here because on
 // T2K the splines at ND280 and SK have different names... 
 // this is completely temporary and will be removed in the future
 const std::vector<std::string> covarianceXsec::GetNDSplineFileParsNamesFromDetID(const int DetID) {
-
+// ********************************************
   std::vector<std::string> returnVec;
   int NDSplineCounter = 0;
   for (int i = 0; i < _fNumPar; ++i) {
@@ -256,6 +248,7 @@ const std::vector<std::string> covarianceXsec::GetNDSplineFileParsNamesFromDetID
 // ********************************************
 // DB Grab the Spline Names for the relevant DetID
 const std::vector<std::string> covarianceXsec::GetSplineFileParsNamesFromDetID(const int DetID) {
+// ********************************************
   std::vector<std::string> returnVec;
 
   int FDSplineCounter = 0;
@@ -278,11 +271,11 @@ const std::vector<std::string> covarianceXsec::GetSplineFileParsNamesFromDetID(c
 
   return returnVec;
 }
-// ********************************************
 
 // ********************************************
 // DB Grab the Spline Modes for the relevant DetID
 const std::vector< std::vector<int> > covarianceXsec::GetSplineModeVecFromDetID(const int DetID) {
+// ********************************************
   std::vector< std::vector<int> > returnVec;
 
   //Need a counter or something to correctly get the index in _fFDSplineModes since it's not of length nPars
@@ -296,14 +289,13 @@ const std::vector< std::vector<int> > covarianceXsec::GetSplineModeVecFromDetID(
 	  }
 	}
   }
-
   return returnVec;
 }
-// ********************************************
 
 // ********************************************
 // DB Grab the Spline Indices for the relevant DetID
 const std::vector<int> covarianceXsec::GetSplineParsIndexFromDetID(const int DetID) {
+// ********************************************
   std::vector<int> returnVec;
 
   for (int i = 0; i < _fNumPar; ++i) {
@@ -316,145 +308,101 @@ const std::vector<int> covarianceXsec::GetSplineParsIndexFromDetID(const int Det
 
   return returnVec;
 }
+
 // ********************************************
+// Get Norm params
+XsecNorms4 covarianceXsec::GetXsecNorm(const int i, const int norm_counter) {
+// ********************************************
+  XsecNorms4 norm;
+  norm.name = GetParFancyName(i);
+
+  //Copy the mode information into an XsecNorms4 struct
+  norm.modes = _fNormModes[norm_counter];
+  norm.pdgs = _fNeutrinoFlavour[norm_counter];
+  norm.preoscpdgs = _fNeutrinoFlavourUnosc[norm_counter];
+  norm.targets = _fTargetNuclei[norm_counter];
+
+  //Next ones are kinematic bounds on where normalisation parameter should apply (at the moment only etrue but hope to add q2
+  //We set a bool to see if any bounds exist so we can short-circuit checking all of them every step
+  bool HasKinBounds = false;
+
+  if(_fKinematicPars.at(i).size() > 0) HasKinBounds = true;
+
+  for(unsigned int KinematicCut_i = 0; KinematicCut_i < _fKinematicPars[i].size(); ++KinematicCut_i) {
+    //Push back with the string for the kinematic cut
+    norm.KinematicVarStr.push_back(_fKinematicPars.at(i).at(KinematicCut_i));
+    //Push back with the bounds for the kinematic cut
+    norm.Selection.push_back(_fKinematicBounds.at(i).at(KinematicCut_i));
+  }
+  norm.hasKinBounds = HasKinBounds;
+  //End of kinematic bound checking
+
+  // Set the global parameter index of the normalisation parameter
+  norm.index = i;
+
+  return norm;
+}
 
 // ********************************************
 // DB Grab the Normalisation parameters
-// ETA - this should be the same as GetNormParsFromDetID but not dependent on the DetID
 // I have changed this because it is quite nice for the covariance object not to care
 // which samplePDF a parameter should affect or not.
 void covarianceXsec::SetupNormPars(){
-
+// ********************************************
   //ETA - in case NormParams already is filled
   NormParams.clear();
 
   int norm_counter = 0;
   for (int i = 0; i < _fNumPar; ++i) {
-	if (strcmp(GetParamType(i), "Norm") == 0) { //If parameter is implemented as a normalisation
-	
-		std::vector<int> temp;
-		XsecNorms4 norm;
-		norm.name = GetParFancyName(i);
-
-		//Copy the mode information into an XsecNorms4 struct
-		norm.modes = _fNormModes[norm_counter];	
-		norm.pdgs = _fNeutrinoFlavour[norm_counter];
-		norm.preoscpdgs = _fNeutrinoFlavourUnosc[norm_counter];
-		norm.targets = _fTargetNuclei[norm_counter];
-		
-		//Next ones are kinematic bounds on where normalisation parameter should apply (at the moment only etrue but hope to add q2
-		//We set a bool to see if any bounds exist so we can short-circuit checking all of them every step
-		bool HasKinBounds=false;
-
-		////////////////////
-		//New generic cuts things 
-		////////////////////
-		if(_fKinematicPars.at(i).size() > 0){
-		  HasKinBounds = true;
-		}
-
-		for(unsigned int KinematicCut_i = 0 ; KinematicCut_i < _fKinematicPars[i].size() ; ++KinematicCut_i){
-		  //Push back with the string for the kinematic cut
-		  norm.KinematicVarStr.push_back(_fKinematicPars.at(i).at(KinematicCut_i));
-		  //Push back with the bounds for the kinematic cut
-          norm.Selection.push_back(_fKinematicBounds.at(i).at(KinematicCut_i));
-		}
-		norm.hasKinBounds = HasKinBounds;
-		//End of kinematic bound checking
-
-		// Set the global parameter index of the normalisation parameter
-		norm.index = i;
-		//Add this parameter to the vector of parameters
-		NormParams.push_back(norm);
-		norm_counter++;
-	  }
-	}
-
+    if (strcmp(GetParamType(i), "Norm") == 0) { //If parameter is implemented as a normalisation
+      //Add this parameter to the vector of parameters
+      NormParams.push_back(GetXsecNorm(i, norm_counter));
+      norm_counter++;
+    }
+  }
   return; 
 }
-// ********************************************
-
 
 // ********************************************
 // DB Grab the Normalisation parameters for the relevant DetID
-// ETA - I think this doesn't need to be the same as scanParameters, haven't we already got this info??
 const std::vector<XsecNorms4> covarianceXsec::GetNormParsFromDetID(const int DetID) {
+// ********************************************
   std::vector<XsecNorms4> returnVec;
   int norm_counter = 0;
 
   for (int i = 0; i < _fNumPar; ++i) {
-	if (strcmp(GetParamType(i), "Norm") == 0) { //If parameter is implemented as a normalisation
-
-	  if ((GetParDetID(i) & DetID)) { //If parameter applies to required DetID
-
-		std::vector<int> temp;
-
-		XsecNorms4 norm;
-		norm.name=GetParFancyName(i);
-
-		//Copy the mode information into an XsecNorms4 struct
-		norm.modes = _fNormModes[norm_counter];	
-		norm.pdgs = _fNeutrinoFlavour[norm_counter];
-		norm.preoscpdgs = _fNeutrinoFlavourUnosc[norm_counter];
-		norm.targets = _fTargetNuclei[norm_counter];
-		
-		//Next ones are kinematic bounds on where normalisation parameter should apply (at the moment only etrue but hope to add q2
-		//We set a bool to see if any bounds exist so we can shortcircuit checking all of them every step
-		bool HasKinBounds=false;
-
-		////////////////////
-		//New generic cuts things 
-		////////////////////
-		if(_fKinematicPars.at(i).size() > 0){
-		  HasKinBounds = true;
-		}
-
-		for(unsigned int KinematicCut_i = 0 ; KinematicCut_i < _fKinematicPars[i].size() ; ++KinematicCut_i){
-		  //Push back with the string for the kinematic cut
-		  //std::cout << "----------------------" << std::endl;
-		  //std::cout << "Will apply a cut on " << _fKinematicPars.at(i).at(KinematicCut_i) << std::endl;
-		  norm.KinematicVarStr.push_back(_fKinematicPars.at(i).at(KinematicCut_i));
-		  //std::cout << "With bounds " << _fKinematicBounds.at(i).at(KinematicCut_i).at(0) << " to " << _fKinematicBounds.at(i).at(KinematicCut_i).at(1) << std::endl;
-		  //Push back with the bounds for the kinematic cut
-          norm.Selection.push_back(_fKinematicBounds.at(i).at(KinematicCut_i));
-		}
-
-		norm.hasKinBounds=HasKinBounds;
-		//End of kinematic bound checking
-
-		// Set the global parameter index of the normalisation parameter
-		norm.index = i;
-		//Add this parameter to the vector of parameters
-		returnVec.push_back(norm);
-	  }
-	  norm_counter++;
-	}
+    if (strcmp(GetParamType(i), "Norm") == 0) { //If parameter is implemented as a normalisation
+      if ((GetParDetID(i) & DetID)) { //If parameter applies to required DetID
+        //Add this parameter to the vector of parameters
+          returnVec.push_back(GetXsecNorm(i, norm_counter));
+      }
+      norm_counter++;
+    }
   }
-
   return returnVec;
 }
-// ********************************************
+
 
 // ********************************************
 // DB Grab the number of Normalisation parameters for the relevant DetID
 int covarianceXsec::GetNumFuncParamsFromDetID(const int DetID) {
+// ********************************************
   int returnVal = 0;
 
   for (int i = 0; i < _fNumPar; ++i) {
     if ((GetParDetID(i) & DetID)) { //If parameter applies to required DetID
       if (strcmp(GetParamType(i), "Functional") == 0) { //If parameter is implemented as a functional parameter
-		returnVal += 1;
+        returnVal += 1;
       }
     }
   }
-
   return returnVal;
 }
-// ********************************************
 
 // ********************************************
 // DB Grab the Functional parameter names for the relevant DetID
 const std::vector<std::string> covarianceXsec::GetFuncParsNamesFromDetID(const int DetID) {
+// ********************************************
   std::vector<std::string> returnVec;
 
   for (int i = 0; i < _fNumPar; ++i) {
@@ -464,33 +412,28 @@ const std::vector<std::string> covarianceXsec::GetFuncParsNamesFromDetID(const i
       }
     }
   }
-
   return returnVec;
 }
-// ********************************************
 
 // ********************************************
 // DB Grab the Functional parameter indices for the relevant DetID
 const std::vector<int> covarianceXsec::GetFuncParsIndexFromDetID(const int DetID) {
+// ********************************************
   std::vector<int> returnVec;
 
   for (int i = 0; i < _fNumPar; ++i) {
     if ((GetParDetID(i) & DetID)) { //If parameter applies to required DetID
       if (strcmp(GetParamType(i), "Functional") == 0) { //If parameter is implemented as a functional param
-		//std::cout << "Found Functional parameter" << std::endl;
 		returnVec.push_back(i);
       }
     }
   }
-
   return returnVec;
 }
-// ********************************************
 
 // ********************************************
 void covarianceXsec::initParams(const double fScale) {
 // ********************************************
-
   for (int i = 0; i < _fNumPar; ++i) {
     //ETA - set the name to be xsec_% as this is what ProcessorMCMC expects
     _fNames[i] = "xsec_"+std::to_string(i);
@@ -498,15 +441,6 @@ void covarianceXsec::initParams(const double fScale) {
     // Set covarianceBase parameters (Curr = current, Prop = proposed, Sigma = step)
     _fCurrVal[i] = _fPreFitValue[i];
     _fPropVal[i] = _fCurrVal[i];
-
-    // Any param with nom == 1 should be > 0
-    if (_fGenerated[i] == 1) {
-      // If the _fPreFitValue is negative we should try to throw it above this
-      // We don't really do this ever...
-      while (_fPreFitValue[i] <= 0) {
-        _fPreFitValue[i] = random_number[0]->Gaus(_fPreFitValue[i], fScale*TMath::Sqrt( (*covMatrix)(i,i) ));
-      }
-    }
   }
   //DB Set Individual Step scale for PCA parameters to the LastPCAdpar fIndivStepScale because the step scale for those parameters is set by 'eigen_values[i]' but needs an overall step scale
   //   However, individual step scale for non-PCA parameters needs to be set correctly
@@ -515,14 +449,12 @@ void covarianceXsec::initParams(const double fScale) {
       _fIndivStepScale[i] = _fIndivStepScale[LastPCAdpar-1];
     }
   }
-
   randomize();
   //KS: Transfer the starting parameters to the PCA basis, you don't want to start with zero..
   if (pca)
   {
     TransferToPCA();
-    for (int i = 0; i < _fNumParPCA; ++i)
-    {
+    for (int i = 0; i < _fNumParPCA; ++i) {
       _fPreFitValue_PCA[i] = fParCurr_PCA(i);
     }
   }
@@ -533,10 +465,6 @@ void covarianceXsec::initParams(const double fScale) {
 // Print everything we know about the inputs we're Getting
 void covarianceXsec::Print() {
 // ********************************************
-
-  // Get the precision so we can go back to normal for cout later
-  //std::streamsize ss = std::cout.precision();
-
   MACH3LOG_INFO("#################################################");
   MACH3LOG_INFO("Printing covarianceXsec:");
 
@@ -621,7 +549,6 @@ void covarianceXsec::Print() {
   CheckCorrectInitialisation();
 } // End
 
-
 // ********************************************
 // KS: Check if matrix is correctly initialised
 void covarianceXsec::CheckCorrectInitialisation() {
@@ -650,34 +577,25 @@ void covarianceXsec::CheckCorrectInitialisation() {
 // Sets the proposed Flux parameters to the prior values
 void covarianceXsec::setFluxOnlyParameters() {
 // ********************************************
-  if(!pca)
-  {
-    for (int i = 0; i < _fNumPar; i++)
-    {
+  if(!pca) {
+    for (int i = 0; i < _fNumPar; i++) {
       if(isFlux[i]) _fPropVal[i] = _fPreFitValue[i];
     }
-  }
-  else
-  {
+  } else {
     MACH3LOG_ERROR("setFluxOnlyParameters not implemented for PCA");
     throw;
   }
-
 }
 
 // ********************************************
 // Sets the proposed Flux parameters to the prior values
 void covarianceXsec::setXsecOnlyParameters() {
 // ********************************************
-  if(!pca)
-  {
-    for (int i = 0; i < _fNumPar; i++)
-    {
+  if(!pca) {
+    for (int i = 0; i < _fNumPar; i++) {
       if(!isFlux[i]) _fPropVal[i] = _fPreFitValue[i];
     }
-  }
-  else
-  {
+  } else {
     MACH3LOG_ERROR("setXsecOnlyParameters not implemented for PCA");
     throw;
   }

--- a/covariance/covarianceXsec.h
+++ b/covariance/covarianceXsec.h
@@ -15,6 +15,11 @@
 class covarianceXsec : public covarianceBase {
   public:
     /// @brief Constructor
+    /// @param FileNames A vector of strings representing the YAML files used for initialisation of matrix
+    /// @param name Matrix name
+    /// @param threshold PCA threshold from 0 to 1. Default is -1 and means no PCA
+    /// @param FirstPCAdpar First PCA parameter that will be decomposed.
+    /// @param LastPCAdpar First PCA parameter that will be decomposed.
     covarianceXsec(const std::vector<std::string>& FileNames, const char *name = "xsec_cov", double threshold = -1, int FirstPCAdpar = -999, int LastPCAdpar = -999);
     /// @brief Destructor
     ~covarianceXsec();
@@ -39,19 +44,30 @@ class covarianceXsec : public covarianceBase {
     inline int GetParDetID(const int i) const { return _fDetID[i];};
     /// @brief ETA - just return a string of "spline", "norm" or "functional"
     /// @param i parameter index
-    inline const char*  GetParamType(const int i) const {return _fParamType[i].c_str();}
+    inline const char* GetParamType(const int i) const {return _fParamType[i].c_str();}
 
     /// @brief Get interpolation type vector
     inline const std::vector<SplineInterpolation>& GetSplineInterpolation() const{return _fSplineInterpolationType;}
     /// @brief Get interpolation type for a given parameter
+    /// @param i spline parameter index, not confuse with global index
     inline SplineInterpolation GetParSplineInterpolation(const int i) {return _fSplineInterpolationType.at(i);}
 
     /// @brief EM: value at which we cap spline knot weight
-    /// @param i parameter index
+    /// @param i spline parameter index, not confuse with global index
     inline double GetParSplineKnotUpperBound(const int i) {return _fSplineKnotUpBound[i];}
     /// @brief EM: value at which we cap spline knot weight
-    /// @param i parameter index
+    /// @param i spline parameter index, not confuse with global index
     inline double GetParSplineKnotLowerBound(const int i) {return _fSplineKnotLowBound[i];}
+
+    /// @brief DB Grab the number of parameters for the relevant DetID
+    /// @param Type Type of syst, for example kNorm, kSpline etc
+    int GetNumParamsFromDetID(const int DetID, const SystType Type);
+    /// @brief DB Grab the parameter names for the relevant DetID
+    /// @param Type Type of syst, for example kNorm, kSpline etc
+    const std::vector<std::string> GetParsNamesFromDetID(const int DetID, const SystType Type);
+    /// @brief DB Grab the parameter indices for the relevant DetID
+    /// @param Type Type of syst, for example kNorm, kSpline etc
+    const std::vector<int> GetParsIndexFromDetID(const int DetID, const SystType Type);
 
     /// @brief DB Get spline parameters depending on given DetID
     const std::vector<std::string> GetSplineParsNamesFromDetID(const int DetID);
@@ -64,20 +80,20 @@ class covarianceXsec : public covarianceBase {
     /// @brief DB Grab the Spline Modes for the relevant DetID
     const std::vector< std::vector<int> > GetSplineModeVecFromDetID(const int DetID);
     /// @brief DB Grab the Spline Indices for the relevant DetID
-    const std::vector<int> GetSplineParsIndexFromDetID(const int DetID);
+    const std::vector<int> GetSplineParsIndexFromDetID(const int DetID){return GetParsIndexFromDetID(DetID, kSpline);}
 
     /// @brief DB Grab the Number of splines for the relevant DetID
-    int GetNumSplineParamsFromDetID(const int DetID);
+    int GetNumSplineParamsFromDetID(const int DetID){return GetNumParamsFromDetID(DetID, kSpline);}
 
     /// @brief DB Get norm/func parameters depending on given DetID
     const std::vector<XsecNorms4> GetNormParsFromDetID(const int DetID);
 
     /// @brief DB Grab the number of Normalisation parameters for the relevant DetID
-    int GetNumFuncParamsFromDetID(const int DetID);
+    int GetNumFuncParamsFromDetID(const int DetID){return GetNumParamsFromDetID(DetID, kFunc);}
     /// @brief DB Grab the Functional parameter names for the relevant DetID
-    const std::vector<std::string> GetFuncParsNamesFromDetID(const int DetID);
+    const std::vector<std::string> GetFuncParsNamesFromDetID(const int DetID){return GetParsNamesFromDetID(DetID, kFunc);}
     /// @brief DB Grab the Functional parameter indices for the relevant DetID
-    const std::vector<int> GetFuncParsIndexFromDetID(const int DetID);
+    const std::vector<int> GetFuncParsIndexFromDetID(const int DetID){return GetParsIndexFromDetID(DetID, kFunc);}
 
     /// @brief KS: For most covariances nominal and fparInit (prior) are the same, however for Xsec those can be different
     /// For example Sigma Var are done around nominal in ND280, no idea why though...
@@ -93,6 +109,7 @@ class covarianceXsec : public covarianceBase {
     /// @param i parameter index
     inline double getNominal(const int i) override { return _fPreFitValue.at(i); };
     /// @brief Is parameter a flux param or not. This might become deprecated in future
+    /// @param i parameter index
     /// @warning Will become deprecated
     inline bool IsParFlux(const int i){ return isFlux[i]; }
     /// @brief KS Function to set to nominal flux parameters
@@ -106,11 +123,11 @@ class covarianceXsec : public covarianceBase {
     /// @brief Initialise CovarianceXsec
     void initParams(const double fScale);
     /// Is parameter flux or not, This might become deprecated in future
+    /// @warning Will become deprecated
     std::vector<bool> isFlux;
 
     /// Tells to which samples object param should be applied
     std::vector<int> _fDetID;
-    //std::vector<std::string> _fDetString;
     /// Type of parameter like norm, spline etc.
     std::vector<std::string> _fParamType;
 

--- a/covariance/covarianceXsec.h
+++ b/covariance/covarianceXsec.h
@@ -23,6 +23,10 @@ class covarianceXsec : public covarianceBase {
     inline void InitXsecFromConfig();
     /// @brief Initialise Norm params
     inline void SetupNormPars();
+    /// @brief Get Norm params
+    /// @param i Global parameter index
+    /// @param norm_counter norm parameter index
+    inline XsecNorms4 GetXsecNorm(const int i, const int norm_counter);
     /// @brief Print information about the whole object once it is set
     inline void Print();
 

--- a/manager/manager.h
+++ b/manager/manager.h
@@ -29,7 +29,7 @@ class manager {
 public:
   /// @brief Constructs a manager object with the specified file name.
   /// @param filename The name of the configuration file.
-  manager(std::string const &filename);
+  explicit manager(std::string const &filename);
   /// @brief Destroys the manager object.
   virtual ~manager();
 

--- a/mcmc/MCMCProcessor.cpp
+++ b/mcmc/MCMCProcessor.cpp
@@ -711,8 +711,8 @@ void MCMCProcessor::DrawPostfit() {
 
 // *********************
 // Make fancy Credible Intervals plots
-void MCMCProcessor::MakeCredibleIntervals(std::vector<double> CredibleIntervals,
-                                          std::vector<Color_t> CredibleIntervalsColours,
+void MCMCProcessor::MakeCredibleIntervals(const std::vector<double>& CredibleIntervals,
+                                          const std::vector<Color_t>& CredibleIntervalsColours,
                                           bool CredibleInSigmas) {
 // *********************
 
@@ -1683,9 +1683,9 @@ void MCMCProcessor::DrawCorrelations1D() {
 
 // *********************
 // Make fancy Credible Intervals plots
-void MCMCProcessor::MakeCredibleRegions(std::vector<double> CredibleRegions,
-                                        std::vector<Style_t> CredibleRegionStyle,
-                                        std::vector<Color_t> CredibleRegionColor,
+void MCMCProcessor::MakeCredibleRegions(const std::vector<double>& CredibleRegions,
+                                        const std::vector<Style_t>& CredibleRegionStyle,
+                                        const std::vector<Color_t>& CredibleRegionColor,
                                         bool CredibleInSigmas) {
 // *********************
 
@@ -1833,14 +1833,14 @@ void MCMCProcessor::MakeCredibleRegions(std::vector<double> CredibleRegions,
 
 // *********************
 // Make fancy triangle plot for selected parameters
-void MCMCProcessor::MakeTrianglePlot(std::vector<std::string> ParNames,
+void MCMCProcessor::MakeTrianglePlot(const std::vector<std::string>& ParNames,
                                      // 1D
-                                     std::vector<double> CredibleIntervals,
-                                     std::vector<Color_t> CredibleIntervalsColours,
+                                     const std::vector<double>& CredibleIntervals,
+                                     const std::vector<Color_t>& CredibleIntervalsColours,
                                      //2D
-                                     std::vector<double> CredibleRegions,
-                                     std::vector<Style_t> CredibleRegionStyle,
-                                     std::vector<Color_t> CredibleRegionColor,
+                                     const std::vector<double>& CredibleRegions,
+                                     const std::vector<Style_t>& CredibleRegionStyle,
+                                     const std::vector<Color_t>& CredibleRegionColor,
                                      // Other
                                      bool CredibleInSigmas) {
 // *********************
@@ -3066,7 +3066,7 @@ void MCMCProcessor::ResetHistograms() {
 
 // **************************
 // KS: Get Super Fancy Polar Plot
-void MCMCProcessor::GetPolarPlot(std::vector<std::string> ParNames){
+void MCMCProcessor::GetPolarPlot(const std::vector<std::string>& ParNames){
 // **************************
   if(hpost[0] == nullptr) MakePostfit();
 
@@ -3146,8 +3146,11 @@ void MCMCProcessor::GetPolarPlot(std::vector<std::string> ParNames){
 }
 
 // **************************
-// Get Bayes Factor for particualar parameter
-void MCMCProcessor::GetBayesFactor(std::vector<std::string> ParNames, std::vector<std::vector<double>> Model1Bounds, std::vector<std::vector<double>> Model2Bounds, std::vector<std::vector<std::string>> ModelNames){
+// Get Bayes Factor for particular parameter
+void MCMCProcessor::GetBayesFactor(const std::vector<std::string>& ParNames,
+                                   const std::vector<std::vector<double>>& Model1Bounds,
+                                   const std::vector<std::vector<double>>& Model2Bounds,
+                                   const std::vector<std::vector<std::string>>& ModelNames){
 // **************************
   if(hpost[0] == nullptr) MakePostfit();
 
@@ -3204,8 +3207,10 @@ void MCMCProcessor::GetBayesFactor(std::vector<std::string> ParNames, std::vecto
 
 
 // **************************
-// KS: Get Savage Dockey point hypothesis test
-void MCMCProcessor::GetSavageDickey(std::vector<std::string> ParNames, std::vector<double> EvaluationPoint, std::vector<std::vector<double>> Bounds){
+// KS: Get Savage Dickey point hypothesis test
+void MCMCProcessor::GetSavageDickey(const std::vector<std::string>& ParNames,
+                                    const std::vector<double>& EvaluationPoint,
+                                    const std::vector<std::vector<double>>& Bounds){
 // **************************
 
   if((ParNames.size() != EvaluationPoint.size()) || (Bounds.size() != EvaluationPoint.size()))
@@ -3352,7 +3357,9 @@ void MCMCProcessor::GetSavageDickey(std::vector<std::string> ParNames, std::vect
 
 // **************************
 // KS: Reweight prior of MCMC chain to another
-void MCMCProcessor::ReweightPrior(std::vector<std::string> Names, std::vector<double> NewCentral, std::vector<double> NewError){
+void MCMCProcessor::ReweightPrior(const std::vector<std::string>& Names,
+                                  const std::vector<double>& NewCentral,
+                                  const std::vector<double>& NewError) {
 // **************************
 
   MACH3LOG_INFO("Reweighting Prior");

--- a/mcmc/MCMCProcessor.cpp
+++ b/mcmc/MCMCProcessor.cpp
@@ -1,5 +1,7 @@
 #include "MCMCProcessor.h"
 
+#include "TChain.h"
+
 //Only if GPU is enabled
 #ifdef CUDA
 extern void InitGPU_AutoCorr(
@@ -2756,7 +2758,7 @@ void MCMCProcessor::RemoveParameters() {
 
 // ***************
 // Make the step cut from a string
-void MCMCProcessor::SetStepCut(std::string Cuts) {
+void MCMCProcessor::SetStepCut(const std::string& Cuts) {
 // ***************
   StepCut = Cuts;
   BurnInCut = std::stoi( Cuts );

--- a/mcmc/MCMCProcessor.h
+++ b/mcmc/MCMCProcessor.h
@@ -77,9 +77,9 @@ class MCMCProcessor {
     void CacheSteps();
     /// @brief Calculate covariance by making 2D projection of each combination of parameters using multithreading
     /// @param Mute Allow silencing many messages, especially important if we calculate matrix many times
-    void MakeCovariance_MP(bool Mute = false);
+    void MakeCovariance_MP(const bool Mute = false);
     /// @brief Make and Draw SubOptimality
-    void MakeSubOptimality(int NIntervals = 10);
+    void MakeSubOptimality(const int NIntervals = 10);
 
     /// @brief Reset 2D posteriors, in case we would like to calculate in again with different BurnInCut
     void ResetHistograms();
@@ -92,8 +92,8 @@ class MCMCProcessor {
     /// @param CredibleIntervals Vector with values of credible intervals, must be in descending order
     /// @param CredibleIntervalsColours Color_t telling what colour to use for each Interval line
     /// @param CredibleInSigmas Bool telling whether intervals are in percentage or in sigmas, then special conversions is used
-    void MakeCredibleIntervals(std::vector<double> CredibleIntervals = {0.99, 0.90, 0.68 },
-                               std::vector<Color_t> CredibleIntervalsColours = {kCyan+4, kCyan-2, kCyan-10},
+    void MakeCredibleIntervals(const std::vector<double>& CredibleIntervals = {0.99, 0.90, 0.68 },
+                               const std::vector<Color_t>& CredibleIntervalsColours = {kCyan+4, kCyan-2, kCyan-10},
                                bool CredibleInSigmas = false
                                );
     /// @brief Draw the post-fit covariances
@@ -103,9 +103,9 @@ class MCMCProcessor {
     /// @param CredibleRegionStyle Style_t telling what line style to use for each Interval line
     /// @param CredibleRegionColor Color_t telling what colour to use for each Interval line
     /// @param CredibleInSigmas Bool telling whether intervals are in percentage or in sigmas, then special conversions is used
-    void MakeCredibleRegions(std::vector<double> CredibleRegions = {0.99, 0.90, 0.68},
-                             std::vector<Style_t> CredibleRegionStyle = {kDashed, kSolid, kDotted},
-                             std::vector<Color_t> CredibleRegionColor = {kGreen-3, kGreen-10, kGreen},
+    void MakeCredibleRegions(const std::vector<double>& CredibleRegions = {0.99, 0.90, 0.68},
+                             const std::vector<Style_t>& CredibleRegionStyle = {kDashed, kSolid, kDotted},
+                             const std::vector<Color_t>& CredibleRegionColor = {kGreen-3, kGreen-10, kGreen},
                              bool CredibleInSigmas = false
                              );
     /// @brief Make fancy triangle plot for selected parameters
@@ -116,39 +116,47 @@ class MCMCProcessor {
     /// @param CredibleRegionStyle Style_t telling what line style to use for each Interval line
     /// @param CredibleRegionColor Color_t telling what colour to use for each Interval line
     /// @param CredibleInSigmas Bool telling whether intervals are in percentage or in sigmas, then special conversions is used
-    void MakeTrianglePlot(std::vector<std::string> ParNames,
+    void MakeTrianglePlot(const std::vector<std::string>& ParNames,
                           // 1D
-                          std::vector<double> CredibleIntervals = {0.99, 0.90, 0.68 },
-                          std::vector<Color_t> CredibleIntervalsColours = {kCyan+4, kCyan-2, kCyan-10},
+                          const std::vector<double>& CredibleIntervals = {0.99, 0.90, 0.68 },
+                          const std::vector<Color_t>& CredibleIntervalsColours = {kCyan+4, kCyan-2, kCyan-10},
                           //2D
-                          std::vector<double> CredibleRegions = {0.99, 0.90, 0.68},
-                          std::vector<Style_t> CredibleRegionStyle = {kDashed, kSolid, kDotted},
-                          std::vector<Color_t> CredibleRegionColor = {kGreen-3, kGreen-10, kGreen},
+                          const std::vector<double>& CredibleRegions = {0.99, 0.90, 0.68},
+                          const std::vector<Style_t>& CredibleRegionStyle = {kDashed, kSolid, kDotted},
+                          const std::vector<Color_t>& CredibleRegionColor = {kGreen-3, kGreen-10, kGreen},
                           // Other
                           bool CredibleInSigmas = false
                           );
     /// @brief Make funny polar plot
     /// @param ParNames Vector with parameter names for which Polar Plot will be made
-    void GetPolarPlot(std::vector<std::string> ParNames);
+    void GetPolarPlot(const std::vector<std::string>& ParNames);
 
     /// @brief Calculate Bayes factor for vector of params, and model boundaries
     /// @param ParName Vector with parameter names for which we calculate Bayes factor
     /// @param Model1Bounds Lower and upper bound for hypothesis 1. Within this bound we calculate integral used later for Bayes Factor
     /// @param Model2Bounds Lower and upper bound for hypothesis 2. Within this bound we calculate integral used later for Bayes Factor
     /// @param ModelNames Names for hypothesis 1 and 2
-    void GetBayesFactor(std::vector<std::string> ParName, std::vector<std::vector<double>> Model1Bounds, std::vector<std::vector<double>> Model2Bounds, std::vector<std::vector<std::string>> ModelNames);
+    void GetBayesFactor(const std::vector<std::string>& ParName,
+                        const std::vector<std::vector<double>>& Model1Bounds,
+                        const std::vector<std::vector<double>>& Model2Bounds,
+                        const std::vector<std::vector<std::string>>& ModelNames);
     /// @brief Calculate Bayes factor for point like hypothesis using SavageDickey
-    void GetSavageDickey(std::vector<std::string> ParName, std::vector<double> EvaluationPoint, std::vector<std::vector<double>> Bounds);
+    void GetSavageDickey(const std::vector<std::string>& ParName,
+                         const std::vector<double>& EvaluationPoint,
+                         const std::vector<std::vector<double>>& Bounds);
     /// @brief Reweight Prior by giving new central value and new error
     /// @param ParName Parameter names for which we do reweighting
     /// @param NewCentral New central value for which we reweight
     /// @param NewError New error used for calculating weight
-    void ReweightPrior(std::vector<std::string> Names, std::vector<double> NewCentral, std::vector<double> NewError);
+    void ReweightPrior(const std::vector<std::string>& Names,
+                       const std::vector<double>& NewCentral,
+                       const std::vector<double>& NewError);
     
     /// @brief KS: Perform MCMC diagnostic including Autocorrelation, Trace etc.
     void DiagMCMC();
     
     // Get the number of parameters
+    /// @brief Get total number of used parameters
     inline int GetNParams() { return nDraw; };
     inline int GetNFlux() { return nFlux; };
     inline int GetNXSec() { return nParam[kXSecPar]; };
@@ -177,6 +185,8 @@ class MCMCProcessor {
     /// @brief Get the post-fit results (arithmetic and Gaussian)
     void GetPostfit(TVectorD *&Central, TVectorD *&Errors, TVectorD *&Central_Gauss, TVectorD *&Errors_Gauss, TVectorD *&Peaks);
     /// @brief Get the post-fit covariances and correlations
+    /// @param Cov Covariance matrix
+    /// @param Corr Correlation matrix
     void GetCovariance(TMatrixDSym *&Cov, TMatrixDSym *&Corr);
     /// @brief Or the individual post-fits
     void GetPostfit_Ind(TVectorD *&Central, TVectorD *&Errors, TVectorD *&Peaks, ParameterEnum kParam);
@@ -252,11 +262,14 @@ class MCMCProcessor {
 
     //Analyse posterior distribution
     /// @brief Get Arithmetic mean from posterior
+    /// @param hist histograms from which we extract arithmetic mean
     inline void GetArithmetic(TH1D * const hist, const int i);
     /// @brief Fit Gaussian to posterior
     /// @param hist histograms to which we fit gaussian
     inline void GetGaussian(TH1D *& hist, const int i);
     /// @brief Get Highest Posterior Density (HPD)
+    /// @param hist histograms from which we HPD
+    /// @param coverage What is defined coverage, by default 0.6827 (1 sigma)
     inline void GetHPD(TH1D * const hist, const int i, const double coverage = 0.6827);
     /// @brief Get 1D Credible Interval
     /// @param hist histograms based on which we calculate credible interval

--- a/mcmc/MCMCProcessor.h
+++ b/mcmc/MCMCProcessor.h
@@ -10,7 +10,6 @@
 // ROOT includes
 #include "TObjArray.h"
 #include "TObjString.h"
-#include "TChain.h"
 #include "TFile.h"
 #include "TBranch.h"
 #include "TCanvas.h"
@@ -20,7 +19,6 @@
 #include "TH1.h"
 #include "TH2.h"
 #include "TF1.h"
-#include "TH2Poly.h"
 #include "TGraphErrors.h"
 #include "TVectorD.h"
 #include "TColor.h"
@@ -28,7 +26,6 @@
 #include "TStopwatch.h"
 #include "TText.h"
 #include "TGaxis.h"
-#include "TObjString.h"
 #include "TTree.h"
 #include "TROOT.h"
 #include "TKey.h"
@@ -39,6 +36,9 @@
 
 // MaCh3 includes
 #include "mcmc/StatisticalUtils.h"
+
+//KS: Joy of forward declaration https://gieseanw.wordpress.com/2018/02/25/the-joys-of-forward-declarations-results-from-the-real-world/
+class TChain;
 
 // TODO
 // Apply reweighted weight to plotting and Bayes Factor
@@ -204,12 +204,13 @@ class MCMCProcessor {
     
     /// @brief Set the step cutting by string
     /// @param Cuts string telling cut value
-    void SetStepCut(std::string Cuts);
+    void SetStepCut(const std::string& Cuts);
     /// @brief Set the step cutting by int
     /// @param Cuts integer telling cut value
     void SetStepCut(const int Cuts);
 
-    //Setter related to plotting
+    /// @brief You can set relative to prior or relative to generated. It is advised to use relate to prior
+    /// @param PlotOrNot bool controlling plotRelativeToPrior argument
     inline void SetPlotRelativeToPrior(const bool PlotOrNot){plotRelativeToPrior = PlotOrNot; };
     inline void SetPrintToPDF(const bool PlotOrNot){printToPDF = PlotOrNot; };
     /// @brief Set whether you want to plot error for parameters which have flat prior
@@ -243,12 +244,17 @@ class MCMCProcessor {
     /// @brief Draw 1D correlations which might be more helpful than looking at huge 2D Corr matrix
     inline void DrawCorrelations1D();
 
-    /// @brief Read Matrices
+    /// @brief CW: Read the input Covariance matrix entries. Get stuff like parameter input errors, names, and so on
     inline void ReadInputCov();
+    /// @brief Read the output MCMC file and find what inputs were used
     inline void FindInputFiles();
+    /// @brief Read the xsec file and get the input central values and errors
     inline void ReadXSecFile();
+    /// @brief Read the ND cov file and get the input central values and errors
     inline void ReadNDFile();
+    /// @brief Read the FD cov file and get the input central values and errors
     inline void ReadFDFile();
+    /// @brief Read the Osc cov file and get the input central values and errors
     inline void ReadOSCFile();
     /// @brief Remove parameter specified in config
     inline void RemoveParameters();

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -145,6 +145,39 @@ inline std::string SplineInterpolation_ToString(const SplineInterpolation i) {
   return name;
 }
 
+/// Make an enum of systematic type recognised by covariance class
+enum SystType {
+  kNorm,
+  kSpline,
+  kFunc,
+  kSystTypes  //This only enumerates
+};
+
+// **************************************************
+/// Convert a Syst type type to a string
+inline std::string SystType_ToString(const SystType i) {
+// **************************************************
+  std::string name = "";
+  switch(i) {
+    case kNorm:
+      name = "Norm";
+      break;
+    case kSpline:
+      name = "Spline";
+      break;
+    case kFunc:
+      name = "Functional";
+      break;
+    default:
+      std::cerr << "UNKNOWN SYST TYPE SPECIFIED!" << std::endl;
+      std::cerr << "You gave  " << i << std::endl;
+      std::cerr << __FILE__ << ":" << __LINE__ << std::endl;
+      throw;
+  }
+  return name;
+}
+
+
 // ***************************
 // A handy namespace for variables extraction
 namespace MaCh3Utils {

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -68,7 +68,7 @@ std::vector<T> MakeVector( const T (&data)[N] ) {
 }
 
 // *******************
-/// KS: This is mad way of converting string to int. Why? To be able to use string with switch
+/// @brief KS: This is mad way of converting string to int. Why? To be able to use string with switch
 constexpr unsigned int str2int(const char* str, int h = 0) {
 // *******************
   return !str[h] ? 5381 : (str2int(str, h+1) * 33) ^ str[h];
@@ -77,11 +77,8 @@ constexpr unsigned int str2int(const char* str, int h = 0) {
 // *******************
 /// ETA - Normalisations for cross-section parameters
 /// Carrier for whether you want to apply a systematic to an event or not
-class XsecNorms4 {
-  // *******************
-  public:
-    /// Bins for normalisation parameter
-    TAxis *ebins;
+struct XsecNorms4 {
+// *******************
     /// Name of parameters
     std::string name;
     /// Mode which parameter applies to
@@ -96,16 +93,16 @@ class XsecNorms4 {
     std::vector<int> targets;
     /// Does this parameter have kinematic bounds
     bool hasKinBounds;
-	/// Generic vector contain enum relating to a kinematic variable
+    /// Generic vector contain enum relating to a kinematic variable
     /// and lower and upper bounds. This can then be passed to IsEventSelected
-	std::vector< std::vector<double> > Selection;
-	
+    std::vector< std::vector<double> > Selection;
+
 	/// Generic vector containing the string of kinematic type
 	/// This then needs to be converted to a kinematic type enum
 	/// within a samplePDF daughter class
 	/// The bounds for each kinematic variable are given in Selection
 	std::vector< std::string > KinematicVarStr;
-	
+
     /// Parameter number of this normalisation in current systematic model
     int index;
 };
@@ -121,7 +118,7 @@ enum SplineInterpolation {
 
 // **************************************************
 /// Convert a LLH type to a string
-inline std::string SplineInterpolation_ToString(SplineInterpolation i) {
+inline std::string SplineInterpolation_ToString(const SplineInterpolation i) {
 // **************************************************
   std::string name = "";
   switch(i) {
@@ -180,7 +177,7 @@ enum TargetMat {
 
 // *****************
 /// @brief Converted the Target Mat to a string
-inline std::string TargetMat_ToString(TargetMat i) {
+inline std::string TargetMat_ToString(const TargetMat i) {
 // *****************
   std::string name;
 


### PR DESCRIPTION
# Pull request description:
Introduce small changes t ocmake due to changes in ROOT

## Changes or fixes:
- Minuit is now default, make cmake work with old as well as new ROOT cmake
- move most of dependencies to separte cmake file. For example incuions of NuOsillator will requeir modifyng MaCh3 feature list etc. Having in seperate file means main cmake is less clunky
- Add cmkae utils to reduce copy pasting
- As always documeantions
- docuemantion as always
- XsecNorm is now struct not class
- Add new fucniton GetXsecNorm, becasue SetupNormPars and GetNormParsFromDetID were like 99% the same. There are weird issues rleated with copying so we have to inilaise XsecNorm  whenever we call GetNormParsFromDetID , should be fixed in the future. But for the the time being just reduce copy pasting.
- Remove some stupid code which could cahnge your prefit value...
- Lots of passing of vectors string by reference to ratherr than copying to make thigns safer and better perofmance wise
- Intorduce Syst type enums to avoid copy pasting

## Examples:
Oscillator will be fully indepednent from MaCh3 project. Expand logger so we can in fancy way convert messages from osciallor. This is to ensure cosnitnet messages but also in case there are more exteranl proejcts, in T2K we use psyche, NIWG RW etc. having prinouts [NIWG], [NuOsc] or [psyche] are helpfull. Sadly code to make this is bit convoluted. But I think it should be fine. Here example
<img width="927" alt="Logger" src="https://github.com/user-attachments/assets/c30293e1-88a4-4604-a083-8c28e57abcfc">

