### PR TITLE
bugfix: Fix flag proapgation to NuOsc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ set(MaCh3_VERSION ${PROJECT_VERSION})
 option(USE_CPU "Whether to *only* use the CPU (i.e. no GPU)" OFF)
 option(MaCh3_PYTHON_ENABLED "Whether to build MaCh3 python bindings" OFF)
 option(MaCh3_WERROR_ENABLED "Whether to build MaCh3 with heightened compiler pedancy" ON)
+option(MaCh3_LOW_MEMORY_STRUCTS_ENABLED "This will use float/short string for many structures" OFF)
 
-# Try to find CUDA
 add_library(MaCh3CompileDefinitions INTERFACE)
 #Create a seperate target for GPU compiler options
 #if GPU is not enabled nothing will be added to this and it will be empty
@@ -177,13 +177,9 @@ if(MaCh3_GPU_ENABLED)
   target_compile_definitions(MaCh3GPUCompilerOptions INTERFACE GPU_ON)
 endif()
 
-if(NOT DEFINED MaCh3_LOW_MEMORY_STRUCTS_ENABLED)
-  set(MaCh3_LOW_MEMORY_STRUCTS_ENABLED FALSE)
-endif()
-
 if(MaCh3_LOW_MEMORY_STRUCTS_ENABLED)
-  target_compile_definitions(MaCh3CompilerOptions INTERFACE _LOW_MEMORY_STRUCTS_)
-endif(MaCh3_LOW_MEMORY_STRUCTS_ENABLED)
+  target_compile_definitions(MaCh3CompileDefinitions INTERFACE _LOW_MEMORY_STRUCTS_)
+endif()
 
 set_target_properties(MaCh3CompilerOptions PROPERTIES EXPORT_NAME CompilerOptions)
 set_target_properties(MaCh3GPUCompilerOptions PROPERTIES EXPORT_NAME GPUCompilerOptions)

--- a/cmake/Modules/NuOscillatorSetup.cmake
+++ b/cmake/Modules/NuOscillatorSetup.cmake
@@ -57,7 +57,7 @@ SwitchLogic(DAN_DOUBLE)
 get_target_property(cpu_compile_options MaCh3CompilerOptions INTERFACE_COMPILE_OPTIONS)
 
 # Join the compile options list into a space-separated string
-string(REPLACE ";" " " compile_options_string "${cpu_compile_options}")
+string(REPLACE ";" " " cpu_compile_options_string "${cpu_compile_options}")
 
 
 #KS: This may seem hacky, but when CMAKE_CUDA_ARCHITECTURES is passed, it's treated as a string rather than a list. Since CMake uses semi-colon-delimited strings to represent lists, we convert it to a proper list to handle CUDA architectures correctly.
@@ -84,7 +84,7 @@ CPMAddPackage(
     "UseNuFASTLinear  ${USE_NuFastLiner}"
     "UseOscProb ${USE_OscProb}"
 
-    "NuOscillator_Compiler_Flags ${cpu_compile_options}"
+    "NuOscillator_Compiler_Flags ${cpu_compile_options_string}"
     "CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_STRING}"
     "CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD}"
 )


### PR DESCRIPTION
# Pull request description
CPU flags weren't proapgted correctly to NuOsc after:
https://github.com/mach3-software/MaCh3/pull/237

## Changes or fixes


## Examples
before:
![image](https://github.com/user-attachments/assets/fb1b61d0-6c0e-4816-87f0-c70aeb5175fd)

after:
<img width="777" alt="image" src="https://github.com/user-attachments/assets/fb0d621c-cdc3-4c27-ad89-fe2027a03de1" />
