### PR TITLE
bugfix: Now use M3::float_t type in more places, tidy: Removing duplicated Unity values

### DIFF
--- a/.github/workflows/PRtittleChecker.yml
+++ b/.github/workflows/PRtittleChecker.yml
@@ -8,9 +8,6 @@ on:
       - synchronize
       - labeled
       - unlabeled
-  pull_request:
-    branches:
-      - develop
   workflow_dispatch:  # This allows the workflow to be triggered manually
 
 jobs:

--- a/samplePDF/FarDetectorCoreInfoStruct.h
+++ b/samplePDF/FarDetectorCoreInfoStruct.h
@@ -1,4 +1,7 @@
 #pragma once
+#include <vector>
+#include <string>
+#include "samplePDF/Structs.h"
 
 /// @brief constructors are same for all three so put in here
 struct FarDetectorCoreInfo {
@@ -30,21 +33,15 @@ struct FarDetectorCoreInfo {
   /// xsec bins
   std::vector< std::vector< int > > xsec_norms_bins;
 
-  /// DB Speedup bits
-  double Unity;
-  float Unity_F;
-  int Unity_Int;
-  double dummy_value = -999;
-
   std::vector<int> nxsec_norm_pointers;
   std::vector<std::vector<const double*>> xsec_norm_pointers;
 
   std::vector<int> nxsec_spline_pointers;
-  std::vector<std::vector<const double*>> xsec_spline_pointers;
+  std::vector<std::vector<const M3::float_t*>> xsec_spline_pointers;
 
   std::vector<int> ntotal_weight_pointers;
-  std::vector<std::vector<const double*>> total_weight_pointers;
-  std::vector<double> total_w;
+  std::vector<std::vector<const M3::float_t*>> total_weight_pointers;
+  std::vector<M3::float_t> total_w;
 
   std::vector<int> XBin;
   std::vector<int> YBin;
@@ -62,5 +59,5 @@ struct FarDetectorCoreInfo {
   std::vector<double*> mode;
 
   std::vector<const M3::float_t*> osc_w_pointer;
-  std::vector<double> xsec_w;
+  std::vector<M3::float_t> xsec_w;
 };

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -1531,9 +1531,9 @@ void samplePDFFDBase::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
   fdobj->signal = false;
   
   int nEvents = fdobj->nEvents;
-  fdobj->x_var.resize(nEvents, &fdobj->Unity);
-  fdobj->y_var.resize(nEvents, &fdobj->Unity);
-  fdobj->rw_etru.resize(nEvents, &fdobj->Unity);
+  fdobj->x_var.resize(nEvents, &Unity);
+  fdobj->y_var.resize(nEvents, &Unity);
+  fdobj->rw_etru.resize(nEvents, &Unity);
   fdobj->XBin.resize(nEvents, -1);
   fdobj->YBin.resize(nEvents, -1);
   fdobj->NomXBin.resize(nEvents, -1);
@@ -1542,7 +1542,7 @@ void samplePDFFDBase::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
   fdobj->rw_lower_lower_xbinedge.resize(nEvents, -1);
   fdobj->rw_upper_xbinedge.resize(nEvents, -1);
   fdobj->rw_upper_upper_xbinedge.resize(nEvents, -1);
-  fdobj->mode.resize(nEvents, &fdobj->Unity);
+  fdobj->mode.resize(nEvents, &Unity);
   fdobj->nxsec_norm_pointers.resize(nEvents);
   fdobj->xsec_norm_pointers.resize(nEvents);
   fdobj->xsec_norms_bins.resize(nEvents);
@@ -1556,9 +1556,9 @@ void samplePDFFDBase::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
   fdobj->total_weight_pointers.resize(nEvents);
   fdobj->Target.resize(nEvents, 0);
 #ifdef _LOW_MEMORY_STRUCTS_
-  fdobj->osc_w_pointer.resize(nEvents, &fdobj->Unity_F);
+  fdobj->osc_w_pointer.resize(nEvents, &Unity_F);
 #else
-  fdobj->osc_w_pointer.resize(nEvents, &fdobj->Unity); 
+  fdobj->osc_w_pointer.resize(nEvents, &Unity); 
 #endif
   fdobj->SampleDetID = -1;
 

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -585,10 +585,10 @@ void samplePDFFDBase::fillArray_MP()
           continue;
         }
 
-        double splineweight = 1.0;
-        double normweight = 1.0;
-        double funcweight = 1.0;
-        double totalweight = 1.0;
+        M3::float_t splineweight = 1.0;
+        M3::float_t normweight = 1.0;
+        M3::float_t funcweight = 1.0;
+        M3::float_t totalweight = 1.0;
 
         //DB SKDet Syst
         //As weights were skdet::fParProp, and we use the non-shifted erec, we might as well cache the corresponding fParProp index for each event and the pointer to it
@@ -720,10 +720,10 @@ void samplePDFFDBase::ResetHistograms() {
 
 // ***************************************************************************
 // Calculate the spline weight for one event
-double samplePDFFDBase::CalcXsecWeightSpline(const int iSample, const int iEvent) {
+M3::float_t samplePDFFDBase::CalcXsecWeightSpline(const int iSample, const int iEvent) {
 // ***************************************************************************
 
-  double xsecw = 1.0;
+  M3::float_t xsecw = 1.0;
   //DB Xsec syst
   //Loop over stored spline pointers
   for (int iSpline=0;iSpline<MCSamples[iSample].nxsec_spline_pointers[iEvent];iSpline++) {
@@ -734,14 +734,17 @@ double samplePDFFDBase::CalcXsecWeightSpline(const int iSample, const int iEvent
 
 // ***************************************************************************
 // Calculate the normalisation weight for one event
-double samplePDFFDBase::CalcXsecWeightNorm(const int iSample, const int iEvent) {
+M3::float_t samplePDFFDBase::CalcXsecWeightNorm(const int iSample, const int iEvent) {
 // ***************************************************************************
 
-  double xsecw = 1.0;
+  M3::float_t xsecw = 1.0;
   //Loop over stored normalisation and function pointers
   for (int iParam = 0;iParam < MCSamples[iSample].nxsec_norm_pointers[iEvent]; iParam++)
   {
-    xsecw *= *(MCSamples[iSample].xsec_norm_pointers[iEvent][iParam]);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+    xsecw *= static_cast<M3::float_t>(*(MCSamples[iSample].xsec_norm_pointers[iEvent][iParam]));
+#pragma GCC diagnostic pop
     #ifdef DEBUG
     if (TMath::IsNaN(xsecw)) std::cout << "iParam=" << iParam << "xsecweight=nan from norms" << std::endl;
     #endif
@@ -1060,8 +1063,8 @@ void samplePDFFDBase::FindNominalBinAndEdges1D() {
       
       //Set x_var and y_var values based on XVarStr and YVarStr
       MCSamples[mc_i].x_var[event_i] = GetPointerToKinematicParameter(XVarStr, mc_i, event_i);
-      //Give y)_var a dummy value
-      MCSamples[mc_i].y_var[event_i] = &(MCSamples[mc_i].dummy_value);
+      //Give y_var _BAD_DOUBLE_ value for the 1D case since this won't be used
+      MCSamples[mc_i].y_var[event_i] = &(_BAD_DOUBLE_);
       int bin = _hPDF1D->FindBin(*(MCSamples[mc_i].x_var[event_i]));
       
       double low_lower_edge = _DEFAULT_RETURN_VAL_;
@@ -1432,8 +1435,8 @@ void samplePDFFDBase::SetupNuOscillator() {
   delete OscillFactory;
 }
 
-double samplePDFFDBase::GetEventWeight(int iSample, int iEntry) {
-  double totalweight = 1.0;
+M3::float_t samplePDFFDBase::GetEventWeight(int iSample, int iEntry) {
+  M3::float_t totalweight = 1.0;
   #ifdef MULTITHREAD
   #pragma omp simd
   #endif
@@ -1526,9 +1529,6 @@ void samplePDFFDBase::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
   
   fdobj->nEvents = nEvents_;
   fdobj->signal = false;
-  fdobj->Unity = 1.;
-  fdobj->Unity_Int = 1.;
-
   
   int nEvents = fdobj->nEvents;
   fdobj->x_var.resize(nEvents, &fdobj->Unity);

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -39,7 +39,7 @@ public:
   //===============================================================================
 
   void reweight();
-  double GetEventWeight(int iSample, int iEntry);
+  M3::float_t GetEventWeight(int iSample, int iEntry);
 
   ///  @brief including Dan's magic NuOscillator
   void SetupNuOscillator();
@@ -131,11 +131,11 @@ public:
   /// @brief Check whether a normalisation systematic affects an event or not
   void CalcXsecNormsBins(int iSample);
   /// @brief Calculate the spline weight for a given event
-  double CalcXsecWeightSpline(const int iSample, const int iEvent);
+  M3::float_t CalcXsecWeightSpline(const int iSample, const int iEvent);
   /// @brief Calculate the norm weight for a given event
-  double CalcXsecWeightNorm(const int iSample, const int iEvent);
+  M3::float_t CalcXsecWeightNorm(const int iSample, const int iEvent);
   /// @brief Virtual so this can be over-riden in an experiment derived class
-  virtual double CalcXsecWeightFunc(int iSample, int iEvent){(void)iSample; (void)iEvent; return 1.0;};
+  virtual M3::float_t CalcXsecWeightFunc(int iSample, int iEvent){(void)iSample; (void)iEvent; return 1.0;};
 
   virtual double ReturnKinematicParameter(std::string KinematicParamter, int iSample, int iEvent) = 0;
   virtual double ReturnKinematicParameter(double KinematicVariable, int iSample, int iEvent) = 0;

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -240,6 +240,8 @@ public:
   float Unity_F = 1.;
   float Zero_F = 0.;
 
+  int Unity_Int = 1;
+
   std::vector<std::string> mc_files;
   std::vector<std::string> spline_files;
   std::vector<int> sample_vecno;

--- a/splines/splineFDBase.h
+++ b/splines/splineFDBase.h
@@ -57,7 +57,7 @@ class splineFDBase : public SplineBase {
 	void PrintArrayDetails(std::string SampleName);
 	void PrintArrayDimension();
 
-	const double* retPointer(int sample, int oscchan, int syst, int mode, int var1bin, int var2bin, int var3bin){
+	const M3::float_t* retPointer(int sample, int oscchan, int syst, int mode, int var1bin, int var2bin, int var3bin){
 	  int index = indexvec[sample][oscchan][syst][mode][var1bin][var2bin][var3bin];
 	  return &weightvec_Monolith[index];
 	}
@@ -120,6 +120,6 @@ class splineFDBase : public SplineBase {
 	M3::float_t *xcoeff_arr;    //x coefficients for each spline
 	M3::float_t *manycoeff_arr; //ybcd coefficients for each spline
 
-	std::vector<double> weightvec_Monolith;
+	std::vector<M3::float_t> weightvec_Monolith;
 	std::vector<int> uniquesplinevec_Monolith;
 };


### PR DESCRIPTION
# Pull request description
Makes the option to use the low memory structs more reliable. Any function in samplePDFFDBase or splineFDBase now is of type M3::float_t so it will change depending on whether _LOW_MEMORY_STRUCTS_ is defined.

Also a small tidy up to remove some duplicated definitions of Unity.

## Changes or fixes
- fix: Now use M3::float_t type in various functions where we want the weight to be a float or a double.
- tidy: Removing Unity and dummy value definition from the FarDetectorCoreInfo struct since there is also a definition in samplePDFFDBase.h

## Examples
![Screenshot_20241211_150411](https://github.com/user-attachments/assets/e555e224-78e2-424a-8fde-3fb8c67d7aa9)
