### PR TITLE
Uses OMP C++ interface rather than grabbing potentially non-existent …

### DIFF
--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -859,7 +859,7 @@ void samplePDFFDBase::SetupOscCalc(double PathLength, double Density)
 //if we just want to use CUDAProb3 CPU then setup BeamCpuPropagator object
 #if defined (MULTITHREAD)
 //if we want to multithread then get number of threads from OMP_NUM_THREADS env variable
-    MCSamples[iSample].Oscillator = new cudaprob3::BeamCpuPropagator<double>(MCSamples[iSample].nEvents, omp_get_max_threads()));
+    MCSamples[iSample].Oscillator = new cudaprob3::BeamCpuPropagator<double>(MCSamples[iSample].nEvents, omp_get_max_threads());
   MCSamples[iSample].Oscillator->setPathLength(PathLength);
   MCSamples[iSample].Oscillator->setDensity(Density);
 #else

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -859,7 +859,7 @@ void samplePDFFDBase::SetupOscCalc(double PathLength, double Density)
 //if we just want to use CUDAProb3 CPU then setup BeamCpuPropagator object
 #if defined (MULTITHREAD)
 //if we want to multithread then get number of threads from OMP_NUM_THREADS env variable
-    MCSamples[iSample].Oscillator = new cudaprob3::BeamCpuPropagator<double>(MCSamples[iSample].nEvents, std::atoi(std::getenv("OMP_NUM_THREADS")));
+    MCSamples[iSample].Oscillator = new cudaprob3::BeamCpuPropagator<double>(MCSamples[iSample].nEvents, omp_get_max_threads()));
   MCSamples[iSample].Oscillator->setPathLength(PathLength);
   MCSamples[iSample].Oscillator->setDensity(Density);
 #else


### PR DESCRIPTION
…environment variable

# Pull request description:
Small tweak, no longer grabs environment variable

## Changes or fixes:
Gets the maximum available number of threads from C++ API
`std::atoi(std::getenv("OMP_NUM_THREADS"))) ` -> `omp_get_max_threads( )`