### PR TITLE
More fixes to werror

### DIFF
--- a/mcmc/MCMCProcessor.cpp
+++ b/mcmc/MCMCProcessor.cpp
@@ -3158,7 +3158,7 @@ void MCMCProcessor::ParameterEvolution(const std::vector<std::string>& Names,
     // ROOT won't overwrite gifs so we need to delete the file if it's there already
     int ret = system(fmt::format("rm {}.gif",Names[k]).c_str());
     if (ret != 0){
-      MACH3LOG_WARN("Error: system call to copy file failed with code {}", ret);
+      MACH3LOG_WARN("Error: system call to delete {} failed with code {}", Names[k], ret);
     }
     // This holds the posterior density
     const double maxi = Chain->GetMaximum(BranchNames[ParamNo]);

--- a/mcmc/MCMCProcessor.cpp
+++ b/mcmc/MCMCProcessor.cpp
@@ -3156,8 +3156,10 @@ void MCMCProcessor::ParameterEvolution(const std::vector<std::string>& Names,
 
     const int IntervalsSize = nSteps/NIntervals[k];
     // ROOT won't overwrite gifs so we need to delete the file if it's there already
-    system(fmt::format("rm {}.gif",Names[k]).c_str());
-
+    int ret = system(fmt::format("rm {}.gif",Names[k]).c_str());
+    if (ret != 0){
+      MACH3LOG_WARN("Error: system call to copy file failed with code {}", ret);
+    }
     // This holds the posterior density
     const double maxi = Chain->GetMaximum(BranchNames[ParamNo]);
     const double mini = Chain->GetMinimum(BranchNames[ParamNo]);

--- a/mcmc/PSO.h
+++ b/mcmc/PSO.h
@@ -98,7 +98,10 @@ class PSO : public LikelihoodFit {
     double swarmIterate();
 
     std::vector<double> vector_multiply(std::vector<double> velocity, double mul){
-      transform(velocity.begin(),velocity.end(),velocity.begin(),std::bind1st(std::multiplies<double>(),mul));
+      // std::bind1st deprecated since C++11, removed in c++17
+      // transform(velocity.begin(),velocity.end(),velocity.begin(),std::bind1st(std::multiplies<double>(),mul));
+      std::transform(velocity.begin(), velocity.end(), velocity.begin(),
+                      std::bind(std::multiplies<double>(), mul, std::placeholders::_1));
       return velocity;
     };
 


### PR DESCRIPTION
# Pull request description
Fixes to compile with werror flag enabled

## Changes or fixes
 - PSO used std::bind1st which is deprecated, now has std::bind implementation
 - makes sure system flags warning (to get around unused variable!)
