### PR TITLE
Less hardcoded GPU splines

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -17,6 +17,7 @@ Henry Wallace <henryisrael08@gmail.com> henry-israel <henryisrael08@gmail.com>
 Henry Wallace <henryisrael08@gmail.com> Henry Wallace <67589487+henry-wallace-phys@users.noreply.github.com>
 Henry Wallace <henryisrael08@gmail.com> Henry Wallace <hwallace@linappserv6.pp.rhul.ac.uk>
 Henry Wallace <henryisrael08@gmail.com> Henry Wallace <henry.wallace@rhul.ac.uk>
+Henry Wallace <henryisrael08@gmail.com> Henry Wallace <henryi@beluga3.int.ets1.calculquebec.ca>
 
 # Ewan Miller
 Ewan Miller <ewan.miller@kcl.ac.uk> Ewan <ewan.miller@kcl.ac.uk>

--- a/cmake/Modules/CUDASetup.cmake
+++ b/cmake/Modules/CUDASetup.cmake
@@ -69,6 +69,17 @@ if(MaCh3_DEBUG_ENABLED)
   include(${CMAKE_CURRENT_LIST_DIR}/CUDASamples.cmake)
 endif()
 
+#KS: We need it to be defined on compiler level,
+if(NOT DEFINED NSplines_GPU)
+   #EM: for OA2024: 160
+  set(NSplines_GPU 160)
+endif()
+
+# Pass NSplines_GPU as a preprocessor definition to the compiler
+target_compile_definitions(MaCh3CompilerOptions INTERFACE NSplines_GPU=${NSplines_GPU})
+
+cmessage(STATUS "Using \"${NSplines_GPU}\" for GPU EventByEvent Splines")
+
 
 #KS: Keep this for backward compatibility
 

--- a/plotting/GetPostfitParamPlots.cpp
+++ b/plotting/GetPostfitParamPlots.cpp
@@ -23,11 +23,18 @@
 #include "plottingUtils/plottingUtils.h"
 #include "plottingUtils/plottingManager.h"
 
-//How to use ./GetPostfitParamPlots ProcessMCMC_Output1.root <ProcessMCMC_Output2.root> <ProcessMCMC_Output3.root>
-//Originally written by Clarence, with some changes by Will, updated by Kamil, made generic plotter by Ewan
-//Central postfit value taken is the Highest Posterior Density but can be changed easily to Gaussian etc. Watch out for parameter names and number of parameters per plot being quite hardcoded
-
-//g++ `root-config --cflags` -g -std=c++11 -o GetPostfitParamPlots GetPostfitParamPlots.cpp -I`root-config --incdir` `root-config --glibs --libs`
+/// This script generates post-fit parameter plots. The central postfit value is
+/// taken as the Highest Posterior Density (HPD), but can be easily changed to
+/// another method such as Gaussian. Be cautious as parameter names and the number
+/// of parameters per plot are currently hardcoded.
+///
+/// @details
+/// Usage:
+/// ```
+/// ./GetPostfitParamPlots ProcessMCMC_Output1.root <ProcessMCMC_Output2.root> <ProcessMCMC_Output3.root>
+/// ```
+///
+/// @note Originally written by Clarence, with changes by Will, updates by Kamil, and converted to a generic plotter by Ewan.
 
 MaCh3Plotting::PlottingManager *man;
 TH1D *Prefit;

--- a/splines/SplineMonolith.cpp
+++ b/splines/SplineMonolith.cpp
@@ -1250,3 +1250,13 @@ void SMonolith::PrintInitialsiation() {
 
   return;
 }
+
+//*********************************************************
+//KS: After calculations are done on GPU we copy memory to CPU. This operation is asynchronous meaning while memory is being copied some operations are being carried. Memory must be copied before actual reweight. This function make sure all has been copied.
+void SMonolith::SynchroniseMemTransfer() {
+//*********************************************************
+  #ifdef CUDA
+  SynchroniseSplines();
+  #endif
+  return;
+}

--- a/splines/SplineMonolith.h
+++ b/splines/SplineMonolith.h
@@ -2,10 +2,6 @@
 
 #include "splines/SplineBase.h"
 
-#ifdef CUDA
-extern void SynchroniseSplines();
-#endif
-
 /// @brief Even-by-event class calculating response for spline parameters. It is possible to use GPU acceleration
 /// @see For more details, visit the [Wiki](https://github.com/mach3-software/MaCh3/wiki/05.-Splines).
 class SMonolith : public SplineBase {
@@ -27,13 +23,7 @@ class SMonolith : public SplineBase {
     inline std::string GetName()const {return "SplineMonolith";};
 
     /// @brief KS: After calculations are done on GPU we copy memory to CPU. This operation is asynchronous meaning while memory is being copied some operations are being carried. Memory must be copied before actual reweight. This function make sure all has been copied.
-    inline void SynchroniseMemTransfer()
-    {
-      #ifdef CUDA
-      SynchroniseSplines();
-      #endif
-      return;
-    };
+    void SynchroniseMemTransfer();
 
     /// @brief KS: Get pointer to total weight to make fit faster wrooom!
     /// @param event Name event number in used MC

--- a/splines/gpuSplineUtils.cu
+++ b/splines/gpuSplineUtils.cu
@@ -3,15 +3,7 @@
 
 /// Hard code the number of splines
 /// Not entirely necessary: only used for val_gpu and segment_gpu being device constants. Could move them to not being device constants
-/// EM: for OA2022:
-#ifdef NSPLINES_ND280
-#pragma message("using User Specified N splines")
-#define _N_SPLINES_ NSPLINES_ND280
-// EM: for OA2024:
-#else
-#define _N_SPLINES_ 160
-#pragma message("using default N splines")
-#endif
+#define _N_SPLINES_ NSplines_GPU
 
 // KS: Forgive me father, for I have sinned.
 #if defined(__CUDA_ARCH__)

--- a/splines/gpuSplineUtils.cuh
+++ b/splines/gpuSplineUtils.cuh
@@ -1,5 +1,9 @@
-/// MaCh3 event-by-event cross-section spline code
-/// Written by Richard Calland, Asher Kaboth, Clarence Wret, Kamil Skwarczynski
+/// @file gpuSplineUtils.cuh
+/// @brief MaCh3 event-by-event cross-section spline code
+/// @author Richard Calland
+/// @author Asher Kaboth
+/// @author Clarence Wret
+/// @author Kamil Skwarczynski
 ///
 /// Contains code to run on CUDA GPUs. Essentially we load up stripped TSpline3 objects to the GPU and do the equivalent of TSpline3->Eval(double) for all events
 /// Now also supports TF1 evals
@@ -10,6 +14,7 @@
 #include "splines/SplineCommon.h"
 
 /// @brief Allocate memory on gpu for spline monolith
+/// @param gpu_x_array Small array with X coefficients at GPU
 __host__ void InitGPU_SplineMonolith(
                           float **gpu_x_array,
                           float **gpu_many_array,
@@ -44,6 +49,7 @@ __host__ void InitGPU_Vals(float **vals);
 
 
 /// @brief Copy to GPU for x array and separate ybcd array
+/// @param gpu_x_array Small array with X coefficients at GPU
 __host__ void CopyToGPU_SplineMonolith(
                             short int *gpu_paramNo_arr,
                             unsigned int *gpu_nKnots_arr,
@@ -79,7 +85,7 @@ __host__ void CopyToGPU_SplineMonolith(
 /// But using spline segments rather than the parameter value: avoids doing binary search on GPU
 /// @param gpu_paramNo_arr has length = spln_counter (keeps track of which parameter we're using on this thread)
 /// @param gpu_nKnots_arr has length = spln_counter (keeps track where current spline starts)
-/// @param gpu_coeff_many has length = nKnots * 4
+/// @param gpu_coeff_many has length = nKnots * 4, stores all coefficients for all splines and knots
 /// @param gpu_weights has length = spln_counter * spline_size
 /// @param text_coeff_x array storing info about X coeff, uses texture memory. Has length = n_params * spline_size,
 __global__ void EvalOnGPU_Splines(
@@ -118,6 +124,7 @@ __global__ void EvalOnGPU_TotWeight(
 /// @brief Run the GPU code for the separate many arrays. As in separate {x}, {y,b,c,d} arrays
 /// Pass the segment and the parameter values
 /// (binary search already performed in SplineMonolith::FindSplineSegment()
+/// @param gpu_coeff_many has length = nKnots * 4, stores all coefficients for all splines and knots
 __host__ void RunGPU_SplineMonolith(
   const short int* gpu_paramNo_arr,
   const unsigned int* gpu_nKnots_arr,
@@ -147,6 +154,8 @@ __host__ void RunGPU_SplineMonolith(
 __host__ void SynchroniseSplines();
 
 /// @brief Clean up the {x},{ybcd} arrays
+/// @param gpu_x_array Small array with X coefficients at GPU
+/// @param gpu_many_array has length = nKnots * 4, stores all coefficients for all splines and knots
 __host__ void CleanupGPU_SplineMonolith(
   short int *gpu_paramNo_arr,
   unsigned int *gpu_nKnots_arr,


### PR DESCRIPTION
# Pull request description:
There was no way to pas number of GPU splines via cmake. Number of GPU splines has to be known on compiler level (annoing) but being able to at leatst pass them via cmake means we can adjsut it on experiemnt level not core level.

## Changes or fixes:

## Examples:
See it works
<img width="950" alt="Proof" src="https://github.com/user-attachments/assets/b84afe9b-ef24-480a-92d6-26d1f46b24fe">
