### PR TITLE
Auto generation python docs

### DIFF
--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -49,18 +49,17 @@ jobs:
 
       ## EM: In order to build the python documentation we first need to build the pyMaCh3 module
       - name: Install Python dependencies
-        uses: py-actions/py-dependency-install@v4
-        with:
-          path: "requirements.txt"
+        run: pip install -r "requirements.txt"
         
       - name: Build pyMaCh3
         run: pip install .
 
       ## EM: Now generate the sphinx documentation
-      - name: Sphinx Build              
-        uses: ammaraskar/sphinx-action@0.4
-        with:
-          docs-folder: "Doc/sphinx"
+      - name: Sphinx Build    
+        working-directory: Doc/sphinx
+        run: | 
+          pip install -r requirements.txt
+          make
 
       ## EM: Move the generated sphinx docs into the final html folder
       - name: Move Sphinx Docs

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -13,14 +13,11 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow two jobs, one called "Build-Docs" and one called "Deploy"
+  # This workflow contains a single job called "Doxygen"
   
-  Build-Docs:
+  Doxygen:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    container:
-      image: ghcr.io/mach3-software/mach3:alma9latest
 
     permissions:
       contents: write
@@ -53,8 +50,23 @@ jobs:
       - name: Upload Doxygen Artifact
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 1
           name: DoxygenHTML
           path: Doc/html
+
+  Sphinx:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    needs: Doxygen
+
+    container:
+      image: ghcr.io/mach3-software/mach3:alma9latest
+      
+    steps:
+    
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
     
       ## EM: In order to build the python documentation we first need to build the pyMaCh3 module        
       - name: Build pyMaCh3
@@ -65,28 +77,35 @@ jobs:
         working-directory: Doc/sphinx
         run: | 
           pip install -r requirements.txt
-          make
-
+          make html
+      
+      - name: Download Doxygen Artifact
+        uses: actions/download-artifact@master
+        with:
+          name: DoxygenHTML
+          location: to-upload/html
+          
       ## EM: Move the generated sphinx docs into the final html folder
       - name: Move Sphinx Docs
         run: |
-          mkdir Doc/html/pyMaCh3
-          mv Doc/sphinx/* Doc/html/pyMaCh3/
-
-  Deploy:
-    runs-on: ubuntu-latest
-    needs: Build-Docs
-    
-    steps:
+          ls
+          ls Doc
+          mkdir to-upload/html/pyMaCh3
+          mv Doc/sphinx/* to-upload/html/pyMaCh3/
+          
       - uses: actions/upload-artifact@v4
         with:
+          retention-days: 1
           name: DocumentationHTML
-          path: Doc/html
+          path: to-upload/html
+
+  #Deploy:
+  #  runs-on: ubuntu-latest
+  #  needs: [Doxygen, Sphinx]
         
       # Deploys the generated documentation to GitHub Pages
       #- name: Deploy
       #  uses: peaceiris/actions-gh-pages@v4
       #  with:
       #    github_token: ${{ secrets.GITHUB_TOKEN }}
-      #    publish_dir: ./Doc/html
-
+      #    publish_dir: ./to-upload/html

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -67,6 +67,10 @@ jobs:
     
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+      
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
     
       ## EM: In order to build the python documentation we first need to build the pyMaCh3 module        
       - name: Build pyMaCh3

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -87,7 +87,7 @@ jobs:
           mkdir build
           cd build 
           cmake -DMaCh3_PYTHON_ENABLED=ON ../
-          make 
+          make -j4
           make install
           
       ## EM: Now generate the sphinx documentation

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -13,11 +13,14 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "Doxygen"
+  # This workflow two jobs, one called "Build-Docs" and one called "Deploy"
   
-  Doxygen:
+  Build-Docs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/mach3-software/mach3:alma9latest
 
     permissions:
       contents: write
@@ -52,25 +55,6 @@ jobs:
         with:
           name: DoxygenHTML
           path: Doc/html
-
-  Sphinx:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    needs: Doxygen
-
-    container:
-      image: ghcr.io/mach3-software/mach3:alma9latest
-      
-    steps:
-    
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-
-      - name: Download Doxygen Artifact
-        uses: actions/download-artifact@master
-        with:
-          name: DoxygenHTML
     
       ## EM: In order to build the python documentation we first need to build the pyMaCh3 module        
       - name: Build pyMaCh3
@@ -91,7 +75,7 @@ jobs:
 
   Deploy:
     runs-on: ubuntu-latest
-    needs: [Doxygen, Sphinx]
+    needs: Build-Docs
     
     steps:
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -47,6 +47,12 @@ jobs:
           doxyfile-path: './Doxyfile'
           working-directory: ./Doc
 
+      - name: Upload Doxygen Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: DoxygenHTML
+          path: Doc/html
+
   Sphinx:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -60,6 +66,11 @@ jobs:
     
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+
+      - name: Download Doxygen Artifact
+        uses: actions/download-artifact@master
+        with:
+          name: DoxygenHTML
     
       ## EM: In order to build the python documentation we first need to build the pyMaCh3 module        
       - name: Build pyMaCh3

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -67,7 +67,7 @@ jobs:
           mkdir Doc/html/pyMaCh3
           mv Doc/sphinx/* Doc/html/pyMaCh3/
         
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: DocumentationHTML
           path: Doc/html

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -67,14 +67,21 @@ jobs:
     
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+
+      - name: Make Python Venv
+        run: |
+          python -m venv sphinx_env
+          source sphinx_env/bin/activate
       
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.9'
-    
-      ## EM: In order to build the python documentation we first need to build the pyMaCh3 module        
-      - name: Build pyMaCh3
-        run: pip install .
+      ## EM: In order to build the python documentation we first need to build the pyMaCh3 module  
+      - name: Build MaCh3
+        run: | 
+          mkdir build
+          cd build
+          cmake -DMaCh3_PYTHON_ENABLED=ON ../ 
+          make 
+          make install
+          source bin/setup.MaCh3.sh
 
       ## EM: Now generate the sphinx documentation
       - name: Sphinx Build    

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -60,6 +60,8 @@ jobs:
     
     container:
       image: ghcr.io/mach3-software/mach3:alma9latest
+
+    needs: Doxygen
       
     steps:
     
@@ -69,6 +71,17 @@ jobs:
       - name: Check Python 
         run: python3 --version
 
+      - name: Download Doxygen Artifact
+        uses: actions/download-artifact@master
+        with:
+          name: DoxygenHTML
+          path: to-upload/
+
+      ## EM: Now we delete the artifact so it doesn't use up our allowance
+      - uses: geekyeggo/delete-artifact@v5
+        with:
+          name: DoxygenHTML
+          
       - name: Build MaCh3
         run: | 
           mkdir build
@@ -81,28 +94,15 @@ jobs:
       - name: Sphinx Build    
         working-directory: Doc/sphinx
         run: | 
-          echo BUILD DIR:
-          ls ../../build
-          echo
-          echo pyMaCh3 DIR:
-          ls ../../build/pyMaCh3
           source ../../build/bin/setup.MaCh3.sh
           python3 -m venv sphinx_env 
           source sphinx_env/bin/activate 
           pip install -r requirements.txt 
           make html
-      
-      - name: Download Doxygen Artifact
-        uses: actions/download-artifact@master
-        with:
-          name: DoxygenHTML
-          location: to-upload/
           
       ## EM: Move the generated sphinx docs into the final html folder
       - name: Move Sphinx Docs
         run: |
-          ls Doc
-          ls Doc/sphinx
           mkdir to-upload/pyMaCh3
           mv Doc/sphinx/build/html/* to-upload/pyMaCh3/
           

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -1,17 +1,21 @@
-# This is a basic workflow make doxygen documentation every time develop is updated
+---
+# This is a basic workflow make doxygen documentation 
+# every time develop is updated
 
 name: Doxygen
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the develop branch
+  # Triggers the workflow on push or pull request events 
+  # but only for the develop branch
   push:
-    branches: [ develop ]
+    branches: [develop]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# A workflow run is made up of one or more jobs that can run 
+# sequentially or in parallel
 jobs:
   # This workflow contains a single job called "Doxygen"
   
@@ -23,9 +27,11 @@ jobs:
       contents: write
       id-token: write
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    # Steps represent a sequence of tasks that will be executed
+    # as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checks-out your repository under $GITHUB_WORKSPACE, 
+      # so your job can access it
       - uses: actions/checkout@v4
       
       # Updates the package list to ensure you get the latest version of packages
@@ -34,7 +40,8 @@ jobs:
       # Installs texlive for LaTeX support in Doxygen documentation
       - run: sudo apt-get install -y texlive
 
-      # Installs libjs-mathjax for rendering mathematical notation in Doxygen documentation
+      # Installs libjs-mathjax for rendering mathematical notation 
+      # in Doxygen documentation
       - run: sudo apt-get install -y libjs-mathjax
 
       # Install perl for bibtex
@@ -65,7 +72,8 @@ jobs:
       
     steps:
     
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checks-out your repository under $GITHUB_WORKSPACE, 
+      # so your job can access it
       - uses: actions/checkout@v4
 
       - name: Check Python 

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -46,11 +46,37 @@ jobs:
         with:
           doxyfile-path: './Doxyfile'
           working-directory: ./Doc
-  
-      # Deploys the generated documentation to GitHub Pages
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+
+      ## EM: In order to build the python documentation we first need to build the pyMaCh3 module
+      - name: Install Python dependencies
+        uses: py-actions/py-dependency-install@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./Doc/html
-    
+          path: "requirements.txt"
+        
+      - name: Build pyMaCh3
+        run: pip install .
+
+      ## EM: Now generate the sphinx documentation
+      - name: Sphinx Build              
+        uses: ammaraskar/sphinx-action@0.4
+        with:
+          docs-folder: "Doc/sphinx"
+
+      ## EM: Move the generated sphinx docs into the final html folder
+      - name: Move Sphinx Docs
+        run: |
+          mkdir Doc/html/pyMaCh3
+          mv Doc/sphinx/* Doc/html/pyMaCh3/
+        
+      - uses: actions/upload-artifact@v1
+        with:
+          name: DocumentationHTML
+          path: Doc/html
+        
+      # Deploys the generated documentation to GitHub Pages
+      #- name: Deploy
+      #  uses: peaceiris/actions-gh-pages@v4
+      #  with:
+      #    github_token: ${{ secrets.GITHUB_TOKEN }}
+      #    publish_dir: ./Doc/html
+

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -47,10 +47,21 @@ jobs:
           doxyfile-path: './Doxyfile'
           working-directory: ./Doc
 
-      ## EM: In order to build the python documentation we first need to build the pyMaCh3 module
-      - name: Install Python dependencies
-        run: pip install -r "requirements.txt"
-        
+  Sphinx:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    needs: Doxygen
+
+    container:
+      image: ghcr.io/mach3-software/mach3:alma9latest
+      
+    steps:
+    
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+    
+      ## EM: In order to build the python documentation we first need to build the pyMaCh3 module        
       - name: Build pyMaCh3
         run: pip install .
 
@@ -66,7 +77,12 @@ jobs:
         run: |
           mkdir Doc/html/pyMaCh3
           mv Doc/sphinx/* Doc/html/pyMaCh3/
-        
+
+  Deploy:
+    runs-on: ubuntu-latest
+    needs: [Doxygen, Sphinx]
+    
+    steps:
       - uses: actions/upload-artifact@v4
         with:
           name: DocumentationHTML

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -53,13 +53,11 @@ jobs:
           retention-days: 1
           name: DoxygenHTML
           path: Doc/html
-
+          
   Sphinx:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    needs: Doxygen
-
+    
     container:
       image: ghcr.io/mach3-software/mach3:alma9latest
       
@@ -68,47 +66,51 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
-      - name: Make Python Venv
-        run: |
-          python -m venv sphinx_env
-          source sphinx_env/bin/activate
-      
-      ## EM: In order to build the python documentation we first need to build the pyMaCh3 module  
+      - name: Check Python 
+        run: python3 --version
+
       - name: Build MaCh3
         run: | 
           mkdir build
-          cd build
-          cmake -DMaCh3_PYTHON_ENABLED=ON ../ 
+          cd build 
+          cmake -DMaCh3_PYTHON_ENABLED=ON ../
           make 
           make install
-          source bin/setup.MaCh3.sh
-
+          
       ## EM: Now generate the sphinx documentation
       - name: Sphinx Build    
         working-directory: Doc/sphinx
         run: | 
-          pip install -r requirements.txt
+          echo BUILD DIR:
+          ls ../../build
+          echo
+          echo pyMaCh3 DIR:
+          ls ../../build/pyMaCh3
+          source ../../build/bin/setup.MaCh3.sh
+          python3 -m venv sphinx_env 
+          source sphinx_env/bin/activate 
+          pip install -r requirements.txt 
           make html
       
       - name: Download Doxygen Artifact
         uses: actions/download-artifact@master
         with:
           name: DoxygenHTML
-          location: to-upload/html
+          location: to-upload/
           
       ## EM: Move the generated sphinx docs into the final html folder
       - name: Move Sphinx Docs
         run: |
-          ls
           ls Doc
-          mkdir to-upload/html/pyMaCh3
-          mv Doc/sphinx/* to-upload/html/pyMaCh3/
+          ls Doc/sphinx
+          mkdir to-upload/pyMaCh3
+          mv Doc/sphinx/build/html/* to-upload/pyMaCh3/
           
       - uses: actions/upload-artifact@v4
         with:
           retention-days: 1
           name: DocumentationHTML
-          path: to-upload/html
+          path: to-upload
 
   #Deploy:
   #  runs-on: ubuntu-latest

--- a/Doc/mainpage.md
+++ b/Doc/mainpage.md
@@ -1,3 +1,5 @@
+# MaCh3
+
 ## Introduction
 Welcome to %MaCh3!
 

--- a/Doc/mainpage.md
+++ b/Doc/mainpage.md
@@ -9,7 +9,7 @@ You can find additional documentation on our [Wiki](https://github.com/mach3-sof
 
 If you are new we recommend to start from our [Tutorial](https://github.com/mach3-software/MaCh3Validations)
 
-MaCh3 also comes with a Python interface. You can find out more about this in the dedicated [pyMaCh3 documentation](./pyMach3/mainpage)
+MaCh3 also comes with a Python interface. You can find out more about this in the dedicated [pyMaCh3 documentation](./pyMach3/mainpage.html)
 
 If something is unclear please contact us via
 - [Mailing lists](https://www.jiscmail.ac.uk/cgi-bin/webadmin?A0=MACH3)

--- a/Doc/mainpage.md
+++ b/Doc/mainpage.md
@@ -9,7 +9,7 @@ You can find additional documentation on our [Wiki](https://github.com/mach3-sof
 
 If you are new we recommend to start from our [Tutorial](https://github.com/mach3-software/MaCh3Validations)
 
-MaCh3 also comes with a Python interface. You can find out more about this in the dedicated [pyMaCh3 documentation](./python/mainpage)
+MaCh3 also comes with a Python interface. You can find out more about this in the dedicated [pyMaCh3 documentation](./pyMach3/mainpage)
 
 If something is unclear please contact us via
 - [Mailing lists](https://www.jiscmail.ac.uk/cgi-bin/webadmin?A0=MACH3)

--- a/Doc/mainpage.md
+++ b/Doc/mainpage.md
@@ -9,6 +9,8 @@ You can find additional documentation on our [Wiki](https://github.com/mach3-sof
 
 If you are new we recommend to start from our [Tutorial](https://github.com/mach3-software/MaCh3Validations)
 
+MaCh3 also comes with a Python interface. You can find out more about this in the dedicated [pyMaCh3 documentation](./python/mainpage)
+
 If something is unclear please contact us via
 - [Mailing lists](https://www.jiscmail.ac.uk/cgi-bin/webadmin?A0=MACH3)
 - [Slack](https://t2k-experiment.slack.com/archives/C06EM0C6D7W/p1705599931356889)

--- a/Doc/mainpage.md
+++ b/Doc/mainpage.md
@@ -1,5 +1,3 @@
-\mainpage %MaCh3 Reference Documentation
-
 ## Introduction
 Welcome to %MaCh3!
 


### PR DESCRIPTION
# Pull request description

"These will be automatically generated. It should be pretty easy to get working" - Me on Monday. Well here we 15 commits and dozens of failed attempts later. But... it works!

## Changes or fixes

Extend the documentation generation action to also build sphinx documentation for python and add it to a sub folder in the existing html which gets uploaded to github pages. 

One note is that it now takes a bit longer to generate as it needs to actually build the python module in order to make the documentation for it. In future it might be good to have it only run the sphinx generation part if the python code has been changed (this is tricky but I think not impossible to do). Or only generate new documentation only on tags rather than every PR.

## Examples
