### PR TITLE
Fix code scanning alert no. 2136: Multiplication result converted to larger type

### DIFF
--- a/Diagnostics/RHat.cpp
+++ b/Diagnostics/RHat.cpp
@@ -301,7 +301,7 @@ void PrepareChains() {
 
       // Output some info for the user
       if (Ntoys > 10 && i % (Ntoys/10) == 0) {
-        MaCh3Utils::PrintProgressBar(i+m*Ntoys, Ntoys*Nchains);
+        MaCh3Utils::PrintProgressBar(i+m*Ntoys, static_cast<Long64_t>(Ntoys)*Nchains);
         MACH3LOG_DEBUG("Getting random entry {}", entry);
       }
 


### PR DESCRIPTION
Fixes [https://github.com/mach3-software/MaCh3/security/code-scanning/2136](https://github.com/mach3-software/MaCh3/security/code-scanning/2136)

To fix the problem, we need to ensure that the multiplication is performed using the larger integer type (`Long64_t`) to avoid overflow. This can be achieved by casting one of the operands to `Long64_t` before performing the multiplication. This way, the multiplication will be done using the larger type, and the result will be correctly stored in the larger type.

Specifically, we will cast `Ntoys` to `Long64_t` before multiplying it by `Nchains` on line 304. This change will ensure that the multiplication is performed using `Long64_t`, preventing any overflow issues.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
