### PR TITLE
Fix CUDA compilation

### DIFF
--- a/.github/workflows/CIValidations.yml
+++ b/.github/workflows/CIValidations.yml
@@ -75,7 +75,7 @@ jobs:
         cd MaCh3Validations
         mkdir build
         cd build
-        cmake ../ -DMaCh3_Branch=${{ github.head_ref }} -DMaCh3Tutorial_UNITTESTS_ENABLED=TRUE -DCUDAProb3_ENABLED=TRUE
+        cmake ../ -DMaCh3_Branch=${{ github.head_ref }} -DMaCh3Tutorial_UNITTESTS_ENABLED=TRUE -DCUDAProb3Linear_ENABLED=TRUE
 
     - name: Build MaCh3 Validations
       run: |

--- a/.github/workflows/CIValidations.yml
+++ b/.github/workflows/CIValidations.yml
@@ -75,7 +75,7 @@ jobs:
         cd MaCh3Validations
         mkdir build
         cd build
-        cmake ../ -DMaCh3_Branch=${{ github.head_ref }} -DMaCh3Tutorial_UNITTESTS_ENABLED=TRUE -DCUDAProb3_ENABLED=ON
+        cmake ../ -DMaCh3_Branch=${{ github.head_ref }} -DMaCh3Tutorial_UNITTESTS_ENABLED=TRUE -DCUDAProb3_ENABLED=TRUE
 
     - name: Build MaCh3 Validations
       run: |

--- a/.github/workflows/CIValidations.yml
+++ b/.github/workflows/CIValidations.yml
@@ -75,7 +75,7 @@ jobs:
         cd MaCh3Validations
         mkdir build
         cd build
-        cmake ../ -DMaCh3_Branch=${{ github.head_ref }} -DMaCh3Tutorial_UNITTESTS_ENABLED=TRUE
+        cmake ../ -DMaCh3_Branch=${{ github.head_ref }} -DMaCh3Tutorial_UNITTESTS_ENABLED=TRUE -DCUDAProb3_ENABLED=ON
 
     - name: Build MaCh3 Validations
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ option(MaCh3_PYTHON_ENABLED "Whether to build MaCh3 python bindings" OFF)
 option(MaCh3_WERROR_ENABLED "Whether to build MaCh3 with heightened compiler pedancy" ON)
 
 # Try to find CUDA
+add_library(MaCh3CompileDefinitions INTERFACE)
+
 find_package(CUDAToolkit QUIET)
 # Check if CUDA was found
 if(CUDAToolkit_FOUND AND NOT(USE_CPU))
@@ -43,7 +45,6 @@ LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/Modules)
 include(MaCh3Utils)
 
 ################################## Dependencies ################################
-add_library(MaCh3CompileDefinitions INTERFACE)
 include(MaCh3Dependencies)
 
 ############################  C++ Compiler  ####################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,6 @@ target_compile_options(MaCh3Warnings INTERFACE
   -Wnull-dereference     # Warn if a null dereference is detected (only in GCC >= 6.0)
   -Wold-style-cast       # Warn for c-style casts
   -Wconversion           # Warn on type conversions that may lose data
-  # -Werror                # Treat Warnings as Errors
 )
 # KS Some compiler options are only available in GCC, in case we move to other compilers we will have to expand this
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ target_compile_options(MaCh3Warnings INTERFACE
   -Wnull-dereference     # Warn if a null dereference is detected (only in GCC >= 6.0)
   -Wold-style-cast       # Warn for c-style casts
   -Wconversion           # Warn on type conversions that may lose data
-  -Werror                # Treat Warnings as Errors
+  # -Werror                # Treat Warnings as Errors
 )
 # KS Some compiler options are only available in GCC, in case we move to other compilers we will have to expand this
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Following neutrino oscillation calculators are available:
 | Prob3++Linear    | CPU        | Beam       |            |
 | NuFastLinear     | CPU        | Beam       | [Ref](https://doi.org/10.48550/arXiv.2405.02400)        |
 
-If nothing is specified in cmake build then CUDAProb3Linear will be used. To control which oscillation calculators you want to use here is syntax:
+If nothing is specified in cmake build then NuFastLinear_ENABLED will be used. To control which oscillation calculators you want to use here is syntax:
 
 ```bash
 cmake ../ -DCUDAProb3Linear_ENABLED=ON -DCUDAProb3_ENABLED=ON -DProbGPULinear_ENABLED=ON -DProb3ppLinear_ENABLED=ON -DNuFastLinear_ENABLED=ON

--- a/cmake/Modules/CUDASamples.cmake
+++ b/cmake/Modules/CUDASamples.cmake
@@ -30,7 +30,7 @@ if(NOT CUDASAMPLES_FOUND)
 endif()
 
 cmessage(STATUS "Using the following CUDA samples paths: ${CMAKE_CUDA_SAMPLES_PATH}")
-target_include_directories(MaCh3CompilerOptions INTERFACE
+target_include_directories(MaCh3CompileDefinitions INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CUDA_SAMPLES_PATH}>"
     "$<INSTALL_INTERFACE:include>"
 )

--- a/cmake/Modules/CUDASetup.cmake
+++ b/cmake/Modules/CUDASetup.cmake
@@ -47,7 +47,7 @@ string(REPLACE ";" " " CUDA_ARCHITECTURES_STR "${CMAKE_CUDA_ARCHITECTURES}")
 cmessage(STATUS "Using following CUDA architectures: ${CUDA_ARCHITECTURES_STR}")
 
 if(NOT MaCh3_DEBUG_ENABLED)
-    target_compile_options(MaCh3CompilerOptions INTERFACE
+    target_compile_options(MaCh3CompileDefinitions INTERFACE
         "$<$<COMPILE_LANGUAGE:CUDA>:-prec-sqrt=false;-use_fast_math;-O3;-Werror;cross-execution-space-call;-w>"
         "$<$<COMPILE_LANGUAGE:CUDA>:-Xptxas=-allow-expensive-optimizations=true;-Xptxas=-fmad=true;-Xptxas=-O3;>"
         "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-fpic;-Xcompiler=-O3;-Xcompiler=-Wall;-Xcompiler=-Wextra;-Xcompiler=-Werror;-Xcompiler=-Wno-error=unused-parameter>"
@@ -55,15 +55,15 @@ if(NOT MaCh3_DEBUG_ENABLED)
 else()
 #CW: -g and -G for debug flags to use cuda-gdb; slows stuff A LOT
 #-pxtas-options=-v, -maxregcount=N
-    target_compile_options(MaCh3CompilerOptions INTERFACE
+    target_compile_options(MaCh3CompileDefinitions INTERFACE
         "$<$<COMPILE_LANGUAGE:CUDA>:-prec-sqrt=false;-use_fast_math;-Werror;cross-execution-space-call;-w>"
         "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-g;>"
         "$<$<COMPILE_LANGUAGE:CUDA>:-Xptxas=-dlcm=ca;-Xptxas=-warn-lmem-usage;-Xptxas=-warn-spills;-Xptxas=-v;-Xcompiler=-Wall;-Xcompiler=-Wextra;-Xcompiler=-Werror;-Xcompiler=-Wno-error=unused-parameter>"
     )
 
-    target_compile_definitions(MaCh3CompilerOptions INTERFACE "$<$<COMPILE_LANGUAGE:CUDA>:CUDA_ERROR_CHECK>")
+    target_compile_definitions(MaCh3CompileDefinitions INTERFACE "$<$<COMPILE_LANGUAGE:CUDA>:CUDA_ERROR_CHECK>")
 endif()
-target_include_directories(MaCh3CompilerOptions INTERFACE ${CUDAToolkit_INCLUDE_DIRS})
+target_include_directories(MaCh3CompileDefinitions INTERFACE ${CUDAToolkit_INCLUDE_DIRS})
 
 if(MaCh3_DEBUG_ENABLED)
   include(${CMAKE_CURRENT_LIST_DIR}/CUDASamples.cmake)
@@ -76,7 +76,7 @@ if(NOT DEFINED NSplines_GPU)
 endif()
 
 # Pass NSplines_GPU as a preprocessor definition to the compiler
-target_compile_definitions(MaCh3CompilerOptions INTERFACE NSplines_GPU=${NSplines_GPU})
+target_compile_definitions(MaCh3CompileDefinitions INTERFACE NSplines_GPU=${NSplines_GPU})
 
 cmessage(STATUS "Using \"${NSplines_GPU}\" for GPU EventByEvent Splines")
 

--- a/cmake/Modules/NuOscillatorSetup.cmake
+++ b/cmake/Modules/NuOscillatorSetup.cmake
@@ -12,8 +12,8 @@ if (NOT CUDAProb3Linear_ENABLED AND
     NOT CUDAProb3_ENABLED AND
     NOT ProbGPULinear_ENABLED AND
     NOT Prob3ppLinear_ENABLED AND
-    NOT NuFastLinear_ENABLED)
-    set(CUDAProb3Linear_ENABLED TRUE)
+    NOT CUDAProb3Linear_ENABLED)
+    set(NuFastLinear_ENABLED TRUE)
 endif()
 
 #KS: Save which oscillators are being used

--- a/manager/gpuUtils.cuh
+++ b/manager/gpuUtils.cuh
@@ -1,12 +1,16 @@
 #pragma once
 
+
 // C i/o  for printf and others
 #include <stdio.h>
 #include <vector>
 
 // CUDA specifics
-
+// Because CUDA is cuda, need to make sure we don't check C-style floats...
+#pragma GCC diagnostic push
+#pragma GCC diagnostics ignored "-Wold-style-cast"
 #include <cuda_runtime.h>
+#pragma GCC diagnostic pop
 
 #ifdef CUDA_ERROR_CHECK
 #include <helper_functions.h>


### PR DESCRIPTION
# Pull request description
Patch to ensure MaCh3 compiles on GPU again

## Changes or fixes

- Changes remaining `MaCh3CompilerOptions` to `MaCh3CompileDefinitions` in `CUDASamples.cmake` and `CUDASetup.cmake`

- Changes to using `NuFastLinear` by default as `CUDAProb3` will no longer compile

- Ignores errors on` #include <cuda_runtime.h>` as it still has C-style casts https://github.com/mach3-software/MaCh3/blob/f511bc15f8adc8c3d7791c90230eeb5a6a6fca68/manager/gpuUtils.cuh#L10-L13
