### PR TITLE
Enum instead of string and C++14 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,8 @@ target_compile_options(MaCh3CompilerOptions INTERFACE
     -Wnon-virtual-dtor      # Warn when a class with virtual functions has a non-virtual destructor
     -Woverloaded-virtual    # Warn when a function declaration hides a virtual function from a base class
     -Wformat=2              # Warn on security issues around functions that format output (ie printf)
-    #-Wnull-dereference      # Warn if a null dereference is detected
+    #-Wpadded               # Warn when padding is added to a structure or class for alignment
+    #-Wnull-dereference     # Warn if a null dereference is detected
     #-Wold-style-cast       # Warn for c-style casts
     #-Wconversion           # Warn on type conversions that may lose data
     #-Werror                # Treat Warnings as Errors

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,8 @@ target_compile_options(MaCh3CompilerOptions INTERFACE
     -Wuninitialized         # Warn about uninitialized variables
     -Wnon-virtual-dtor      # Warn when a class with virtual functions has a non-virtual destructor
     -Woverloaded-virtual    # Warn when a function declaration hides a virtual function from a base class
-    -Wnull-dereference      # Warn if a null dereference is detected
     -Wformat=2              # Warn on security issues around functions that format output (ie printf)
+    #-Wnull-dereference      # Warn if a null dereference is detected
     #-Wold-style-cast       # Warn for c-style casts
     #-Wconversion           # Warn on type conversions that may lose data
     #-Werror                # Treat Warnings as Errors
@@ -106,18 +106,21 @@ endif()
 
 #KS: If Debug add debugging compile flag if not add optimisation for speed
 if(MaCh3_DEBUG_ENABLED)
+  target_compile_options(MaCh3CompilerOptions INTERFACE
+    -O0                                  # Turn off any optimisation to have best debug experience
+  )
   target_compile_definitions(MaCh3CompilerOptions INTERFACE DEBUG=${DEBUG_LEVEL})
   cmessage(STATUS "Enabling DEBUG with Level: \"${DEBUG_LEVEL}\"")
 else()
   #KS: Consider in future __attribute__((always_inline)) see https://indico.cern.ch/event/386232/sessions/159923/attachments/771039/1057534/always_inline_performance.pdf
   #https://gcc.gnu.org/onlinedocs/gcc-3.3.6/gcc/Optimize-Options.html
-target_compile_options(MaCh3CompilerOptions INTERFACE
+  target_compile_options(MaCh3CompilerOptions INTERFACE
     -O3                                  # Optimize code for maximum speed
     -funroll-loops                       # Unroll loops where possible for performance
     --param=max-vartrack-size=100000000  # Set maximum size of variable tracking data to avoid excessive memory usage
     -finline-limit=100000000             # Increase the limit for inlining functions to improve performance
     #-flto # FIXME need more testing     # Enable link-time optimization (commented out for now, needs more testing)
-)
+  )
   #KS: add Link-Time Optimization (LTO)
   # FIXME previously it wasn't used correctly but would need more testing
   #target_link_libraries(MaCh3CompilerOptions INTERFACE -flto)
@@ -217,9 +220,7 @@ install(EXPORT MaCh3-targets
 )
 
 #KS: Options to print dependency graph
-if(NOT DEFINED MaCh3_DependancyGraph)
-  set(MaCh3_DependancyGraph FALSE)
-endif()
+DefineEnabledRequiredSwitch(MaCh3_DependancyGraph FALSE)
 
 if(MaCh3_DependancyGraph)
   add_custom_target(graphviz ALL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,3 +296,15 @@ set_target_properties(version_header PROPERTIES INCLUDE_DIRECTORIES ${CMAKE_CURR
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/version.h
     DESTINATION ${CMAKE_INSTALL_PREFIX}/)
+
+
+# uninstall target
+if(NOT TARGET uninstall)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Templates/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,14 +80,19 @@ target_compile_options(MaCh3CompilerOptions INTERFACE
     -g                      # Generate debug information
     -Wextra                 # Enable extra warning flags
     -Wall                   # Enable all standard warning flags
-    -pedantic               # Enforce strict ISO compliance
+    -pedantic               # Enforce strict ISO compliance (all versions of GCC, Clang >= 3.2)
     -Wshadow                # Warn when a variable declaration shadows one from an outer scope
     -Wuninitialized         # Warn about uninitialized variables
     -Wnon-virtual-dtor      # Warn when a class with virtual functions has a non-virtual destructor
     -Woverloaded-virtual    # Warn when a function declaration hides a virtual function from a base class
     -Wformat=2              # Warn on security issues around functions that format output (ie printf)
+    -Wunused                # Warn on anything being unused
+    -Wlogical-op            # Warn about logical operations being used where bitwise were probably wanted (only in GCC)
+    -Wduplicated-cond       # Warn if if / else chain has duplicated conditions (only in GCC >= 6.0)
+    -Wduplicated-branches   # Warn if if / else branches have duplicated code (only in GCC >= 7.0)
+    #-Wuseless-cast         # Warn if you perform a cast to the same type (only in GCC >= 4.8)
     #-Wpadded               # Warn when padding is added to a structure or class for alignment
-    #-Wnull-dereference     # Warn if a null dereference is detected
+    #-Wnull-dereference     # Warn if a null dereference is detected (only in GCC >= 6.0)
     #-Wold-style-cast       # Warn for c-style casts
     #-Wconversion           # Warn on type conversions that may lose data
     #-Werror                # Treat Warnings as Errors

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,9 +87,6 @@ target_compile_options(MaCh3CompilerOptions INTERFACE
     -Woverloaded-virtual    # Warn when a function declaration hides a virtual function from a base class
     -Wformat=2              # Warn on security issues around functions that format output (ie printf)
     -Wunused                # Warn on anything being unused
-    -Wlogical-op            # Warn about logical operations being used where bitwise were probably wanted (only in GCC)
-    -Wduplicated-cond       # Warn if if / else chain has duplicated conditions (only in GCC >= 6.0)
-    -Wduplicated-branches   # Warn if if / else branches have duplicated code (only in GCC >= 7.0)
     #-Wuseless-cast         # Warn if you perform a cast to the same type (only in GCC >= 4.8)
     #-Wpadded               # Warn when padding is added to a structure or class for alignment
     #-Wnull-dereference     # Warn if a null dereference is detected (only in GCC >= 6.0)
@@ -97,6 +94,15 @@ target_compile_options(MaCh3CompilerOptions INTERFACE
     #-Wconversion           # Warn on type conversions that may lose data
     #-Werror                # Treat Warnings as Errors
 )
+# KS Some compiler options are only available in GCC, in case we move to other compilers we will have to expand this
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  target_compile_options(MaCh3CompilerOptions INTERFACE
+    -Wlogical-op            # Warn about logical operations being used where bitwise were probably wanted (only in GCC)
+    -Wduplicated-cond       # Warn if if / else chain has duplicated conditions (only in GCC >= 6.0)
+    -Wduplicated-branches   # Warn if if / else branches have duplicated code (only in GCC >= 7.0)
+  )
+endif()
+
 #KS: If Debug is not defined disable it by default
 DefineEnabledRequiredSwitch(MaCh3_DEBUG_ENABLED FALSE)
 

--- a/cmake/Templates/cmake_uninstall.cmake.in
+++ b/cmake/Templates/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()

--- a/covariance/covarianceXsec.cpp
+++ b/covariance/covarianceXsec.cpp
@@ -31,6 +31,10 @@ void covarianceXsec::InitXsecFromConfig() {
   _fParamType = std::vector<SystType>(_fNumPar);
   isFlux.resize(_fNumPar);
 
+  //KS: We know at most how params we expect so reserve memory for max possible params. Later we will shrink to size to not waste memory. Reserving means slightly faster loading and possible less memory fragmentation.
+  NormParams.reserve(_fNumPar);
+  SplineParams.reserve(_fNumPar);
+
   int i = 0;
   //ETA - read in the systematics. Would be good to add in some checks to make sure
   //that there are the correct number of entries i.e. are the _fNumPars for Names,
@@ -80,6 +84,10 @@ void covarianceXsec::InitXsecFromConfig() {
     else isFlux[i] = false;
     i++;
   }
+
+  NormParams.shrink_to_fit();
+  SplineParams.shrink_to_fit();
+
   return;
 }
 

--- a/covariance/covarianceXsec.h
+++ b/covariance/covarianceXsec.h
@@ -24,12 +24,6 @@ class covarianceXsec : public covarianceBase {
     /// @brief Destructor
     ~covarianceXsec();
 
-    /// @brief ETA - trying out the yaml parsing
-    inline void InitXsecFromConfig();
-    /// @brief Get Norm params
-    /// @param i Global parameter index
-    /// @param norm_counter norm parameter index
-    inline XsecNorms4 GetXsecNorm(const YAML::Node& param, const int Index);
     /// @brief Print information about the whole object once it is set
     inline void Print();
 
@@ -47,18 +41,16 @@ class covarianceXsec : public covarianceBase {
     /// @param i parameter index
     inline SystType GetParamType(const int i) const {return _fParamType[i];}
 
-    /// @brief Get interpolation type vector
-    inline const std::vector<SplineInterpolation>& GetSplineInterpolation() const{return _fSplineInterpolationType;}
     /// @brief Get interpolation type for a given parameter
     /// @param i spline parameter index, not confuse with global index
-    inline SplineInterpolation GetParSplineInterpolation(const int i) {return _fSplineInterpolationType.at(i);}
+    inline SplineInterpolation GetParSplineInterpolation(const int i) {return SplineParams.at(i).SplineInterpolationType;}
 
     /// @brief EM: value at which we cap spline knot weight
     /// @param i spline parameter index, not confuse with global index
-    inline double GetParSplineKnotUpperBound(const int i) {return _fSplineKnotUpBound[i];}
+    inline double GetParSplineKnotUpperBound(const int i) {return SplineParams.at(i).SplineKnotUpBound;}
     /// @brief EM: value at which we cap spline knot weight
     /// @param i spline parameter index, not confuse with global index
-    inline double GetParSplineKnotLowerBound(const int i) {return _fSplineKnotLowBound[i];}
+    inline double GetParSplineKnotLowerBound(const int i) {return SplineParams.at(i).SplineKnotLowBound;}
 
     /// @brief DB Grab the number of parameters for the relevant DetID
     /// @param Type Type of syst, for example kNorm, kSpline etc
@@ -123,6 +115,16 @@ class covarianceXsec : public covarianceBase {
   protected:
     /// @brief Initialise CovarianceXsec
     void initParams();
+    /// @brief ETA - trying out the yaml parsing
+    inline void InitXsecFromConfig();
+    /// @brief Get Norm params
+    /// @param param Yaml node describing param
+    /// @param Index Global parameter index
+    inline XsecNorms4 GetXsecNorm(const YAML::Node& param, const int Index);
+    /// @brief Get Spline params
+    /// @param param Yaml node describing param
+    inline XsecSplines1 GetXsecSpline(const YAML::Node& param);
+
     /// Is parameter flux or not, This might become deprecated in future
     /// @warning Will become deprecated
     std::vector<bool> isFlux;
@@ -136,13 +138,9 @@ class covarianceXsec : public covarianceBase {
     std::vector<std::string> _fNDSplineNames;
     std::vector<std::string> _fFDSplineNames;
     std::vector<std::vector<int>> _fFDSplineModes;
-    /// Spline interpolation vector
-    std::vector<SplineInterpolation> _fSplineInterpolationType;
 
-    /// EM: Cap spline knot lower value
-    std::vector<double> _fSplineKnotLowBound;
-    /// EM: Cap spline knot higher value
-    std::vector<double> _fSplineKnotUpBound;
+    /// Vector containing info for normalisation systematics
+    std::vector<XsecSplines1> SplineParams;
 
     /// Vector containing info for normalisation systematics
     std::vector<XsecNorms4> NormParams;

--- a/covariance/covarianceXsec.h
+++ b/covariance/covarianceXsec.h
@@ -26,12 +26,10 @@ class covarianceXsec : public covarianceBase {
 
     /// @brief ETA - trying out the yaml parsing
     inline void InitXsecFromConfig();
-    /// @brief Initialise Norm params
-    inline void SetupNormPars();
     /// @brief Get Norm params
     /// @param i Global parameter index
     /// @param norm_counter norm parameter index
-    inline XsecNorms4 GetXsecNorm(const int i, const int norm_counter);
+    inline XsecNorms4 GetXsecNorm(const YAML::Node& param, const int Index);
     /// @brief Print information about the whole object once it is set
     inline void Print();
 
@@ -134,12 +132,6 @@ class covarianceXsec : public covarianceBase {
     /// Type of parameter like norm, spline etc.
     std::vector<SystType> _fParamType;
 
-    //Some "usual" variables. Don't think we really need the ND/FD split
-    std::vector<std::vector<int>> _fNormModes;
-    std::vector<std::vector<int>> _fTargetNuclei;
-    std::vector<std::vector<int>> _fNeutrinoFlavour;
-    std::vector<std::vector<int>> _fNeutrinoFlavourUnosc;
-
     //Variables related to spline systematics
     std::vector<std::string> _fNDSplineNames;
     std::vector<std::string> _fFDSplineNames;
@@ -151,11 +143,6 @@ class covarianceXsec : public covarianceBase {
     std::vector<double> _fSplineKnotLowBound;
     /// EM: Cap spline knot higher value
     std::vector<double> _fSplineKnotUpBound;
-
-    /// Information to be able to apply generic cuts
-    std::vector<std::vector<std::string>> _fKinematicPars;
-    /// Information to be able to apply generic cuts
-    std::vector<std::vector<std::vector<double>>> _fKinematicBounds;
 
     /// Vector containing info for normalisation systematics
     std::vector<XsecNorms4> NormParams;

--- a/covariance/covarianceXsec.h
+++ b/covariance/covarianceXsec.h
@@ -44,7 +44,10 @@ class covarianceXsec : public covarianceBase {
     inline int GetParDetID(const int i) const { return _fDetID[i];};
     /// @brief ETA - just return a string of "spline", "norm" or "functional"
     /// @param i parameter index
-    inline const char* GetParamType(const int i) const {return _fParamType[i].c_str();}
+    inline const char* GetParamTypeString(const int i) const {return SystType_ToString(_fParamType[i]).c_str();}
+    /// @brief Returns enum describing our param type
+    /// @param i parameter index
+    inline SystType GetParamType(const int i) const {return _fParamType[i];}
 
     /// @brief Get interpolation type vector
     inline const std::vector<SplineInterpolation>& GetSplineInterpolation() const{return _fSplineInterpolationType;}
@@ -121,7 +124,7 @@ class covarianceXsec : public covarianceBase {
     
   protected:
     /// @brief Initialise CovarianceXsec
-    void initParams(const double fScale);
+    void initParams();
     /// Is parameter flux or not, This might become deprecated in future
     /// @warning Will become deprecated
     std::vector<bool> isFlux;
@@ -129,7 +132,7 @@ class covarianceXsec : public covarianceBase {
     /// Tells to which samples object param should be applied
     std::vector<int> _fDetID;
     /// Type of parameter like norm, spline etc.
-    std::vector<std::string> _fParamType;
+    std::vector<SystType> _fParamType;
 
     //Some "usual" variables. Don't think we really need the ND/FD split
     std::vector<std::vector<int>> _fNormModes;

--- a/mcmc/SampleSummary.h
+++ b/mcmc/SampleSummary.h
@@ -35,6 +35,7 @@ class SampleSummary {
     ~SampleSummary();
 
     /// @brief KS: Add data histograms
+    /// @param DataHist Histogram with data even rates for each sample
     void AddData(std::vector<TH2Poly*> &DataHist);
     /// @brief KS: Add prior histograms
     void AddNominal(std::vector<TH2Poly*> &NominalHist, std::vector<TH2Poly*> &W2Nom);
@@ -94,14 +95,18 @@ class SampleSummary {
     /// @brief Helper to project TH2Poly onto axis
     inline TH1D* ProjectPoly(TH2Poly* Histogram, const bool ProjectX, const _int_ selection, const bool MakeErrorHist = false);
 
-    // Make Poisson fluctuation of TH1D hist
+    /// @brief Make Poisson fluctuation of TH1D hist
     inline void MakeFluctuatedHistogram(TH1D *FluctHist, TH1D* PolyHist);
+    /// @brief Make Poisson fluctuation of TH1D hist using default fast method
     inline void MakeFluctuatedHistogramStandard(TH1D *FluctHist, TH1D* PolyHist);
+    /// @brief Make Poisson fluctuation of TH1D hist using slow method which is only for cross-check
     inline void MakeFluctuatedHistogramAlternative(TH1D *FluctHist, TH1D* PolyHist);
 
-    // Make Poisson fluctuation of TH2Poly hist
+    /// @brief Make Poisson fluctuation of TH2Poly hist
     inline void MakeFluctuatedHistogram(TH2Poly *FluctHist, TH2Poly* PolyHist);
+    /// @brief Make Poisson fluctuation of TH2Poly hist using default fast method
     inline void MakeFluctuatedHistogramStandard(TH2Poly *FluctHist, TH2Poly* PolyHist);
+    /// @brief Make Poisson fluctuation of TH2Poly hist using slow method which is only for cross-check
     inline void MakeFluctuatedHistogramAlternative(TH2Poly *FluctHist, TH2Poly* PolyHist);
         
     /// @brief KS: Fill Violin histogram with entry from a toy

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -13,7 +13,7 @@
 #define _unsigned_int_ unsigned int
 #endif
 
-/// KS: noexcept can help with performance but is terrible for debugging, this is meant to help easy way of of turning it on or off. In near future move this to struct or other central class. Keep it in ND for the time being
+/// KS: noexcept can help with performance but is terrible for debugging, this is meant to help easy way of of turning it on or off. In near future move this to struct or other central class.
 //#define SafeException
 #ifndef SafeException
 #define _noexcept_ noexcept
@@ -107,6 +107,7 @@ struct XsecNorms4 {
     int index;
 };
 
+
 /// Make an enum of the spline interpolation type
 enum SplineInterpolation {
   kTSpline3,
@@ -151,6 +152,20 @@ enum SystType {
   kSpline,
   kFunc,
   kSystTypes  //This only enumerates
+};
+
+
+// *******************
+/// @brief KS: Struct holding info about Spline Systematics
+struct XsecSplines1 {
+  // *******************
+  /// Spline interpolation vector
+  SplineInterpolation SplineInterpolationType;
+
+  /// EM: Cap spline knot lower value
+  double SplineKnotLowBound;
+  /// EM: Cap spline knot higher value
+  double SplineKnotUpBound;
 };
 
 // **************************************************


### PR DESCRIPTION
# Pull request description:
Instead of doing string comaprison whether param is spline or norm let's use enum, param types always have to be defined by MaCh3 core, I can't imagine expeirent sepcyfic types, in future types might be expadnaed, using enums helps to mainaint good code.

Also not use python like structure binding, as this causes problem in c++14. Given still many poep have root with c++14 and this was easy change I did this. MaCh3 natively should use c++14 but if we can easily mianaint c++14 then why not.

This was the issue
![image](https://github.com/user-attachments/assets/2cea559c-c8a7-486b-9a25-433e20b43309)

Setting XsecNorm4 was a mess. First we filled variables like modes, only later to save it to XsecNomr4. Now rather than have many artifialc variabels we store only XsecNorm4. This means that potetnail expansion to XsecNorms5 will be easier as everythig is handled `GetXsecNorm` rather than many bits in different places.
![image](https://github.com/user-attachments/assets/aab81b2f-1bdc-4866-9aed-4dd1b44e464d)
left old, right new
![image](https://github.com/user-attachments/assets/447e8b86-e12c-49b9-ba9e-37f2ecea5ae4)
