### PR TITLE
Yaml for Osc Cov

### DIFF
--- a/covariance/covarianceOsc.cpp
+++ b/covariance/covarianceOsc.cpp
@@ -22,6 +22,7 @@ covarianceOsc::covarianceOsc(const std::vector<std::string>& YAMLFile, const cha
   }
 
   /// WARNING HARDCODED
+  MACH3LOG_CRITICAL("Fixing baseline and density, it is hardcoded sry");
   toggleFixParameter("baseline");
   toggleFixParameter("density");
 
@@ -96,7 +97,7 @@ void covarianceOsc::Print() {
                 "#", "Name", "Nom.", "IndivStepScale", "_fError", "FlatPrior");
 
   for(int i = 0; i < _fNumPar; i++) {
-    MACH3LOG_INFO("{:<5} | {:<25} | {:<10.5f} | {:<15.5f} | {:<15.5f} | {:<10.5f}",
+    MACH3LOG_INFO("{:<5} | {:<25} | {:<10.4f} | {:<15.2f} | {:<15.4f} | {:<10}",
                   i, _fNames[i].c_str(), _fPreFitValue[i], _fIndivStepScale[i], _fError[i], _fFlatPrior[i]);
   }
 }
@@ -111,20 +112,20 @@ void covarianceOsc::CheckOrderOfParams() {
   if(_fNames[0] != "sin2th_12"){wrongParam.push_back(0); wrongMatrix = true;};
   if(_fNames[1] != "sin2th_23"){wrongParam.push_back(1); wrongMatrix = true;};
   if(_fNames[2] != "sin2th_13"){wrongParam.push_back(2); wrongMatrix = true;};
-  if(_fNames[3] != "delm2_12"){wrongParam.push_back(3); wrongMatrix = true;};
-  if(_fNames[4] != "delm2_23"){wrongParam.push_back(4); wrongMatrix = true;};
-  if(_fNames[5] != "delta_cp"){wrongParam.push_back(5); wrongMatrix = true;};
-  if(_fNames[6] != "baseline"){wrongParam.push_back(6); wrongMatrix = true;};
-  if(_fNames[7] != "density "){wrongParam.push_back(7); wrongMatrix = true;};
+  if(_fNames[3] != "delm2_12") {wrongParam.push_back(3); wrongMatrix = true;};
+  if(_fNames[4] != "delm2_23") {wrongParam.push_back(4); wrongMatrix = true;};
+  if(_fNames[5] != "delta_cp") {wrongParam.push_back(5); wrongMatrix = true;};
+  if(_fNames[6] != "baseline") {wrongParam.push_back(6); wrongMatrix = true;};
+  if(_fNames[7] != "density") {wrongParam.push_back(7); wrongMatrix = true;};
 
   if(wrongMatrix)
   {
     for(unsigned int i = 0; i < wrongParam.size(); i++ )
     {
-      MACH3LOG_ERROR("Osc Parameter  {} isn't in good order", _fNames[i].c_str());
+      MACH3LOG_ERROR("Osc Parameter  {} isn't in good order", _fNames[wrongParam[i]].c_str());
     }
     MACH3LOG_ERROR("Currently prob3++/probgp requires particular order");
-    MACH3LOG_ERROR("Please modify XML and make new matrix with good order");
+    MACH3LOG_ERROR("Please modify your cov osc config");
     throw MaCh3Exception(__FILE__ , __LINE__ );
   }
 }

--- a/covariance/covarianceOsc.cpp
+++ b/covariance/covarianceOsc.cpp
@@ -1,86 +1,44 @@
 #include "covarianceOsc.h"
 
 // *************************************
-covarianceOsc::covarianceOsc(const char* name, const char *file)
-: covarianceBase(name, file) {
+covarianceOsc::covarianceOsc(const std::vector<std::string>& YAMLFile, const char *name, double threshold, int FirstPCA, int LastPCA)
+: covarianceBase(YAMLFile, name, threshold, FirstPCA, LastPCA){
 // *************************************
-
-  //Read in osc pars from xml file
-  TFile *infile = new TFile(file, "READ");
-  TVectorD* osc_prior = (TVectorD*)infile->Get("osc_nom");
-  TVectorD* osc_stepscale = (TVectorD*)infile->Get("osc_stepscale");
-  TVectorD* osc_sigma = (TVectorD*)infile->Get("osc_sigma");
-  TVectorD* osc_flat_prior = (TVectorD*)infile->Get("osc_flat_prior");
-
-  TObjArray* objarr_name = (TObjArray*)(infile->Get("osc_param_names"));
-
-  TVectorD* osc_baseline = (TVectorD*)infile->Get("osc_baseline");
-  TVectorD* osc_density = (TVectorD*)infile->Get("osc_density");
-
-  //KS: Save all necessary information from covariance
-  for(int io = 0; io < _fNumPar; io++)
-  {
-    _fNames[io] = std::string(((TObjString*)objarr_name->At(io))->GetString());
-    _fFancyNames[io] = _fNames[io];
-
-    _fPreFitValue[io]  = (*osc_prior)(io);
-    _fCurrVal[io] = _fPropVal[io] = _fPreFitValue[io];
-    _fError[io] = (*osc_sigma)(io);
- 
-    _fIndivStepScale[io] = (*osc_stepscale)(io);
-    
-    //KS: Set flat prior
-    //HW: Might as well set it for everything in case default behaviour changes
-    setFlatPrior(io, (*osc_flat_prior)(io));
-  }
 
   kDeltaCP = -999;
   kDeltaM23 = -999;
   kSinTheta23 = -999;
-  kBeta = -999;
-  PerformBetaStudy = false;
+  kSinTheta23 = -999;
+  kSinTheta23 = -999;
   for(int io = 0; io < _fNumPar; io++)
   {
+    _fNames[io] = _fFancyNames[io];
+
     if(_fNames[io] == "delta_cp")  kDeltaCP = io;
     if(_fNames[io] == "delm2_23")  kDeltaM23 = io;
     if(_fNames[io] == "sin2th_23") kSinTheta23 = io;
-    if(_fNames[io] == "beta")
-    {
-      PerformBetaStudy = true;
-      kBeta = io;
-    }
+    if(_fNames[io] == "baseline") kBaseline = io;
+    if(_fNames[io] == "density") kDensity = io;
   }
 
-  L = (*osc_baseline)(0);
-  density = (*osc_density)(0);
+  /// WARNING HARDCODED
+  toggleFixParameter("baseline");
+  toggleFixParameter("density");
 
   flipdelM = false;
-  reactorPrior = false;
-  flipBeta = false;
 
   randomize();
 
-  oscpars1 = new double[10];
-  
-  //KS:those are constant no need to overwrite them each time
-  oscpars1[6] = 2;
-  oscpars1[7] = L;
-  oscpars1[8] = density;
-  
   Print();
   CheckOrderOfParams();
-    
-  infile->Close();
-  delete infile;
-  
-  MACH3LOG_INFO("created oscillation parameter handler");
+
+  MACH3LOG_INFO("Created oscillation parameter handler");
 }
 
 // *************************************
 covarianceOsc::~covarianceOsc() {
 // *************************************
 
-  delete[] oscpars1;
 }
 
 // *************************************
@@ -96,71 +54,9 @@ int covarianceOsc::CheckBounds() {
       //|| fabs(_fPropVal[kDeltaM23]) > 0.004 || fabs(_fPropVal[kDeltaM23]) < 0.001
       //|| _fPropVal[kDeltaCP] < -1*TMath::Pi() || _fPropVal[kDeltaCP] > TMath::Pi()
      ){ NOutside++;}
-
-  if(PerformBetaStudy) {
-    if(_fPropVal[kBeta] < 0) { // Don't let beta be less than 0 (no upper limit)
-      NOutside++;
-    }
-  }
-
   return NOutside;
 }
-// *************************************
-double covarianceOsc::GetLikelihood() {
-// *************************************
 
-  double logL = 0.0;
-  logL += covarianceBase::GetLikelihood();
-
-  // reactor prior
-  // ETA - we can remove this
-  if (reactorPrior)
-  {
-    // Reactor prior from 2013 PDG: sin^2(2theta13) = 0.095 +/- 0.01
-    // Reactor prior from 2014 PDG: sin^2(2theta13) = 0.093 +/- 0.008
-    // Reactor prior from 2015 PDG: sin^2(2theta13) = 0.085 +/- 0.005
-    // Reactor prior from 2016ca PDG: sin^2(2theta13) = 0.0857 +/- 0.0046
-    // Next convert between single angle (what we have) and double angle (what the PDG gives)
-    // double dblang = 4*_fPropVal[2]*(1-_fPropVal[2]);
-    // double tmp = (dblang-0.0857) / 0.0046;
-    
-    // Reactor prior from 2018 PDG: sin^2(theta13) = 0.0212 +/- 0.0008
-    // Reactor prior from 2019 PDG: sin^2(theta13) = 0.0218 +/- 0.0007
-    // Reactor prior from 2021 PDG: sin^2(theta13) = 0.0220 +/- 0.0007
-    // This time we don't have to convert between single<->double angle, PDG gives RC in single angle.
-
-    // Now calculate penalty           
-    double tmp = (_fPropVal[2]-0.0220) / 0.0007;
-    //double tmp = (dblang-0.095) / 0.01;
-
-    // this line for T2K joint fit result, NOT REACTOR CONSTRAINT!
-    //double tmp = (_fPropVal[2] - 0.04571) / 0.01125; 
-
-    // Finally: add to likelihood
-    logL += 0.5 * tmp * tmp;
-    //std::cout << "oscllh post-RC: " << logL << std::endl;
-  }
-  return logL;
-}
-
-// *************************************
-double *covarianceOsc::getPropPars() {
-// *************************************
-
-  for(int i = 0; i < 6; i++)
-    oscpars1[i] = _fPropVal[i];
-
-  //Those are constant we initialised them already
-  //oscpars1[6] = 2;
-  //oscpars1[7] = L;
-  //oscpars1[8] = density;
-  if(PerformBetaStudy)
-    oscpars1[9] = _fPropVal[kBeta];
-  else
-    oscpars1[9] = 1;
-
-  return oscpars1;
-}
 // *************************************
 void covarianceOsc::proposeStep() {
 // *************************************
@@ -174,7 +70,6 @@ void covarianceOsc::proposeStep() {
   } else if (_fPropVal[kDeltaCP] < -TMath::Pi()) {
     _fPropVal[kDeltaCP] = TMath::Pi() + std::fmod(_fPropVal[kDeltaCP], TMath::Pi());
   }
-
   
   // Okay now we've done the standard steps, we can add in our nice flips
   // hierarchy flip first
@@ -182,63 +77,33 @@ void covarianceOsc::proposeStep() {
     _fPropVal[kDeltaM23] *= -1;
   }
   // now octant flip
-  if(random_number[0]->Uniform() < 0.5){
+  if(random_number[0]->Uniform() < 0.5) {
     // flip octant around point of maximal disappearance (0.5112)
     // this ensures we move to a parameter value which has the same oscillation probability
     _fPropVal[kSinTheta23] = 0.5112 - (_fPropVal[kSinTheta23] - 0.5112);
   }
-  // And the beta flip (not sure if beta will still work...)
-  if(flipBeta)
-  {
-    if(random_number[0]->Uniform() < 0.5) _fPropVal[kBeta] = 1-_fCurrVal[kBeta];
-  }
 }
 
 // *************************************
-void covarianceOsc::setExtraBranches(TTree &tree) {
-// *************************************
-
-  // set branches to save current and proposed osc pars for dm_32 and th_23
-  // Is this any different for any of the other parameters?
-  // Or can this SetExtraBranches just be in the base class?
-  for (int i = 0; i < _fNumPar; ++i)
-  {
-    if (!(i==1 || i==4)) continue;
-
-    char bit_c[1024] = "c_";
-    strcat(bit_c, _fNames[i].c_str());
-    strcat(bit_c, "/D");
-    char name_c[1024] = "c_";
-    strcat(name_c, _fNames[i].c_str());
-    tree.Branch(name_c, (double*)&_fCurrVal[i], bit_c);
-
-    char bit_p[1024] = "p_";
-    strcat(bit_p, _fNames[i].c_str());
-    strcat(bit_p, "/D");
-    char name_p[1024] = "p_";
-    strcat(name_p, _fNames[i].c_str());
-    tree.Branch(name_p, (double*)&_fPropVal[i], bit_p);
-  }
-}
-// *************************************
-//KS: Print all usefull informations after initialization
+//KS: Print all useful information's after initialization
 void covarianceOsc::Print() {
 // *************************************
 
   MACH3LOG_INFO("Number of pars: {}", _fNumPar);
   MACH3LOG_INFO("Current: {} parameters:", matrixName);
-  std::cout << std::left << std::setw(5) << "#" << std::setw(2) << "|" << std::setw(25) << "Name" << std::setw(2) << "|" << std::setw(10) << "Nom." << std::setw(2) << "|" << std::setw(15) << "IndivStepScale" << std::setw(2) << "|" <<std::setw(15) << "_fError"  << std::endl;
+
+  MACH3LOG_INFO("{:<5} | {:<25} | {:<10} | {:<15} | {:<15} | {:<10}",
+                "#", "Name", "Nom.", "IndivStepScale", "_fError", "FlatPrior");
+
   for(int i = 0; i < _fNumPar; i++) {
-    std::cout << std::fixed << std::setprecision(5) << std::left << std::setw(5) << i << std::setw(2) << "|" << std::setw(25) << _fNames[i].c_str() << std::setw(2) << "|" << std::setw(10) << _fPreFitValue[i]<< std::setw(2) << "|" << std::setw(15) << _fIndivStepScale[i] << std::setw(2) << "|" << std::setw(15)<< _fError[i]<< std::endl;
+    MACH3LOG_INFO("{:<5} | {:<25} | {:<10.5f} | {:<15.5f} | {:<15.5f} | {:<10.5f}",
+                  i, _fNames[i].c_str(), _fPreFitValue[i], _fIndivStepScale[i], _fError[i], _fFlatPrior[i]);
   }
-  
-  MACH3LOG_INFO("Baseline: {}", L);
-  MACH3LOG_INFO("Earth Density: {}", density);
 }
 
 // *************************************
 //KS: Currently prob3++/probgpu requires particular order so we need to check this is the case
-void covarianceOsc::CheckOrderOfParams()  {
+void covarianceOsc::CheckOrderOfParams() {
 // *************************************
 
   std::vector<int> wrongParam;
@@ -249,7 +114,8 @@ void covarianceOsc::CheckOrderOfParams()  {
   if(_fNames[3] != "delm2_12"){wrongParam.push_back(3); wrongMatrix = true;};
   if(_fNames[4] != "delm2_23"){wrongParam.push_back(4); wrongMatrix = true;};
   if(_fNames[5] != "delta_cp"){wrongParam.push_back(5); wrongMatrix = true;};
-  if(PerformBetaStudy && _fNames[6] != "beta"){wrongParam.push_back(6); wrongMatrix = true;};
+  if(_fNames[6] != "baseline"){wrongParam.push_back(6); wrongMatrix = true;};
+  if(_fNames[7] != "density "){wrongParam.push_back(7); wrongMatrix = true;};
 
   if(wrongMatrix)
   {

--- a/covariance/covarianceOsc.h
+++ b/covariance/covarianceOsc.h
@@ -8,12 +8,9 @@ class covarianceOsc : public covarianceBase
 {
  public:
   /// @brief Constructor
-  covarianceOsc(const char* name, const char *file);
+  covarianceOsc(const std::vector<std::string>& FileNames, const char *name = "osc_cov", double threshold = -1, int FirstPCAdpar = -999, int LastPCAdpar = -999);
   /// @brief Destructor
   virtual ~covarianceOsc();
-  /// @brief Same implementation as in base class but accounts for applying reactor prior
-  /// @warning May become deprecated and use only base class instead
-  double GetLikelihood() override;
   /// @brief Checks if parameter didn't go outside of physical bounds
   inline int CheckBounds() override;
   /// @brief Retrieves the proposed parameters.
@@ -22,41 +19,21 @@ class covarianceOsc : public covarianceBase
   void proposeStep() override;
   /// @brief Sets whether to flip delta M23.
   void setFlipDeltaM23(bool flip){flipdelM = flip;}
-  /// @brief Sets whether to flip beta.
-  void setFlipBeta(bool flip){flipBeta = flip;}
-  /// @brief Sets whether to use reactor prior.
-  /// @warning May become deprecated
-  void useReactorPrior(bool reactor){reactorPrior = reactor;};
-  /// @brief Sets extra branches for processing.
-  /// @param tree ROOT tree to which we set additional variables
-  void setExtraBranches(TTree &tree);
 
   /// @brief Get baseline
-  inline double GetPathLength() { return L;}
+  inline double GetPathLength() { return _fPropVal[kBaseline];}
   /// @brief Get density
-  inline double GetDensity() { return density;}
-  /// @brief Check if we are performing beta study or not
-  inline bool GetPerformBetaStudy(){return PerformBetaStudy;}
+  inline double GetDensity() { return _fPropVal[kDensity];}
+
   /// @brief KS: Print all useful information's after initialization
   void Print();
   /// @brief KS: Currently prob3++/probgpu requires particular order so we need to check this is the case
   void CheckOrderOfParams();
 
  protected:
-    /// Value of baseline
-    double L;
-    /// Value of density
-    double density;
+
     /// Do we flip DeltaM23 or not
     bool flipdelM;
-    /// Bool whether we apply additional reactor prior or not
-    bool reactorPrior;
-    /// Do we flip Beta or not
-    bool flipBeta;
-    /// Value of all osc parameters
-    double *oscpars1;
-    /// Bool whether we are performing beta study or not
-    bool PerformBetaStudy;
 
     /// There is special treatment for delta CP, therefore store enum keeping track when to apply special treatment
     int kDeltaCP;
@@ -64,6 +41,8 @@ class covarianceOsc : public covarianceBase
     int kDeltaM23;
     /// Enum for special treatment of sin(theta23).
     int kSinTheta23;
-    /// Enum for special treatment of beta.
-    int kBeta;
+    /// Enum for special treatment of of baseline
+    int kBaseline;
+    /// Enum for special treatment of of density
+    int kDensity;
 };

--- a/mcmc/MCMCProcessor.cpp
+++ b/mcmc/MCMCProcessor.cpp
@@ -2666,6 +2666,7 @@ void MCMCProcessor::ReadFDFile() {
 void MCMCProcessor::ReadOSCFile() {
 // ***************
 
+  /// TODO WARNING remeber to fix this baka!
   // Do the same for the ND280
   TFile *OscFile = new TFile(CovPos[kOSCPar].back().c_str(), "open");
   if (OscFile->IsZombie()) {

--- a/mcmc/MCMCProcessor.h
+++ b/mcmc/MCMCProcessor.h
@@ -184,10 +184,10 @@ class MCMCProcessor {
     inline TH2D* GetViolinPrior() { return hviolin_prior; };
 
     //Covariance getters
-    inline std::vector<std::string> const & GetXSecCov()  const { return CovPos[kXSecPar]; };
-    inline std::string const & GetNDCov() const { return CovPos[kNDPar].back(); };
-    inline std::string const & GetFDCov()    const { return CovPos[kFDDetPar].back(); };
-    inline std::string const & GetOscCov()   const { return CovPos[kOSCPar].back(); };
+    inline std::vector<std::string> GetXSecCov()  const { return CovPos[kXSecPar]; };
+    inline std::string GetNDCov() const { return CovPos[kNDPar].back(); };
+    inline std::string GetFDCov() const { return CovPos[kFDDetPar].back(); };
+    inline std::vector<std::string> GetOscCov()   const { return CovPos[kOSCPar]; };
 
     /// @brief Get the post-fit results (arithmetic and Gaussian)
     void GetPostfit(TVectorD *&Central, TVectorD *&Errors, TVectorD *&Central_Gauss, TVectorD *&Errors_Gauss, TVectorD *&Peaks);

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -12,9 +12,10 @@ samplePDFFDBase::samplePDFFDBase(double pot, std::string mc_version, covarianceX
   //ETA - safety feature so you can't pass a NULL xsec_cov
   if(xsec_cov == NULL){std::cerr << "[ERROR:] You've passed me a NULL xsec covariance matrix... I need this to setup splines!" << std::endl; throw;}
 
-  samplePDFFD_array = NULL;
-  samplePDFFD_data = NULL;
-  
+  samplePDFFD_array = nullptr;
+  samplePDFFD_data = nullptr;
+  oscpars = nullptr;
+
   //KS: For now FD support only one sample
   nSamples = 1;
   SampleName.push_back("FDsample");
@@ -33,16 +34,18 @@ samplePDFFDBase::~samplePDFFDBase()
   std::cout << "I'm deleting samplePDFFDBase" << std::endl;
 
   for (unsigned int yBin=0;yBin<(YBinEdges.size()-1);yBin++) {
-	if(samplePDFFD_array != NULL){delete[] samplePDFFD_array[yBin];}
-	delete[] samplePDFFD_array_w2[yBin];
-	//ETA - there is a chance that you haven't added any data...
-	if(samplePDFFD_data != NULL){delete[] samplePDFFD_data[yBin];}
+    if(samplePDFFD_array != nullptr){delete[] samplePDFFD_array[yBin];}
+    delete[] samplePDFFD_array_w2[yBin];
+    //ETA - there is a chance that you haven't added any data...
+    if(samplePDFFD_data != nullptr){delete[] samplePDFFD_data[yBin];}
   }
 
-  if(samplePDFFD_array != NULL){delete[] samplePDFFD_array;}
+  if(samplePDFFD_array != nullptr){delete[] samplePDFFD_array;}
   delete[] samplePDFFD_array_w2;
   //ETA - there is a chance that you haven't added any data...
-  if(samplePDFFD_data != NULL){delete[] samplePDFFD_data;}
+  if(samplePDFFD_data != nullptr){delete[] samplePDFFD_data;}
+
+  if(oscpars != nullptr) delete[] oscpars;
 }
 
 void samplePDFFDBase::fill1DHist()
@@ -221,7 +224,7 @@ bool samplePDFFDBase::IsEventSelected(std::vector< std::string > ParameterStr, s
 double samplePDFFDBase::calcOscWeights(int sample, int nutype, int oscnutype, double en)
 {
   MCSamples[sample].Oscillator->SetMNS(*oscpars[0], *oscpars[2], *oscpars[1], *oscpars[3], *oscpars[4], *oscpars[5], en, doubled_angle, nutype);
-  MCSamples[sample].Oscillator->propagateLinear(nutype , *oscpars[7], *oscpars[8]); 
+  MCSamples[sample].Oscillator->propagateLinear(nutype , *oscpars[6], *oscpars[7]);
 
   return MCSamples[sample].Oscillator->GetProb(nutype, oscnutype);
 }
@@ -235,13 +238,12 @@ extern "C" void GetProb(int Alpha, int Beta, double Path, double Density, double
 void samplePDFFDBase::calcOscWeights(int nutype, int oscnutype, double *en, double *w, int num)
 {
   setMNS(*oscpars[0], *oscpars[2], *oscpars[1], *oscpars[3], *oscpars[4], *oscpars[5], doubled_angle);
-  GetProb(nutype, oscnutype, &oscpar[7], &oscpar[8], en, num, w);
-
+  GetProb(nutype, oscnutype, *oscpar[6], *oscpar[7], en, num, w);
 
   if (std::isnan(w[10]))
-    {
-      std::cerr << "WARNING: ProbGPU oscillation weight returned NaN! " << w[10] << std::endl;
-    }
+  {
+    std::cerr << "WARNING: ProbGPU oscillation weight returned NaN! " << w[10] << std::endl;
+  }
 }
 #endif
 
@@ -743,10 +745,10 @@ void samplePDFFDBase::SetXsecCov(covarianceXsec *xsec){
 
 void samplePDFFDBase::SetOscCov(covarianceOsc* osc_cov){
   OscCov = osc_cov;
-  int nOscPars = OscCov->getProposed().size(); 
+  int nOscPars = OscCov->GetNumParams();
   oscpars = new const double*[nOscPars];
   for(auto osc_par_i = 0; osc_par_i < nOscPars ; ++osc_par_i){
-	oscpars[osc_par_i] = OscCov->retPointer(osc_par_i);
+    oscpars[osc_par_i] = OscCov->retPointer(osc_par_i);
   } 
   return;
 }


### PR DESCRIPTION
# Pull request description:
Use yaml like approach for Ocs cov
If you want to test it yourself use https://github.com/mach3-software/MaCh3Validations/pull/3

## Changes or fixes:
- Cov osc uses yaml not root from xml converted
- Remove lot's of depracated stuff in cov osc
- Cov Osc uses not Base constructor, tl:dr all yaml reading is done VIA Base constructor, making mainaince easier
- Add baseline and denstiy as fit params. They are fixed with flat prior thus have no impact on anything
- Memory leak fixes
- Remove beta...

## Examples:
![image](https://github.com/user-attachments/assets/7dc5a9d5-28bb-4c87-9a00-5b756c48a0a4)
