### PR TITLE
Fix py ma ch3 pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,17 @@ Some functionalities rely on setting `Env{MACH3}` which should point to path exp
 
 ## Python
 
-MaCh3 can be compiled with a python interface by specifying the cmake option
+MaCh3 has an optional python interface (pyMaCh3) which provides much of the same functionality as the c++ interface 
+(see [here](https://mach3-software.github.io/MaCh3/pyMaCh3/mainpage.html) for documentation).
+
+You can tell the build system to set up the pyMaCh3 interface by specifying 
+
 ```bash
 cmake ../ -DMaCh3_PYTHON_ENABLED=ON
 make && make install
 ```
 
-Currently the python module only contains an interface to the plotting library (see [here](https://github.com/mach3-software/MaCh3/blob/develop/plotting/README.md#python) for more information on how to use it)
-
+when building
 
 ### Building with Pip
 
@@ -79,7 +82,7 @@ Additionally, you can build just the Python module by doing:
 ```bash
 pip install -t <install location> .
 ```
-The -t option specifies an install location which can be useful if you are on a computing cluster and don't have write access to the default install location. If you specify a non-standard location you will need to add it to your `PYTHONPATH` as above so that python can find the module.
+The (optional) -t option specifies an install location which can be useful if you are on a computing cluster and don't have write access to the default install location. If you specify a non-standard location you will need to add it to your `PYTHONPATH` as above so that python can find the module.
 
 ## Multithreading
 MaCh3 quite heavily relies on Multithreading, it is turned on by default. If for debugging purposes you would like to turn it off please use

--- a/cmake/Templates/setup.MaCh3.sh.in
+++ b/cmake/Templates/setup.MaCh3.sh.in
@@ -85,7 +85,7 @@ add_to_PATH ${MaCh3_ROOT}/bin
 add_to_LD_LIBRARY_PATH ${MaCh3_ROOT}/lib
 
 if test -d ${MaCh3_ROOT}/pyMaCh3; then
-  add_to_PYTHONPATH ${MaCh3_ROOT}/pyMaCh3
+  add_to_PYTHONPATH ${MaCh3_ROOT}
 fi
 
 unset SETUPDIR

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,7 +2,7 @@
 ################################# pybind11 stuff ##################################
 ## EM: make a module target out of all the python*Module.cpp files (currently just one...)
 pybind11_add_module(
-  pyMaCh3 MODULE
+  _pyMaCh3 MODULE
   pyMaCh3.cpp
   plotting.cpp
   fitter.cpp
@@ -13,7 +13,8 @@ pybind11_add_module(
 )
 ## EM: only works with code compiled with -fPIC enabled.. I think this flag can make things slightly slower
 ## so would be good to find a way around this.
-set_property( TARGET pyMaCh3 PROPERTY POSITION_INDEPENDENT_CODE ON )
-target_link_libraries( pyMaCh3 PUBLIC MaCh3::All )
-target_link_libraries( pyMaCh3 PRIVATE MaCh3Warnings )
-install( TARGETS pyMaCh3 DESTINATION pyMaCh3/)
+set_property( TARGET _pyMaCh3 PROPERTY POSITION_INDEPENDENT_CODE ON )
+target_link_libraries( _pyMaCh3 PUBLIC MaCh3::All )
+target_link_libraries( _pyMaCh3 PRIVATE MaCh3Warnings )
+install( DIRECTORY pyMaCh3 DESTINATION ./)
+install( TARGETS _pyMaCh3 DESTINATION pyMaCh3/)

--- a/python/pyMaCh3.cpp
+++ b/python/pyMaCh3.cpp
@@ -10,7 +10,7 @@ void initManager(py::module &); // <- defined in python/manager.cpp
 void initCovariance(py::module &); // <- defined in python/covariance.cpp
 void initSplines(py::module &); // <- defined in python/splines.cpp
 
-PYBIND11_MODULE( pyMaCh3, m ) {
+PYBIND11_MODULE( _pyMaCh3, m ) {
     initPlotting(m);
     initFitter(m);
     initSamplePDF(m);

--- a/python/pyMaCh3/__init__.py
+++ b/python/pyMaCh3/__init__.py
@@ -1,0 +1,3 @@
+from ._pyMaCh3 import __doc__, fitter, manager, plotting, sample_pdf, splines
+
+__all__ = ["__doc__", "fitter", "manager", "plotting", "sample_pdf", "splines"]

--- a/python/pyMaCh3/fitter.py
+++ b/python/pyMaCh3/fitter.py
@@ -1,0 +1,2 @@
+from ._pyMaCh3 import fitter
+from ._pyMaCh3.fitter import *

--- a/python/pyMaCh3/manager.py
+++ b/python/pyMaCh3/manager.py
@@ -1,0 +1,2 @@
+from ._pyMaCh3 import manager
+from ._pyMaCh3.manager import *

--- a/python/pyMaCh3/plotting.py
+++ b/python/pyMaCh3/plotting.py
@@ -1,0 +1,2 @@
+from ._pyMaCh3 import plotting
+from ._pyMaCh3.plotting import *

--- a/python/pyMaCh3/samplePDF.py
+++ b/python/pyMaCh3/samplePDF.py
@@ -1,0 +1,2 @@
+from ._pyMaCh3 import sample_pdf
+from ._pyMaCh3.sample_pdf import *

--- a/python/pyMaCh3/splines.py
+++ b/python/pyMaCh3/splines.py
@@ -1,0 +1,2 @@
+from ._pyMaCh3 import splines
+from ._pyMaCh3.splines import *


### PR DESCRIPTION
# Pull request description

Previously when pip installing, python was unable to find the sub-modules of pyMaCh3. Have now restructured the python directory to be more similar to a "normal" python only module so that it can now find it. ( This restructure also makes it easier to add any python only code in future if that's something we ever want to do ). the module now works when installing normally and with pip.

## Changes or fixes

- restructured python directory
- update readme a bit 


## Examples
