### PR TITLE
Adds an MD5 to the manager

### DIFF
--- a/manager/manager.cpp
+++ b/manager/manager.cpp
@@ -1,4 +1,5 @@
 #include "TFile.h"
+#include "TMD5.h"
 
 #include "manager/manager.h"
 
@@ -7,11 +8,22 @@ manager::manager(std::string const &filename)
     : config(YAML::LoadFile(filename)) {
 // *************************
 
+  TMD5 config_digest;
+  std::stringstream config_stream;
+  config_stream << config;
+  std::vector<UChar_t> config_bytes;
+  for(char c : config_stream.str()){
+    config_bytes.push_back(UChar_t(c));
+  }
+  config_digest.Update(config_bytes.data(), UInt_t(config_bytes.size()));
+  config_digest.Final();
+  md5 = config_digest.AsString();
+
   FileName = filename;
   SetMaCh3LoggerFormat();
   MaCh3Utils::MaCh3Welcome();
 
-  MACH3LOG_INFO("Setting config to be: {}", filename);
+  MACH3LOG_INFO("Setting config to be: {} (MD5: {})", filename, md5);
 
   MACH3LOG_INFO("Config is now: ");
   MaCh3Utils::PrintConfig(config);

--- a/manager/manager.h
+++ b/manager/manager.h
@@ -49,6 +49,8 @@ public:
     OverrideConfig(config, std::forward<Args>(args)...);
   }
 
+  std::string md5;
+
 private:
   /// The YAML node containing the configuration data.
   YAML::Node config;


### PR DESCRIPTION
# Pull request description

This md5 isn't used for anything yet, and only parses the YAML file passed to the manager (not any subsequent files that are loaded), but as a proof of concept for hashing configurations, it works. Relies on ROOT's TMD5.

## Changes or fixes


## Examples

```[manager.cpp][info] Setting config to be: Inputs/SamplePDF_Tutorial.yaml (MD5: a0a7a6c391bd097f3b4e267b2078e681)```