### PR TITLE
Feature plotting parameter tagging

### DIFF
--- a/plotting/PlotLLH.cpp
+++ b/plotting/PlotLLH.cpp
@@ -23,7 +23,7 @@ void getSplitSampleStack(int fileIdx, std::string parameterName, TH1D LLH_allSam
                          float baselineLLH_main = 0.00001) 
   {
 
-  std::vector<std::string> sampNames = man->input().getKnownSamples();
+  std::vector<std::string> sampNames = man->input().getTaggedSamples(man->getOption<std::vector<std::string>>("sampleTags"));
   size_t nSamples = sampNames.size();
 
   cumSums.resize(nSamples);
@@ -259,10 +259,10 @@ void makeSplitSampleLLHScanComparisons(std::string paramName, std::string output
   label->SetTextSize(0.012);
 
   // need to draw the labels after other stuff or they dont show up
-  for (uint i = 0; i < man->input().getKnownSamples().size(); i++)
+  for (uint i = 0; i < man->input().getTaggedSamples(man->getOption<std::vector<std::string>>("sampleTags")).size(); i++)
   {
     MACH3LOG_DEBUG("  Will I draw the label for sample {}??", i);
-    std::string sampName = man->input().getKnownSamples()[i];
+    std::string sampName = man->input().getTaggedSamples(man->getOption<std::vector<std::string>>("sampleTags"))[i];
     if (!drawLabel[i])
     { 
       MACH3LOG_DEBUG("   - Not drawing label");
@@ -331,9 +331,9 @@ void makeSplitSampleLLHScanComparisons(std::string paramName, std::string output
     splitSamplesLegend->Draw();
 
     // need to draw the labels after other stuff or they dont show up
-    for (uint i = 0; i < man->input().getKnownSamples().size(); i++)
+    for (uint i = 0; i < man->input().getTaggedSamples(man->getOption<std::vector<std::string>>("sampleTags")).size(); i++)
     {
-      std::string sampName = man->input().getKnownSamples()[i];
+      std::string sampName = man->input().getTaggedSamples(man->getOption<std::vector<std::string>>("sampleTags"))[i];
       if (!drawLabel[i])
         continue;
       label->DrawLatex(compLLH_main.GetBinLowEdge(compLLH_main.GetNbinsX() + 1), extraCumSums[i],
@@ -348,7 +348,7 @@ void makeSplitSampleLLHScanComparisons(std::string paramName, std::string output
       TList *baselineHistList = baseSplitSamplesStack->GetHists();
       TList *compHistList = splitSamplesStack->GetHists();
 
-      for (uint sampleIdx = 0; sampleIdx < man->input().getKnownSamples().size(); sampleIdx++)
+      for (uint sampleIdx = 0; sampleIdx < man->input().getTaggedSamples(man->getOption<std::vector<std::string>>("sampleTags")).size(); sampleIdx++)
       {
         TH1D *divHist = new TH1D(
             Form("%s_%s_splitDiv_%i", paramName.c_str(), man->getFileLabel(extraFileIdx).c_str(),
@@ -410,8 +410,9 @@ int PlotLLH() {
   if (man->getSplitBySample())
     canv->SaveAs((man->getOutputName("_bySample") + "[").c_str());
 
+  for( std::string par: man->getOption<std::vector<std::string>>("parameterTags")) std::cout << par << ", ";
   // loop over the spline parameters
-  for (std::string paramName : man->input().getKnownParameters())
+  for (std::string paramName : man->input().getTaggedParameters(man->getOption<std::vector<std::string>>("parameterTags")))
   {
     MACH3LOG_DEBUG("working on parameter {}", paramName);
     // ###############################################################

--- a/plotting/PlottingConfig.yaml
+++ b/plotting/PlottingConfig.yaml
@@ -20,6 +20,8 @@ PlotLLH:
     lineWidth: 3
     totalOnSplitPlots: false
     sameAxis: true
+    parameterTags: []
+    sampleTags: []
 
 #########################################
 GetPostfitParamPlots:

--- a/plotting/plottingUtils/inputManager.cpp
+++ b/plotting/plottingUtils/inputManager.cpp
@@ -189,6 +189,8 @@ std::vector<std::string> InputManager::getTaggedValues(const std::vector<std::st
     checkType = "all";
   }
 
+  // If no tags were specified, take this to mean that anything should be a match
+  if (tags.size() == 0) return values;
 
   std::vector<std::string> retVec;
 

--- a/plotting/plottingUtils/inputManager.h
+++ b/plotting/plottingUtils/inputManager.h
@@ -354,6 +354,28 @@ public:
   inline const std::vector<std::string> &getKnownParameters() const { return _knownParameters; }
   inline const std::vector<std::string> &getKnownSamples() const { return _knownSamples; }
   inline int getNInputFiles() const { return _fileVec.size(); }
+
+  /// @brief Get all parameters which have some set of tags
+  /// @param tags The tags to check for 
+  /// @param checkType The type of check to perform:
+  /// checkType can be one of:
+  ///   - all: All parameters which have *all* of the specified tags will be returned 
+  ///   - any: All parameters which have *any* of the specified tags will be returned 
+  ///   - exact: All of the parameters which have *exactly* the specified tags will be returned
+  inline std::vector<std::string> getTaggedParameters(const std::vector<std::string> &tags, std::string checkType = "all") const {
+    return getTaggedValues(_knownParameters, _paramToTagsMap, tags, checkType);
+  }
+
+  /// @brief Get all samples which have some set of tags
+  /// @param tags The tags to check for 
+  /// @param checkType The type of check to perform:
+  /// checkType can be one of:
+  ///   - all: All samples which have *all* of the specified tags will be returned 
+  ///   - any: All samples which have *any* of the specified tags will be returned 
+  ///   - exact: All of the samples which have *exactly* the specified tags will be returned
+  inline std::vector<std::string> getTaggedSamples(const std::vector<std::string> &tags, std::string checkType = "all") const {
+    return getTaggedValues(_knownSamples, _sampleToTagsMap, tags, checkType);
+  }
   /// @}
 
   /// @name File Specific Getters
@@ -374,6 +396,15 @@ public:
   /// @}
 
 private:
+
+  // Helper function to get tagged values from a vector of values
+  // specify the initial list of *values*, the map of values to their tags, the tags to check,
+  // and the type of check to perform (see getTaggedParameter() for details)
+  std::vector<std::string> getTaggedValues(const std::vector<std::string> &values, 
+                                           const std::unordered_map<std::string, 
+                                           std::vector<std::string>> &tagMap, 
+                                           const std::vector<std::string> &tags, std::string checkType) const;
+
   // Helper function to parse a root file location string
   // any instance of {PARAMETER} gets replaced with fitter specific parameter name
   // similar for {SAMPLE}
@@ -493,6 +524,11 @@ private:
 
   // hold the names of the fitters known to this manager
   std::vector<std::string> _knownFitters;
+
+  // map parameter names to their specified tags
+  std::unordered_map<std::string, std::vector<std::string>> _paramToTagsMap;
+  // map sample names to their specified tags
+  std::unordered_map<std::string, std::vector<std::string>> _sampleToTagsMap;
   
   // the configs defining the translation of parameters between fitters and also the directory
   // structure for each fitter

--- a/plotting/plottingUtils/pythonPlottingModule.cpp
+++ b/plotting/plottingUtils/pythonPlottingModule.cpp
@@ -52,6 +52,8 @@ void initPlotting(py::module &m){
         .def("get_post_fit_value", &MaCh3Plotting::InputManager::getPostFitValue, "Get the post fit value for a parameter from a particular file")
         .def("get_known_parameters", &MaCh3Plotting::InputManager::getKnownParameters, "Get all the parameters that this manager knows about. Useful for iterating over")
         .def("get_known_samples", &MaCh3Plotting::InputManager::getKnownSamples, "Get all the samples that this manager knows about. Useful for iterating over")
+        .def("get_tagged_parameters", &MaCh3Plotting::InputManager::getTaggedParameters, "Get all the parameters whose tags match some specified list")
+        .def("get_tagged_samples", &MaCh3Plotting::InputManager::getTaggedSamples, "Get all the samples whose tags match some specified list")
         .def("get_n_input_files", &MaCh3Plotting::InputManager::getNInputFiles, "Get the number of input files registered with this manager")
         .def("get_known_llh_parameters", &MaCh3Plotting::InputManager::getKnownLLHParameters, "Get all the parameters that a file has LLH scans for")
         .def("get_known_llh_samples", &MaCh3Plotting::InputManager::getKnownLLHSamples, "Get all the samples that a file has individual LLH scans for")

--- a/plotting/universalTranslator.yaml
+++ b/plotting/universalTranslator.yaml
@@ -198,6 +198,12 @@ Samples:
             ## to also be able to specify this for different file types, hence why LLH is specified
             ## and not just something general
             LLH: "Sample-1"
+
+        ## We can specify "tags" to apply to a sample
+        ## This allows you to later on in your plotting scripts get, for example, all the samples which, for example,
+        ## are related to some particular sub-detector by adding a tag for that detector
+        ## Or to samples which correspond to a particular tagged particle
+        tags: ["subDet1", "particleTag"]
             
 
     SAMPLE_2: 
@@ -252,13 +258,10 @@ Parameters:
             LLH: "XSEC-PARAMETER-1" 
             PostFit: "PARAMETER-1"
 
-        ### *** TODO *** I'd like to add some other options for parameters
-        ###     One that i think might be useful would be tagging so we can specify that a parameter
-        ###     belongs to some group
-        ###     e.g:
-        ###       tags: ["xsec", "FSI", "Pion"]
-        ###     and then can give the user easy access in the code to all xsec parameters, or all
-        ###     parameters relating to pions, or all FSI... etc.
+        ## We can also specify "tags" to apply to a parameter
+        ## This allows you to later on in your plotting scripts get, for example, all parameters which have the tag "pion"
+        ## and plot them together, or all parameters with both the tags "pion" and "FSI"
+        tags: ["xsec", "FSI", "pion"]
 
     XSEC_PAR_2:
         FITTER_2:


### PR DESCRIPTION
# Pull request description:

Implemented a system for applying tags to parameters and samples for plotting. When making plots you can then loop through only parameters/samples with a given tag or set of tags. This makes it super easy to make plots for e.g. only parameters relating to pions, or only to CCQE, or only functional parameters....  

## Changes or fixes:

- All that's needed are a few new functions in inputManager for getting tagged values, and some maps for keeping track of the tags. 
- Tagging is now used in PlotLLH and the tags to apply can be configured in the PlottingConfig.yaml

## Examples:

As always, have ran using 2024 T2K Asimov:

added some vv basic tags to some of the samples
```
FGD1_numuCC_0pi_0_protons_no_photon: 
        tags: ["ND280", "FGD1", "pion", "proton", "photon"]
        MaCh3_ND:
            LLH: "FGD1_numuCC_0pi_0_protons_no_photon"

    FGD1_numuCC_0pi_N_protons_no_photon: 
        tags: ["ND280", "FGD1", "pion", "proton", "photon"]
        MaCh3_ND:
            LLH: "FGD1 numuCC 0pi N protons no photon"

    FGD1_numuCC_1pi_no_photon: 
        tags: ["ND280", "FGD1", "pion", "photon"]
        MaCh3_ND:
            LLH: "FGD1 numuCC 1pi no photon"

...

FGD2_numuCC_0pi_0_protons_no_photon: 
        tags: ["ND280", "FGD2", "pion", "proton", "photon"]
        MaCh3_ND:
            LLH: "FGD2 numuCC 0pi 0 protons no photon"

    FGD2_numuCC_0pi_N_protons_no_photon: 
        tags: ["ND280", "FGD2", "pion", "proton", "photon"]
        MaCh3_ND:
            LLH: "FGD2 numuCC 0pi N protons no photon"
...
```

and for some parameters:
```

    FEFQE:
        tags: ["xsec", "FSI", "pion", "QE", "lowE"]

    FEFQEH:
        tags: ["xsec", "FSI", "pion", "QE", "highE"]

    FEFINEL:
        tags: ["xsec", "FSI", "pion", "inel"]

    FEFABS:
        tags: ["xsec", "FSI", "pion", "abs"]

    FEFCX:
        tags: ["xsec", "FSI", "pion", "CEX"]

    FEFCXH:
        tags: ["xsec", "FSI", "pion", "CEX", "highE"]

    ...

    EB_dial_C_nu:
            tags: ["xsec", "Eb", "functional", "carbon", "nu"]
    
            
    EB_dial_C_nubar:
            tags: ["xsec", "Eb", "functional", "carbon", "nubar"]
            
    ...
```

And made LLH scans with PlotLLH with tag "pion" applied for parameters and "FGD1" for samples

### c++
[LLHScan_Total.pdf](https://github.com/user-attachments/files/16818983/LLHScan_Total.pdf)
[LLHScan_Sample.pdf](https://github.com/user-attachments/files/16818984/LLHScan_Sample.pdf)
[LLHScan_Penalty.pdf](https://github.com/user-attachments/files/16818985/LLHScan_Penalty.pdf)
[LLHScan_bySample.pdf](https://github.com/user-attachments/files/16818986/LLHScan_bySample.pdf)

### Python

ran a super basic python script
```
from pyMaCh3.plotting import PlottingManager
import sys

man = PlottingManager()

man.parse_inputs(sys.argv)

print("Parameters with the tag 'pion': ", man.input().get_tagged_parameters(["pion"], "all"))
print("Samples with the tag 'pion': ", man.input().get_tagged_samples(["FGD1"], "all"))
```

and seemed to get sensible output:
```
Parameters with the tag 'pion':  ['FEFQE', 'FEFQEH', 'FEFINEL', 'FEFABS', 'FEFCX', 'FEFCXH', 'SIPion_Abs', 'SIPion_CEX', 'SIPion_QE']
Samples with the tag 'pion':  ['FGD1_numuCC_0pi_0_protons_no_photon', 'FGD1_numuCC_0pi_N_protons_no_photon', 'FGD1_numuCC_1pi_no_photon', 'FGD1_numuCC_other_no_photon', 'FGD1_numuCC_photon', 'FGD1_numuCC_0pi_Fwd_NoPhoton_No_Protons', 'FGD1_numuCC_0pi_Fwd_NoPhoton_N_Protons', 'FGD1_numuCC_0pi_Bwd_NoPhoton_No_Protons', 'FGD1_numuCC_0pi_Bwd_NoPhoton_N_Protons', 'FGD1_numuCC_0pi_HA_NoPhoton_No_Protons', 'FGD1_numuCC_0pi_HA_NoPhoton_N_Protons', 'FGD1_numuCC_1Pi_HAFwd_NoPhoton', 'FGD1_numuCC_1Pi_Fwd_NoPhoton', 'FGD1_numuCC_Other_Fwd_NoPhoton', 'FGD1_numuCC_Photon_Fwd']
```