### PR TITLE
Add small check to monitor so it doesn't have unhelpful crash when you haven't sourced MaCh3-core

### DIFF
--- a/manager/Monitor.cpp
+++ b/manager/Monitor.cpp
@@ -49,7 +49,7 @@ std::string GetMaCh3Version() {
   //KS: Find MaCh3 version based on header file. There could be better way to just include version.h but as long as we don't have to hardcode version I am content
   std::string MaCh3_VERSION = "";
 
-  if(std::getenv("MaCh3_ROOT") != nullptr){
+  if(std::getenv("MaCh3_ROOT") == nullptr){
     throw MaCh3Exception(__FILE__, __LINE__, "Error: you haven't sourced setup.MaCh3.sh in core!");
   }
 

--- a/manager/Monitor.cpp
+++ b/manager/Monitor.cpp
@@ -49,6 +49,10 @@ std::string GetMaCh3Version() {
   //KS: Find MaCh3 version based on header file. There could be better way to just include version.h but as long as we don't have to hardcode version I am content
   std::string MaCh3_VERSION = "";
 
+  if(std::getenv("MaCh3_ROOT") != nullptr){
+    throw MaCh3Exception(__FILE__, __LINE__, "Error: you haven't sourced setup.MaCh3.sh in core!");
+  }
+
   std::string file = std::string(std::getenv("MaCh3_ROOT")) + "/version.h";
   // Open the version.h file
   std::ifstream versionFile(file);

--- a/manager/Monitor.h
+++ b/manager/Monitor.h
@@ -17,6 +17,7 @@
 // MaCh3 includes
 #include "manager/MaCh3Logger.h"
 #include "samplePDF/Structs.h"
+#include "manager/MaCh3Exception.h"
 #include "manager/YamlHelper.h"
 
 namespace MaCh3Utils {


### PR DESCRIPTION

# Pull request description:
Small check to environment variable, has more verbose crash when MaCh3 core hasn't been sourced

## Changes or fixes:
Small change to check MaCh3 version in `manager/Monitor.cpp`
