### PR TITLE
Override Settings

### DIFF
--- a/manager/manager.cpp
+++ b/manager/manager.cpp
@@ -48,7 +48,6 @@ manager::~manager() {
 // *************************
 
   if(!Modes) delete Modes;
-
 }
 
 // *************************
@@ -101,8 +100,8 @@ void manager::SaveSettings(TFile* const OutputFile) {
 // *************************
 void manager::Print() {
 // *************************
-
   MACH3LOG_INFO("---------------------------------");
-  std::cout << config << "\n";
+  MaCh3Utils::PrintConfig(config);
   MACH3LOG_INFO("---------------------------------");
 }
+

--- a/manager/manager.h
+++ b/manager/manager.h
@@ -38,6 +38,43 @@ public:
   MaCh3Modes* GetMaCh3Modes() const { return Modes; }
   /// @brief Get class name
   inline std::string GetName()const {return "Manager";};
+
+  /// @brief Overrides the configuration settings based on provided arguments.
+  ///
+  /// This function allows you to set configuration options for the manager.
+  /// It accepts either two or three string arguments:
+  /// - For two arguments, the first argument is a key, and the second is the value.
+  /// - For three arguments, the first two arguments are keys, and the third is the value.
+  ///
+  /// @param args The arguments to override the configuration.
+  ///             - When two arguments are provided, they represent the key and value, respectively.
+  ///             - When three arguments are provided, they represent two keys and a value.
+  ///
+  /// @note Example usage:
+  /// @code
+  /// FitManager->OverrideConfig("General", "OutputFile", "Wooimbouttamakeanameformyselfere.root");
+  /// @endcode
+  template <typename... Args>
+  void OverrideConfig(Args... args) {
+    static_assert(sizeof...(args) == 2 || sizeof...(args) == 3,
+                  "OverrideConfig accepts either 2 or 3 arguments.");
+
+    auto args_tuple = std::make_tuple(args...); // Create a tuple from the parameter pack
+
+    if constexpr (sizeof...(args) == 2) {
+      std::string blarb1 = std::get<0>(args_tuple); // First argument
+      std::string result = std::get<1>(args_tuple); // Second argument
+
+      config[blarb1] = result;
+    }
+    else if constexpr (sizeof...(args) == 3) {
+      std::string blarb1 = std::get<0>(args_tuple); // First argument
+      std::string blarb2 = std::get<1>(args_tuple); // Second argument
+      std::string result = std::get<2>(args_tuple); // Third argument
+
+      config[blarb1][blarb2] = result;
+    }
+  }
 private:
   /// The YAML node containing the configuration data.
   YAML::Node config;


### PR DESCRIPTION
# Pull request description:
Add fucntion whicih allow to overwite setting.

For example within exectuable we can hardcode name. Might be usefull for some unit testing.

In future I would like some CLI which would allow to ovewrite settings from comand line.

```
mcmc config.yaml   "[General, OutputFile, Wooimbouttamakeanameformyselfere.root]"
```

## Changes or fixes:


## Examples:
What I used
```
  std::string ManagerInput = "Inputs/ManagerTest.yaml";
  manager *FitManager = new manager(ManagerInput);
  MACH3LOG_INFO("After");
  FitManager->OverrideConfig("General", "OutputFile", "Wooimbouttamakeanameformyselfere.root");
  FitManager->Print();
```
proof:
<img width="555" alt="proof" src="https://github.com/user-attachments/assets/5ba46294-902a-4856-ae4d-60b84b9ba6a4">
