### PR TITLE
Feature tidy up

### DIFF
--- a/python/samplePDF.cpp
+++ b/python/samplePDF.cpp
@@ -2,9 +2,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
 
-#include "samplePDF/samplePDFBase.h"
 #include "samplePDF/samplePDFFDBase.h"
-#include "samplePDF/FDMCStruct.h"
 
 namespace py = pybind11;
 

--- a/samplePDF/CMakeLists.txt
+++ b/samplePDF/CMakeLists.txt
@@ -2,7 +2,7 @@ set(HEADERS
     samplePDFBase.h
     samplePDFFDBase.h
     Structs.h
-    FDMCStruct.h
+	FarDetectorCoreInfoStruct.h
 )
 
 add_library(SamplePDF SHARED

--- a/samplePDF/FarDetectorCoreInfoStruct.h
+++ b/samplePDF/FarDetectorCoreInfoStruct.h
@@ -2,6 +2,14 @@
 
 /// @brief constructors are same for all three so put in here
 struct FarDetectorCoreInfo {
+  FarDetectorCoreInfo() : isNC{nullptr} {}
+  FarDetectorCoreInfo(FarDetectorCoreInfo const &other) = delete;
+  FarDetectorCoreInfo(FarDetectorCoreInfo &&other) = default;
+  FarDetectorCoreInfo& operator=(FarDetectorCoreInfo const &other) = delete;
+  FarDetectorCoreInfo& operator=(FarDetectorCoreInfo &&other) = delete;
+
+  ~FarDetectorCoreInfo(){ delete [] isNC; }
+
   int nutype; // 2 = numu/signue | -2 = numub | 1 = nue | -1 = nueb           
   int oscnutype;    
   int nupdg;
@@ -22,7 +30,7 @@ struct FarDetectorCoreInfo {
   std::vector<const double*> rw_truecz;
 
   /// xsec bins
-  std::list< int > *xsec_norms_bins;
+  std::vector< std::vector< int > > xsec_norms_bins;
 
   /// DB Speedup bits
   double Unity;

--- a/samplePDF/FarDetectorCoreInfoStruct.h
+++ b/samplePDF/FarDetectorCoreInfoStruct.h
@@ -11,15 +11,15 @@ struct FarDetectorCoreInfo {
   double ChannelIndex;
   std::string flavourName;
 
-  int **Target; // target the interaction was on
+  std::vector<int*> Target; // target the interaction was on
 
   int SampleDetID;
 
   //THe x_var and y_vars that you're binning in
-  const double** x_var;
-  const double** y_var;
-  const double **rw_etru;
-  const double **rw_truecz = nullptr;
+  std::vector<const double*> x_var;
+  std::vector<const double*> y_var;
+  std::vector<const double*> rw_etru;
+  std::vector<const double*> rw_truecz;
 
   /// xsec bins
   std::list< int > *xsec_norms_bins;
@@ -30,32 +30,32 @@ struct FarDetectorCoreInfo {
   int Unity_Int;
   double dummy_value = -999;
 
-  int* nxsec_norm_pointers;
-  const double*** xsec_norm_pointers;
+  std::vector<int> nxsec_norm_pointers;
+  std::vector<std::vector<const double*>> xsec_norm_pointers;
 
-  int* nxsec_spline_pointers;
-  const double*** xsec_spline_pointers;
+  std::vector<int> nxsec_spline_pointers;
+  std::vector<std::vector<const double*>> xsec_spline_pointers;
 
-  int* ntotal_weight_pointers;
-  const double*** total_weight_pointers;
-  double* total_w;
+  std::vector<int> ntotal_weight_pointers;
+  std::vector<std::vector<const double*>> total_weight_pointers;
+  std::vector<double> total_w;
 
-  int* XBin;
-  int* YBin;
-  int* NomXBin;
-  int* NomYBin;
+  std::vector<int> XBin;
+  std::vector<int> YBin;
+  std::vector<int> NomXBin;
+  std::vector<int> NomYBin;
 
   bool *isNC;
 
   // histo pdf bins
-  double *rw_lower_xbinedge; // lower to check if Eb has moved the erec bin
-  double *rw_lower_lower_xbinedge; // lower to check if Eb has moved the erec bin
-  double *rw_upper_xbinedge; // upper to check if Eb has moved the erec bin
-  double *rw_upper_upper_xbinedge; // upper to check if Eb has moved the erec bin
+  std::vector<double> rw_lower_xbinedge; // lower to check if Eb has moved the erec bin
+  std::vector<double> rw_lower_lower_xbinedge; // lower to check if Eb has moved the erec bin
+  std::vector<double> rw_upper_xbinedge; // upper to check if Eb has moved the erec bin
+  std::vector<double> rw_upper_upper_xbinedge; // upper to check if Eb has moved the erec bin
 
-  double **mode;
+  std::vector<double*> mode;
 
-  const M3::float_t **osc_w_pointer;
-  double *xsec_w;
-  splineFDBase *splineFile; 
+  std::vector<const M3::float_t*> osc_w_pointer;
+  std::vector<double> xsec_w;
+
 };

--- a/samplePDF/FarDetectorCoreInfoStruct.h
+++ b/samplePDF/FarDetectorCoreInfoStruct.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /// @brief constructors are same for all three so put in here
-struct fdmc_base {
+struct FarDetectorCoreInfo {
   int nutype; // 2 = numu/signue | -2 = numub | 1 = nue | -1 = nueb           
   int oscnutype;    
   int nupdg;
@@ -19,7 +19,7 @@ struct fdmc_base {
   const double** x_var;
   const double** y_var;
   const double **rw_etru;
-  const double **rw_truecz = NULL;
+  const double **rw_truecz = nullptr;
 
   /// xsec bins
   std::list< int > *xsec_norms_bins;

--- a/samplePDF/FarDetectorCoreInfoStruct.h
+++ b/samplePDF/FarDetectorCoreInfoStruct.h
@@ -57,5 +57,4 @@ struct FarDetectorCoreInfo {
 
   std::vector<const M3::float_t*> osc_w_pointer;
   std::vector<double> xsec_w;
-
 };

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -79,7 +79,7 @@ void samplePDFFDBase::ReadSampleConfig()
   }
   
   for (int i=0;i<nSamples;i++) {
-    struct fdmc_base obj = fdmc_base();
+    struct FarDetectorCoreInfo obj = FarDetectorCoreInfo();
     MCSamples.push_back(obj);
   }
   
@@ -402,8 +402,8 @@ void samplePDFFDBase::fillArray() {
   }
 
   PrepFunctionalParameters();
-  if(splineFile){
-    splineFile->Evaluate();
+  if(SplineHandler){
+    SplineHandler->Evaluate();
   }
 
   for (unsigned int iSample=0;iSample<MCSamples.size();iSample++) {
@@ -419,7 +419,7 @@ void samplePDFFDBase::fillArray() {
       double funcweight = 1.0;
       double totalweight = 1.0;
       
-      if(splineFile){
+      if(SplineHandler){
         splineweight *= CalcXsecWeightSpline(iSample, iEvent);
       }
       //DB Catch negative spline weights and skip any event with a negative event. Previously we would set weight to zero and continue but that is inefficient. Do this on a spline-by-spline basis
@@ -558,8 +558,8 @@ void samplePDFFDBase::fillArray_MP()
     PrepFunctionalParameters();
     //==================================================
     //Calc Weights and fill Array
-    if(splineFile){
-      splineFile->Evaluate();
+    if(SplineHandler){
+      SplineHandler->Evaluate();
     }
     
     for (unsigned int iSample=0;iSample<MCSamples.size();iSample++) {
@@ -585,7 +585,7 @@ void samplePDFFDBase::fillArray_MP()
 	//DB SKDet Syst
 	//As weights were skdet::fParProp, and we use the non-shifted erec, we might as well cache the corresponding fParProp index for each event and the pointer to it
 	
-	if(splineFile){
+	if(SplineHandler){
 	  splineweight *= CalcXsecWeightSpline(iSample, iEvent);
 	}
 	//DB Catch negative spline weights and skip any event with a negative event. Previously we would set weight to zero and continue but that is inefficient
@@ -791,7 +791,7 @@ void samplePDFFDBase::SetupNormParameters(){
 //A way to check whether a normalisation parameter applies to an event or not
 void samplePDFFDBase::CalcXsecNormsBins(int iSample){
 
-  fdmc_base *fdobj = &MCSamples[iSample];
+  FarDetectorCoreInfo *fdobj = &MCSamples[iSample];
 
   for(int iEvent=0; iEvent < fdobj->nEvents; ++iEvent){
     std::list< int > XsecBins = {};
@@ -1453,10 +1453,10 @@ void samplePDFFDBase::fillSplineBins() {
       std::vector< std::vector<int> > EventSplines;
       switch(nDimensions){
       case 1:
-	EventSplines = splineFile->GetEventSplines(GetName(), i, int(*(MCSamples[i].mode[j])), *(MCSamples[i].rw_etru[j]), *(MCSamples[i].x_var[j]), 0.);
+	EventSplines = SplineHandler->GetEventSplines(GetName(), i, int(*(MCSamples[i].mode[j])), *(MCSamples[i].rw_etru[j]), *(MCSamples[i].x_var[j]), 0.);
 	break;
       case 2:
-	EventSplines = splineFile->GetEventSplines(GetName(), i, int(*(MCSamples[i].mode[j])), *(MCSamples[i].rw_etru[j]), *(MCSamples[i].x_var[j]), *(MCSamples[i].y_var[j]));
+	EventSplines = SplineHandler->GetEventSplines(GetName(), i, int(*(MCSamples[i].mode[j])), *(MCSamples[i].rw_etru[j]), *(MCSamples[i].x_var[j]), *(MCSamples[i].y_var[j]));
 	break;
       default:
 	MACH3LOG_ERROR("Error in assigning spline bins because nDimensions = {}", nDimensions);
@@ -1471,7 +1471,7 @@ void samplePDFFDBase::fillSplineBins() {
       MCSamples[i].xsec_spline_pointers[j] = new const double*[MCSamples[i].nxsec_spline_pointers[j]];
       for(int spline=0; spline<MCSamples[i].nxsec_spline_pointers[j]; spline++){          
 	//Event Splines indexed as: sample name, oscillation channel, syst, mode, etrue, var1, var2 (var2 is a dummy 0 for 1D splines)
-	MCSamples[i].xsec_spline_pointers[j][spline] = splineFile->retPointer(EventSplines[spline][0], EventSplines[spline][1], EventSplines[spline][2], 
+	MCSamples[i].xsec_spline_pointers[j][spline] = SplineHandler->retPointer(EventSplines[spline][0], EventSplines[spline][1], EventSplines[spline][2], 
 									      EventSplines[spline][3], EventSplines[spline][4], EventSplines[spline][5], EventSplines[spline][6]);
       }
     }
@@ -1520,8 +1520,8 @@ void samplePDFFDBase::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
     throw MaCh3Exception(__FILE__, __LINE__);
   }
   
-  MCSamples[iSample] = fdmc_base();
-  fdmc_base *fdobj = &MCSamples[iSample];
+  MCSamples[iSample] = FarDetectorCoreInfo();
+  FarDetectorCoreInfo *fdobj = &MCSamples[iSample];
   
   fdobj->nEvents = nEvents_;
   fdobj->nutype = -9;
@@ -1600,10 +1600,10 @@ void samplePDFFDBase::InitialiseSplineObject() {
     SplineVarNames.push_back(YVarStr);
   }
   
-  splineFile->AddSample(samplename, SampleDetID, spline_filepaths, SplineVarNames);
-  splineFile->PrintArrayDimension();
-  splineFile->CountNumberOfLoadedSplines(false, 1);
-  splineFile->TransferToMonolith();
+  SplineHandler->AddSample(samplename, SampleDetID, spline_filepaths, SplineVarNames);
+  SplineHandler->PrintArrayDimension();
+  SplineHandler->CountNumberOfLoadedSplines(false, 1);
+  SplineHandler->TransferToMonolith();
 
   MACH3LOG_INFO("--------------------------------");
   MACH3LOG_INFO("Setup Far Detector splines");

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -739,9 +739,9 @@ void samplePDFFDBase::SetXsecCov(covarianceXsec *xsec){
 
   //DB Now get this information using the DetID from the config
   xsec_norms = XsecCov->GetNormParsFromDetID(SampleDetID);
-  nFuncParams = XsecCov->GetNumFuncParamsFromDetID(SampleDetID);
-  funcParsNames = XsecCov->GetFuncParsNamesFromDetID(SampleDetID);
-  funcParsIndex = XsecCov->GetFuncParsIndexFromDetID(SampleDetID);
+  nFuncParams = XsecCov->GetNumParamsFromDetID(SampleDetID, SystType::kFunc);
+  funcParsNames = XsecCov->GetParsNamesFromDetID(SampleDetID, SystType::kFunc);
+  funcParsIndex = XsecCov->GetParsIndexFromDetID(SampleDetID, SystType::kFunc);
 
   return;
 }
@@ -1533,7 +1533,7 @@ void samplePDFFDBase::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
   fdobj->rw_lower_lower_xbinedge.resize(nEvents, -1);
   fdobj->rw_upper_xbinedge.resize(nEvents, -1);
   fdobj->rw_upper_upper_xbinedge.resize(nEvents, -1);
-  fdobj->mode.resize(nEvents, &fdobj->Unity_Int);
+  fdobj->mode.resize(nEvents, &fdobj->Unity);
   fdobj->nxsec_norm_pointers.resize(nEvents);
   fdobj->xsec_norm_pointers.resize(nEvents);
   fdobj->xsec_norms_bins.resize(nEvents);

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -775,7 +775,7 @@ void samplePDFFDBase::SetupNormParameters(){
 	  counter = 0;
 
 	  MCSamples[iSample].nxsec_norm_pointers[iEvent] = int(MCSamples[iSample].xsec_norms_bins[iEvent].size());
-	  MCSamples[iSample].xsec_norm_pointers[iEvent] = new const double*[MCSamples[iSample].nxsec_norm_pointers[iEvent]];
+	  MCSamples[iSample].xsec_norm_pointers[iEvent].resize(MCSamples[iSample].nxsec_norm_pointers[iEvent]);
 
 	  for(std::list< int >::iterator lit = MCSamples[iSample].xsec_norms_bins[iEvent].begin();lit!=MCSamples[iSample].xsec_norms_bins[iEvent].end();lit++) {
 		MCSamples[iSample].xsec_norm_pointers[iEvent][counter] = XsecCov->retPointer(*lit);
@@ -1069,14 +1069,14 @@ void samplePDFFDBase::FindNominalBinAndEdges1D() {
       }
       
       if ((bin-1) >= 0 && (bin-1) < int(XBinEdges.size()-1)) {
-	MCSamples[mc_i].NomXBin[event_i] = bin-1;
-      } else {
-	MCSamples[mc_i].NomXBin[event_i] = -1;
-	low_edge = _DEFAULT_RETURN_VAL_;
-	upper_edge = _DEFAULT_RETURN_VAL_;
-	low_lower_edge = _DEFAULT_RETURN_VAL_;
-	upper_upper_edge = _DEFAULT_RETURN_VAL_;
-      }
+		  MCSamples[mc_i].NomXBin[event_i] = bin-1;
+	  } else {
+		  MCSamples[mc_i].NomXBin[event_i] = -1;
+		  low_edge = _DEFAULT_RETURN_VAL_;
+		  upper_edge = _DEFAULT_RETURN_VAL_;
+		  low_lower_edge = _DEFAULT_RETURN_VAL_;
+		  upper_upper_edge = _DEFAULT_RETURN_VAL_;
+	  }
       MCSamples[mc_i].NomYBin[event_i] = 0;
       
       MCSamples[mc_i].rw_lower_xbinedge[event_i] = low_edge;
@@ -1348,9 +1348,9 @@ void samplePDFFDBase::SetupNuOscillator() {
 
       //============================================================================
       //DB Atmospheric only part
-      if (MCSamples[iSample].rw_truecz != nullptr) { //Can only happen if truecz has been initialised within the experiment specific code
+      if (MCSamples[iSample].rw_truecz.size() > 0 && MCSamples[iSample].rw_truecz.size() == MCSamples[iSample].nEvents) { //Can only happen if truecz has been initialised within the experiment specific code
 	std::vector<M3::float_t> CosineZArray;
-	for (int iEvent=0;iEvent<MCSamples[iSample].nEvents;iEvent++) {
+	for (int iEvent=0;iEvent<int(MCSamples[iSample].nEvents);iEvent++) {
 	  //DB Remove NC events from the arrays which are handed to the NuOscillator objects
 	  if (!MCSamples[iSample].isNC[iEvent]) {
 	    CosineZArray.push_back(float(*(MCSamples[iSample].rw_truecz[iEvent])));
@@ -1421,7 +1421,7 @@ void samplePDFFDBase::SetupNuOscillator() {
 	  InitFlav *= -1;
 	  FinalFlav *= -1;
 	}
-	if (MCSamples[iSample].rw_truecz != nullptr) { //Can only happen if truecz has been initialised within the experiment specific code
+	if (MCSamples[iSample].rw_truecz.size() > 0) { //Can only happen if truecz has been initialised within the experiment specific code
 	  //Atmospherics
 	  MCSamples[iSample].osc_w_pointer[iEvent] = NuOscProbCalcers[iSample]->ReturnWeightPointer(InitFlav,FinalFlav,FLOAT_T(*(MCSamples[iSample].rw_etru[iEvent])),FLOAT_T(*(MCSamples[iSample].rw_truecz[iEvent])));
 	} else {
@@ -1452,31 +1452,31 @@ void samplePDFFDBase::fillSplineBins() {
     for (int j = 0; j < MCSamples[i].nEvents; ++j) {
       std::vector< std::vector<int> > EventSplines;
       switch(nDimensions){
-      case 1:
-	EventSplines = SplineHandler->GetEventSplines(GetName(), i, int(*(MCSamples[i].mode[j])), *(MCSamples[i].rw_etru[j]), *(MCSamples[i].x_var[j]), 0.);
-	break;
-      case 2:
-	EventSplines = SplineHandler->GetEventSplines(GetName(), i, int(*(MCSamples[i].mode[j])), *(MCSamples[i].rw_etru[j]), *(MCSamples[i].x_var[j]), *(MCSamples[i].y_var[j]));
-	break;
-      default:
-	MACH3LOG_ERROR("Error in assigning spline bins because nDimensions = {}", nDimensions);
-	MACH3LOG_ERROR("MaCh3 only supports splines binned in Etrue + the sample binning");
-	MACH3LOG_ERROR("Please check the sample binning you specified in your sample config ");
-	break;
+        case 1:
+          EventSplines = SplineHandler->GetEventSplines(GetName(), i, int(*(MCSamples[i].mode[j])), *(MCSamples[i].rw_etru[j]), *(MCSamples[i].x_var[j]), 0.);
+          break;
+        case 2:
+          EventSplines = SplineHandler->GetEventSplines(GetName(), i, int(*(MCSamples[i].mode[j])), *(MCSamples[i].rw_etru[j]), *(MCSamples[i].x_var[j]), *(MCSamples[i].y_var[j]));
+          break;
+        default:
+          MACH3LOG_ERROR("Error in assigning spline bins because nDimensions = {}", nDimensions);
+          MACH3LOG_ERROR("MaCh3 only supports splines binned in Etrue + the sample binning");
+          MACH3LOG_ERROR("Please check the sample binning you specified in your sample config ");
+          break;
       }
       MCSamples[i].nxsec_spline_pointers[j] = int(EventSplines.size());
       if(MCSamples[i].nxsec_spline_pointers[j] < 0){
-	throw MaCh3Exception(__FILE__, __LINE__);
+        throw MaCh3Exception(__FILE__, __LINE__);
       }
-      MCSamples[i].xsec_spline_pointers[j] = new const double*[MCSamples[i].nxsec_spline_pointers[j]];
+      MCSamples[i].xsec_spline_pointers[j].resize(MCSamples[i].nxsec_spline_pointers[j]);
       for(int spline=0; spline<MCSamples[i].nxsec_spline_pointers[j]; spline++){          
-	//Event Splines indexed as: sample name, oscillation channel, syst, mode, etrue, var1, var2 (var2 is a dummy 0 for 1D splines)
-	MCSamples[i].xsec_spline_pointers[j][spline] = SplineHandler->retPointer(EventSplines[spline][0], EventSplines[spline][1], EventSplines[spline][2], 
-									      EventSplines[spline][3], EventSplines[spline][4], EventSplines[spline][5], EventSplines[spline][6]);
+        //Event Splines indexed as: sample name, oscillation channel, syst, mode, etrue, var1, var2 (var2 is a dummy 0 for 1D splines)
+        MCSamples[i].xsec_spline_pointers[j][spline] = SplineHandler->retPointer(EventSplines[spline][0], EventSplines[spline][1], EventSplines[spline][2], 
+            EventSplines[spline][3], EventSplines[spline][4], EventSplines[spline][5], EventSplines[spline][6]);
       }
     }
   }
-  
+
   return;
 }
 
@@ -1530,31 +1530,30 @@ void samplePDFFDBase::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
   fdobj->Unity = 1.;
   fdobj->Unity_Int = 1.;
   
-  fdobj->x_var = new const double*[fdobj->nEvents];
-  fdobj->y_var = new const double*[fdobj->nEvents];
-  fdobj->rw_etru = new const double*[fdobj->nEvents];
-  fdobj->XBin = new int[fdobj->nEvents];
-  fdobj->YBin = new int[fdobj->nEvents];    
-  fdobj->NomXBin = new int[fdobj->nEvents];
-  fdobj->NomYBin = new int[fdobj->nEvents];
-  fdobj->XBin = new int [fdobj->nEvents];
-  fdobj->YBin = new int [fdobj->nEvents];;	 
-  fdobj->rw_lower_xbinedge = new double [fdobj->nEvents];
-  fdobj->rw_lower_lower_xbinedge = new double [fdobj->nEvents];
-  fdobj->rw_upper_xbinedge = new double [fdobj->nEvents];
-  fdobj->rw_upper_upper_xbinedge = new double [fdobj->nEvents];
-  fdobj->mode = new double*[fdobj->nEvents];
-  fdobj->nxsec_norm_pointers = new int[fdobj->nEvents];
-  fdobj->xsec_norm_pointers = new const double**[fdobj->nEvents];
+  int nEvents = fdobj->nEvents;
+  fdobj->x_var.resize(fdobj->nEvents);
+  fdobj->y_var.resize(fdobj->nEvents);
+  fdobj->rw_etru.resize(fdobj->nEvents);
+  fdobj->XBin.resize(nEvents);
+  fdobj->YBin.resize(nEvents);
+  fdobj->NomXBin.resize(nEvents);
+  fdobj->NomYBin.resize(nEvents);
+  fdobj->rw_lower_xbinedge.resize(nEvents);
+  fdobj->rw_lower_lower_xbinedge.resize(nEvents);
+  fdobj->rw_upper_xbinedge.resize(nEvents);
+  fdobj->rw_upper_upper_xbinedge.resize(nEvents);
+  fdobj->mode.resize(nEvents);// = new int*[fdobj->nEvents];
+  fdobj->nxsec_norm_pointers.resize(fdobj->nEvents);
+  fdobj->xsec_norm_pointers.resize(nEvents);// = new const double**[fdobj->nEvents];
   fdobj->xsec_norms_bins = new std::list< int >[fdobj->nEvents];
-  fdobj->xsec_w = new double[fdobj->nEvents];
+  fdobj->xsec_w.resize(nEvents);// = new double[fdobj->nEvents];
   fdobj->isNC = new bool[fdobj->nEvents];
-  fdobj->nxsec_spline_pointers = new int[fdobj->nEvents];
-  fdobj->xsec_spline_pointers = new const double**[fdobj->nEvents];
-  fdobj->ntotal_weight_pointers = new int[fdobj->nEvents];
-  fdobj->total_weight_pointers = new const double**[fdobj->nEvents];
-  fdobj->Target = new int*[fdobj->nEvents];
-  fdobj->osc_w_pointer = new const M3::float_t*[fdobj->nEvents];
+  fdobj->nxsec_spline_pointers.resize(fdobj->nEvents);
+  fdobj->xsec_spline_pointers.resize(nEvents);// = new const double**[fdobj->nEvents];
+  fdobj->ntotal_weight_pointers.resize(fdobj->nEvents);
+  fdobj->total_weight_pointers.resize(fdobj->nEvents);
+  fdobj->Target.resize(nEvents);
+  fdobj->osc_w_pointer.resize(nEvents);// = new const _float_*[fdobj->nEvents];
   //fdobj->rw_truecz = new const double*[fdobj->nEvents];
   
   for(int iEvent = 0 ;iEvent < fdobj->nEvents ; ++iEvent){
@@ -1562,11 +1561,11 @@ void samplePDFFDBase::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
     //fdobj->rw_truecz[iEvent] = &fdobj->Unity;
     fdobj->mode[iEvent] = &fdobj->Unity;
     fdobj->Target[iEvent] = 0;
-    fdobj->NomXBin[iEvent] = -1;
-    fdobj->NomYBin[iEvent] = -1;
-    fdobj->XBin[iEvent] = -1;
-    fdobj->YBin[iEvent] = -1;
-    fdobj->rw_lower_xbinedge[iEvent] = -1;
+    fdobj->NomXBin.emplace_back(-1);
+    fdobj->NomYBin.emplace_back(-1);
+    fdobj->XBin.emplace_back(-1);
+    fdobj->YBin.emplace_back(-1);
+    fdobj->rw_lower_xbinedge.emplace_back(-1);
     fdobj->rw_lower_lower_xbinedge[iEvent] = -1;
     fdobj->rw_upper_xbinedge[iEvent] = -1;
     fdobj->rw_upper_upper_xbinedge[iEvent] = -1;

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -50,33 +50,29 @@ samplePDFFDBase::~samplePDFFDBase()
 void samplePDFFDBase::ReadSampleConfig() 
 {
    
-  if (CheckNodeExists(SampleManager->raw(), "SampleName")) {
-    samplename = SampleManager->raw()["SampleName"].as<std::string>();
-  } else{
+  if (!CheckNodeExists(SampleManager->raw(), "SampleName")) {
     MACH3LOG_ERROR("SampleName not defined in {}, please add this!", SampleManager->GetFileName());
     throw MaCh3Exception(__FILE__, __LINE__);
   }
+  samplename = SampleManager->raw()["SampleName"].as<std::string>();
   
-  if (CheckNodeExists(SampleManager->raw(), "NSubSamples")) {
-    nSamples = SampleManager->raw()["NSubSamples"].as<M3::int_t>();
-  } else{
+  if (!CheckNodeExists(SampleManager->raw(), "NSubSamples")) {
     MACH3LOG_ERROR("NSubSamples not defined in {}, please add this!", SampleManager->GetFileName());
     throw MaCh3Exception(__FILE__, __LINE__);
   }
+  nSamples = SampleManager->raw()["NSubSamples"].as<M3::int_t>();
   
-  if (CheckNodeExists(SampleManager->raw(), "DetID")) {
-    SampleDetID = SampleManager->raw()["DetID"].as<int>();
-  } else{
+  if (!CheckNodeExists(SampleManager->raw(), "DetID")) {
     MACH3LOG_ERROR("ID not defined in {}, please add this!", SampleManager->GetFileName());
     throw MaCh3Exception(__FILE__, __LINE__);
   }
+  SampleDetID = SampleManager->raw()["DetID"].as<int>();
   
-  if (CheckNodeExists(SampleManager->raw(), "NuOsc", "NuOscConfigFile")) {
-    NuOscillatorConfigFile = SampleManager->raw()["NuOsc"]["NuOscConfigFile"].as<std::string>();
-  } else {
+  if (!CheckNodeExists(SampleManager->raw(), "NuOsc", "NuOscConfigFile")) {
     MACH3LOG_ERROR("NuOsc::NuOscConfigFile is not defined in {}, please add this!", SampleManager->GetFileName());
     throw MaCh3Exception(__FILE__, __LINE__);
   }
+  NuOscillatorConfigFile = SampleManager->raw()["NuOsc"]["NuOscConfigFile"].as<std::string>();
   
   for (int i=0;i<nSamples;i++) {
     struct FarDetectorCoreInfo obj = FarDetectorCoreInfo();

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -1342,7 +1342,7 @@ void samplePDFFDBase::SetupNuOscillator() {
       //DB Atmospheric only part
       if (MCSamples[iSample].rw_truecz.size() > 0 && int(MCSamples[iSample].rw_truecz.size()) == MCSamples[iSample].nEvents) { //Can only happen if truecz has been initialised within the experiment specific code
 	std::vector<M3::float_t> CosineZArray;
-	for (int iEvent=0;iEvent<int(MCSamples[iSample].nEvents);iEvent++) {
+	for (int iEvent=0;iEvent<MCSamples[iSample].nEvents;iEvent++) {
 	  //DB Remove NC events from the arrays which are handed to the NuOscillator objects
 	  if (!MCSamples[iSample].isNC[iEvent]) {
 	    CosineZArray.push_back(M3::float_t(*(MCSamples[iSample].rw_truecz[iEvent])));

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -57,7 +57,8 @@ public:
   ///  @brief including Dan's magic NuOscillator
   void SetupNuOscillator();
 
-  virtual void setupSplines(fdmc_base *, const char *, int , int ){};
+  virtual void setupSplines(FarDetectorCoreInfo *, const char *, int , int ){};
+
   void ReadSampleConfig();
 
   int getNMCSamples() {return int(MCSamples.size());}
@@ -105,7 +106,7 @@ public:
   /// @brief Function which does a lot of the lifting regarding the workflow in creating different MC objects
   void Initialise();
   
-  splineFDBase *splineFile;
+  std::unique_ptr<splineFDBase> SplineHandler;
   //===============================================================================
   void fillSplineBins();
 
@@ -192,7 +193,7 @@ public:
 
   //===============================================================================
   //MC variables
-  std::vector<fdmc_base> MCSamples;
+  std::vector<FarDetectorCoreInfo> MCSamples;
   //===============================================================================
 
   //===============================================================================

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -14,7 +14,7 @@
 #include "covariance/covarianceOsc.h"
 
 #include "samplePDF/samplePDFBase.h"
-#include "samplePDF/FDMCStruct.h"
+#include "samplePDF/FarDetectorCoreInfoStruct.h"
 
 //forward declare so we don't bleed NuOscillator headers
 class OscillatorBase;
@@ -106,6 +106,7 @@ public:
   /// @brief Function which does a lot of the lifting regarding the workflow in creating different MC objects
   void Initialise();
   
+  /// @brief Contains all your binned splines and handles the setup and the returning of weights from spline evaluations
   std::unique_ptr<splineFDBase> SplineHandler;
   //===============================================================================
   void fillSplineBins();


### PR DESCRIPTION
# Pull request description
Mainly tidying up some bits of code especially the FarDetectorStruct class. Removing allocation of lots of arrays on the heap to use std::vectors instead. Also a general bit of tidy up here and there.

## Changes or fixes
Rename of FDMC struct to FarDetectorStruct. Also moving many of the members of this struct to be vectors. Small clean up of splineFDBase class.

## Examples
e.g. int* modes = new int[nEvents]; -> std::vector<int> modes; modes.resize(nEvents);