### PR TITLE
Fix code scanning alert no. 2135: Multiplication result converted to larger type

### DIFF
--- a/Diagnostics/RHat.cpp
+++ b/Diagnostics/RHat.cpp
@@ -327,7 +327,7 @@ void PrepareChains() {
   for(int j = 0; j < nDraw; j++)
   {
     MedianArr[j] = 0.;
-    std::vector<double> TempDraws((size_t)Ntoys * Nchains);
+    std::vector<double> TempDraws(static_cast<size_t>(Ntoys) * Nchains);
     for(int m = 0; m < Nchains; m++)
     {
       for(int i = 0; i < Ntoys; i++)

--- a/Diagnostics/RHat.cpp
+++ b/Diagnostics/RHat.cpp
@@ -327,7 +327,7 @@ void PrepareChains() {
   for(int j = 0; j < nDraw; j++)
   {
     MedianArr[j] = 0.;
-    std::vector<double> TempDraws(Ntoys * Nchains);
+    std::vector<double> TempDraws((size_t)Ntoys * Nchains);
     for(int m = 0; m < Nchains; m++)
     {
       for(int i = 0; i < Ntoys; i++)


### PR DESCRIPTION
Fixes [https://github.com/mach3-software/MaCh3/security/code-scanning/2135](https://github.com/mach3-software/MaCh3/security/code-scanning/2135)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. We can achieve this by casting one of the operands to `size_t` before performing the multiplication. This will promote the multiplication to `size_t`, which has a larger range than `int`.

- Change the multiplication `Ntoys * Nchains` to `(size_t)Ntoys * Nchains` to ensure the multiplication is done using `size_t`.
- This change should be made on line 330 in the file `Diagnostics/RHat.cpp`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
