### PR TITLE
tidy: Janitorial work for SamplePDF

### DIFF
--- a/mcmc/FitterBase.cpp
+++ b/mcmc/FitterBase.cpp
@@ -179,9 +179,6 @@ void FitterBase::PrepareOutput() {
       oss << "LogL_sample_" << i;
       oss2 << oss.str() << "/D";
       outTree->Branch(oss.str().c_str(), &sample_llh[i], oss2.str().c_str());
-
-      // For adding sample dependent branches to the posteriors tree
-      samples[i]->setMCMCBranches(outTree);
     }
 
     for (size_t i = 0; i < systematics.size(); ++i) {

--- a/samplePDF/FarDetectorCoreInfoStruct.h
+++ b/samplePDF/FarDetectorCoreInfoStruct.h
@@ -13,12 +13,12 @@ struct FarDetectorCoreInfo {
 
   ~FarDetectorCoreInfo(){ delete [] isNC; }
 
-  bool signal; // true if signue                                              
-  int nEvents; // how many MC events are there
+  bool signal; ///< true if signue
+  int nEvents; ///< how many MC events are there
   double ChannelIndex;
   std::string flavourName;
 
-  std::vector<int*> Target; // target the interaction was on
+  std::vector<int*> Target; ///< target the interaction was on
   std::vector<const int*> nupdg;
   std::vector<const int*> nupdgUnosc;
 
@@ -51,12 +51,12 @@ struct FarDetectorCoreInfo {
   bool *isNC;
 
   // histo pdf bins
-  std::vector<double> rw_lower_xbinedge; // lower to check if Eb has moved the erec bin
-  std::vector<double> rw_lower_lower_xbinedge; // lower to check if Eb has moved the erec bin
-  std::vector<double> rw_upper_xbinedge; // upper to check if Eb has moved the erec bin
-  std::vector<double> rw_upper_upper_xbinedge; // upper to check if Eb has moved the erec bin
+  std::vector<double> rw_lower_xbinedge;       ///< lower to check if Eb has moved the erec bin
+  std::vector<double> rw_lower_lower_xbinedge; ///< lower to check if Eb has moved the erec bin
+  std::vector<double> rw_upper_xbinedge;       ///< upper to check if Eb has moved the erec bin
+  std::vector<double> rw_upper_upper_xbinedge; ///< upper to check if Eb has moved the erec bin
 
-  std::vector<double*> mode;
+  std::vector<const double*> mode;
 
   std::vector<const M3::float_t*> osc_w_pointer;
   std::vector<M3::float_t> xsec_w;

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -41,6 +41,13 @@ constexpr static const int _BAD_INT_ = -999;
 
 constexpr static const double _DEFAULT_RETURN_VAL_ = -999999.123456;
 
+// Some commonly used variables to which we set pointers to
+constexpr static const double Unity = 1.;
+constexpr static const double Zero = 0.;
+constexpr static const float Unity_F = 1.;
+constexpr static const float Zero_F = 0.;
+constexpr static const int Unity_Int = 1;
+
 // C++ includes
 #include <sstream>
 #include <fstream> 

--- a/samplePDF/samplePDFBase.h
+++ b/samplePDF/samplePDFBase.h
@@ -66,6 +66,9 @@ class samplePDFBase
   /// @param mc is mc
   /// @param w2 is is Sum(w_{i}^2) (sum of weights squared), which is sigma^2_{MC stats}
   double getTestStatLLH(const double data, const double mc, const double w2) const;
+  /// @brief Set the test statistic to be used when calculating the binned likelihoods
+  /// @param testStat The test statistic to use.
+  inline void SetTestStatistic(TestStatistic testStat){ fTestStatistic = testStat; }
 
   virtual void fill1DHist()=0;
   virtual void fill2DHist()=0;

--- a/samplePDF/samplePDFBase.h
+++ b/samplePDF/samplePDFBase.h
@@ -29,8 +29,6 @@ class samplePDFBase
   virtual inline std::string GetName()const {return "samplePDF";};
   virtual std::string GetSampleName(int Sample);
   virtual inline double getSampleLikelihood(const int isample){(void) isample; return GetLikelihood();};
-  inline void GetSampleNames(std::vector<std::string> &sampleNameVect) ;
-  inline void GetModeName(std::vector<std::string> &modeNameVect);
 
   /// @brief Return pointer to MaCh3 modes
   MaCh3Modes* GetMaCh3Modes() const { return Modes; }
@@ -39,30 +37,17 @@ class samplePDFBase
   TH2D* get2DHist();
   TH1D* get1DDataHist(){return dathist;}
   TH2D* get2DDataHist(){return dathist2d;}
-  void set1DBinning(int nbins, double* boundaries);
-  void set1DBinning(int nbins, double low, double high);
-  void set2DBinning(int nbins1, double* boundaries1, int nbins2, double* boundaries2);
-  void set2DBinning(int nbins1, double low1, double high1, int nbins2, double low2, double high2);
-  double getEventRate();
-  void setMCthrow(bool mc){MCthrow= mc;}
       
-  // generate fake dataset based on rejection sampling    
-  std::vector< std::vector <double> > generate2D(TH2D* pdf = 0);
-  std::vector<double> generate();
   virtual void reweight()=0;
   virtual double GetLikelihood() = 0;
-  virtual std::vector<double>* getDataSample() {return dataSample;};
 
   virtual int getNEventsInSample(int sample){ (void) sample; throw MaCh3Exception(__FILE__ , __LINE__ , "Not implemented"); }
   virtual int getNMCSamples(){ throw MaCh3Exception(__FILE__ , __LINE__ , "Not implemented"); }
 
-  void addData(std::vector<double> &dat);
-  void addData(std::vector< std::vector <double> > &dat);
-  void addData(TH1D* binneddata);
-  void addData(TH2D* binneddata);
-
-  // For adding sample dependent branches to the posteriors tree
-  virtual void setMCMCBranches(TTree *outtree) {(void)outtree;};
+  virtual void addData(std::vector<double> &dat);
+  virtual void addData(std::vector< std::vector <double> > &dat);
+  virtual void addData(TH1D* binneddata);
+  virtual void addData(TH2D* binneddata);
 
   // WARNING KS: Needed for sigma var
   virtual void SetupBinning(const M3::int_t Selection, std::vector<double> &BinningX, std::vector<double> &BinningY){
@@ -81,16 +66,11 @@ class samplePDFBase
   /// @param mc is mc
   /// @param w2 is is Sum(w_{i}^2) (sum of weights squared), which is sigma^2_{MC stats}
   double getTestStatLLH(const double data, const double mc, const double w2) const;
-  /// @brief Set the test statistic to be used when calculating the binned likelihoods 
-  /// @param testStat The test statistic to use.
-  inline void SetTestStatistic(TestStatistic testStat){ fTestStatistic = testStat; }
 
   virtual void fill1DHist()=0;
   virtual void fill2DHist()=0;
 
 protected:
-  void init();
-  
   /// @brief CW: Redirect std::cout to silence some experiment specific libraries
   void QuietPlease();
   /// @brief CW: Redirect std::cout to silence some experiment specific libraries
@@ -103,11 +83,6 @@ protected:
   std::streambuf *buf;
   /// Keep the cerr buffer
   std::streambuf *errbuf;
-
-  // KS: Need thinking what to do with them
-
-  std::vector<double>* dataSample;
-  std::vector< std::vector <double> >* dataSample2D;
 
   /// Contains how many samples we've got
   M3::int_t nSamples;
@@ -127,7 +102,6 @@ protected:
   TH2D*_hPDF2D;
 
   TRandom3* rnd;
-  bool MCthrow;
 
   double pot;
 };

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -1255,7 +1255,7 @@ void samplePDFFDBase::addData(std::vector< std::vector <double> > &data) {
 }
 
 void samplePDFFDBase::addData(TH1D* Data) {
-  MACH3LOG_INFO("Adding 1D data histogram : {} with {} events", Data->GetName(), Data->Integral());
+  MACH3LOG_INFO("Adding 1D data histogram: {} with {:.2f} events", Data->GetName(), Data->Integral());
   dathist2d = nullptr;
   dathist = Data;
   
@@ -1276,7 +1276,7 @@ void samplePDFFDBase::addData(TH1D* Data) {
 }
 
 void samplePDFFDBase::addData(TH2D* Data) {
-  MACH3LOG_INFO("Adding 2D data histogram : {} with {} events", Data->GetName(), Data->Integral());
+  MACH3LOG_INFO("Adding 2D data histogram: {} with {:.2f} events", Data->GetName(), Data->Integral());
   dathist2d = Data;
   dathist = nullptr;
 

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -713,10 +713,8 @@ M3::float_t samplePDFFDBase::CalcXsecWeightNorm(const int iSample, const int iEv
   return xsecw;
 }
 
-void samplePDFFDBase::SetupNormParameters() {
-  
+void samplePDFFDBase::SetupNormParameters() {  
   xsec_norms = XsecCov->GetNormParsFromDetID(SampleDetID);
-  std::cout << "FOUND " << xsec_norms.size() << " norm parameters that affect this sample" << std::endl;
 
   if(!XsecCov){
     MACH3LOG_ERROR("XsecCov is not setup!");

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -56,7 +56,6 @@ samplePDFFDBase::~samplePDFFDBase()
 
 void samplePDFFDBase::ReadSampleConfig() 
 {
-
   if (!CheckNodeExists(SampleManager->raw(), "SampleName")) {
     MACH3LOG_ERROR("SampleName not defined in {}, please add this!", SampleManager->GetFileName());
     throw MaCh3Exception(__FILE__, __LINE__);
@@ -163,12 +162,9 @@ void samplePDFFDBase::ReadSampleConfig()
     StoredSelection.push_back(SelectionVec);
   }
   NSelections = int(SelectionStr.size());
-
-  return;
 }
 
 void samplePDFFDBase::Initialise() {
-
   //First grab all the information from your sample config via your manager
   ReadSampleConfig();
 
@@ -208,28 +204,26 @@ void samplePDFFDBase::Initialise() {
 
 void samplePDFFDBase::fill1DHist()
 {
-  // DB Commented out by default - Code heading towards GetLikelihood using arrays instead of root objects 
-  // Wouldn't actually need this for GetLikelihood as TH objects wouldn't be filled   
+  // DB Commented out by default - Code heading towards GetLikelihood using arrays instead of root objects
+  // Wouldn't actually need this for GetLikelihood as TH objects wouldn't be filled
   _hPDF1D->Reset();
   for (unsigned int yBin=0;yBin<(YBinEdges.size()-1);yBin++) {
     for (unsigned int xBin=0;xBin<(XBinEdges.size()-1);xBin++) {
       _hPDF1D->AddBinContent(xBin+1,samplePDFFD_array[yBin][xBin]);
     }
   }
-  return;
 }
 
 void samplePDFFDBase::fill2DHist()
 {
-  // DB Commented out by default - Code heading towards GetLikelihood using arrays instead of root objects 
-  // Wouldn't actually need this for GetLikelihood as TH objects wouldn't be filled   
+  // DB Commented out by default - Code heading towards GetLikelihood using arrays instead of root objects
+  // Wouldn't actually need this for GetLikelihood as TH objects wouldn't be filled
   _hPDF2D->Reset();
   for (unsigned int yBin=0;yBin<(YBinEdges.size()-1);yBin++) {
     for (unsigned int xBin=0;xBin<(XBinEdges.size()-1);xBin++) {
       _hPDF2D->SetBinContent(xBin+1,yBin+1,samplePDFFD_array[yBin][xBin]);
     }
   }
-  return;
 }
 
 // ************************************************
@@ -283,7 +277,6 @@ void samplePDFFDBase::SetupSampleBinning(){
     MACH3LOG_INFO("Setting up 1D binning with {}", XVarStr);
     set1DBinning(SampleXBins);  
   }
-  
   else if(nDimensions == 2){
     MACH3LOG_INFO("Setting up 2D binning with {} and {}", XVarStr, YVarStr);
     set2DBinning(SampleXBins, SampleYBins);
@@ -292,14 +285,11 @@ void samplePDFFDBase::SetupSampleBinning(){
     MACH3LOG_ERROR("Number of dimensions is not 1 or 2, this is unsupported at the moment");
     throw MaCh3Exception(__FILE__, __LINE__);
   }
-  
-  return; 
 }
 
 // ************************************************
 bool samplePDFFDBase::IsEventSelected(const int iSample, const int iEvent) {
-  // ************************************************
-  
+// ************************************************
   double Val;
   for (unsigned int iSelection=0;iSelection < Selection.size() ;iSelection++) {  
     Val = ReturnKinematicParameter(Selection[iSelection][0], iSample, iEvent);
@@ -314,8 +304,7 @@ bool samplePDFFDBase::IsEventSelected(const int iSample, const int iEvent) {
 
 // ************************************************
 bool samplePDFFDBase::IsEventSelected(const std::vector< std::string >& ParameterStr, const int iSample, const int iEvent) {
-  // ************************************************
-  
+// ************************************************
   double Val;
   for (unsigned int iSelection=0;iSelection<ParameterStr.size();iSelection++) {
     Val = ReturnKinematicParameter(ParameterStr[iSelection], iSample, iEvent);
@@ -333,7 +322,7 @@ bool samplePDFFDBase::IsEventSelected(const std::vector< std::string >& Paramete
 bool samplePDFFDBase::IsEventSelected(const std::vector< std::string >& ParameterStr,
                                       const std::vector< std::vector<double> > &SelectionCuts,
                                       const int iSample, const int iEvent) {
-  // ************************************************
+// ************************************************
   
   double Val;
   for (unsigned int iSelection=0;iSelection<ParameterStr.size();iSelection++) {
@@ -346,13 +335,14 @@ bool samplePDFFDBase::IsEventSelected(const std::vector< std::string >& Paramete
       return false;
     }
   }
-  
   //DB To avoid unnecessary checks, now return false rather than setting bool to true and continuing to check
   return true;
 }
 
-void samplePDFFDBase::reweight() // Reweight function - Depending on Osc Calculator this function uses different CalcOsc functions
-{
+//************************************************
+// Reweight function - Depending on Osc Calculator this function uses different CalcOsc functions
+void samplePDFFDBase::reweight() {
+//************************************************
   //KS: Reset the histograms before reweight 
   ResetHistograms();
   
@@ -372,8 +362,6 @@ void samplePDFFDBase::reweight() // Reweight function - Depending on Osc Calcula
   }
   
   fillArray();
-  
-  return;
 }
 
 //************************************************
@@ -384,8 +372,8 @@ void samplePDFFDBase::reweight() // Reweight function - Depending on Osc Calcula
 /// It also follows the ND code reweighting pretty closely. This function fills the samplePDFFD 
 /// array array which is binned to match the sample binning, such that bin[1][1] is the 
 /// equivalent of _hPDF2D->GetBinContent(2,2) {Noticing the offset}
-//************************************************
 void samplePDFFDBase::fillArray() {
+//************************************************
   //DB Reset which cuts to apply
   Selection = StoredSelection;
   
@@ -393,18 +381,9 @@ void samplePDFFDBase::fillArray() {
 #ifdef MULTITHREAD
   fillArray_MP();
 #else
-
   //ETA we should probably store this in samplePDFFDBase
-  int nXBins = int(XBinEdges.size()-1);
-  int nYBins = int(YBinEdges.size()-1);
-
-  //DB Reset values stored in PDF array to 0.
-  for (int yBin=0;yBin<nYBins;yBin++) {
-    for (int xBin=0;xBin<nXBins;xBin++) {
-      samplePDFFD_array[yBin][xBin] = 0.;
-      samplePDFFD_array_w2[yBin][xBin] = 0.;
-    }
-  }
+  size_t nXBins = int(XBinEdges.size()-1);
+  size_t nYBins = int(YBinEdges.size()-1);
 
   PrepFunctionalParameters();
   if(SplineHandler){
@@ -503,31 +482,18 @@ void samplePDFFDBase::fillArray() {
       }
     }
   }
-  
 #endif // end the else in openMP
-  return;
 }
 
 #ifdef MULTITHREAD
 // ************************************************ 
 /// Multithreaded version of fillArray @see fillArray()
-// ************************************************ 
-void samplePDFFDBase::fillArray_MP() 
-{
+void samplePDFFDBase::fillArray_MP()  {
+// ************************************************
   size_t nXBins = int(XBinEdges.size()-1);
   size_t nYBins = int(YBinEdges.size()-1);
-  
-  //DB Reset values stored in PDF array to 0.
-  for (size_t yBin=0;yBin<nYBins;yBin++) {
-    for (size_t xBin=0;xBin<nXBins;xBin++) {
-      samplePDFFD_array[yBin][xBin] = 0.;
-      samplePDFFD_array_w2[yBin][xBin] = 0.;
-    }
-  }
-  
-  //reconfigureFuncPars();
-  
-  //This is stored as [y][x] due to shifts only occuring in the x variable (Erec/Lep mom) - I believe this will help reduce cache misses 
+
+  //This is stored as [y][x] due to shifts only occurring in the x variable (Erec/Lep mom) - I believe this will help reduce cache misses
   double** samplePDFFD_array_private = nullptr;
   double** samplePDFFD_array_private_w2 = nullptr;
   // Declare the omp parallel region
@@ -622,7 +588,6 @@ void samplePDFFDBase::fillArray_MP()
 
         //DB Catch negative weights and skip any event with a negative event
         if (totalweight <= 0.){
-          //std::cout << "NEGATIVE WEIGHT!!" << std::endl;
           MCSamples[iSample].xsec_w[iEvent] = 0.;
           continue;
         }
@@ -647,7 +612,7 @@ void samplePDFFDBase::fillArray_MP()
         }
         //DB - Second, check to see if the event is outside of the binning range and skip event if it is
         else if (XVar < XBinEdges[0] || XVar >= XBinEdges[nXBins]) {
-          std::cout << "XVAR BEYOND BIN EDGES!!" << std::endl;
+          MACH3LOG_WARN("XVAR BEYOND BIN EDGES!!");
           continue;
         }
         //DB - Thirdly, check the adjacent bins first as Eb+CC+EScale shifts aren't likely to move an Erec more than 1bin width
@@ -678,20 +643,19 @@ void samplePDFFDBase::fillArray_MP()
         }
       }
     }    
-    
     //End of Calc Weights and fill Array
     //==================================================
     // DB Copy contents of 'samplePDFFD_array_private' into 'samplePDFFD_array' which can then be used in GetLikelihood
-    for (size_t yBin=0;yBin<nYBins;yBin++) {
-      for (size_t xBin=0;xBin<nXBins;xBin++) {
-#pragma omp atomic
-	samplePDFFD_array[yBin][xBin] += samplePDFFD_array_private[yBin][xBin];
-#pragma omp atomic    
-	samplePDFFD_array_w2[yBin][xBin] += samplePDFFD_array_private_w2[yBin][xBin];
+    for (size_t yBin = 0; yBin < nYBins; ++yBin) {
+      for (size_t xBin = 0; xBin < nXBins; ++xBin) {
+        #pragma omp atomic
+        samplePDFFD_array[yBin][xBin] += samplePDFFD_array_private[yBin][xBin];
+        #pragma omp atomic
+        samplePDFFD_array_w2[yBin][xBin] += samplePDFFD_array_private_w2[yBin][xBin];
       }
     }
     
-    for (size_t yBin=0;yBin<nYBins;yBin++) {
+    for (size_t yBin = 0; yBin < nYBins; ++yBin) {
       delete[] samplePDFFD_array_private[yBin];
       delete[] samplePDFFD_array_private_w2[yBin];
     }
@@ -706,13 +670,12 @@ void samplePDFFDBase::fillArray_MP()
 // Helper function to reset the data and MC histograms
 void samplePDFFDBase::ResetHistograms() {
 // **************************************************
-  
   size_t nXBins = int(XBinEdges.size()-1);
   size_t nYBins = int(YBinEdges.size()-1);
   
   //DB Reset values stored in PDF array to 0.
-  for (size_t yBin = 0; yBin < nYBins; yBin++) {
-    for (size_t xBin = 0; xBin < nXBins; xBin++) {
+  for (size_t yBin = 0; yBin < nYBins; ++yBin) {
+    for (size_t xBin = 0; xBin < nXBins; ++xBin) {
       samplePDFFD_array[yBin][xBin] = 0.;
     }
   }
@@ -722,7 +685,6 @@ void samplePDFFDBase::ResetHistograms() {
 // Calculate the spline weight for one event
 M3::float_t samplePDFFDBase::CalcXsecWeightSpline(const int iSample, const int iEvent) {
 // ***************************************************************************
-
   M3::float_t xsecw = 1.0;
   //DB Xsec syst
   //Loop over stored spline pointers
@@ -736,7 +698,6 @@ M3::float_t samplePDFFDBase::CalcXsecWeightSpline(const int iSample, const int i
 // Calculate the normalisation weight for one event
 M3::float_t samplePDFFDBase::CalcXsecWeightNorm(const int iSample, const int iEvent) {
 // ***************************************************************************
-
   M3::float_t xsecw = 1.0;
   //Loop over stored normalisation and function pointers
   for (int iParam = 0;iParam < MCSamples[iSample].nxsec_norm_pointers[iEvent]; iParam++)
@@ -752,7 +713,7 @@ M3::float_t samplePDFFDBase::CalcXsecWeightNorm(const int iSample, const int iEv
   return xsecw;
 }
 
-void samplePDFFDBase::SetupNormParameters(){
+void samplePDFFDBase::SetupNormParameters() {
   
   xsec_norms = XsecCov->GetNormParsFromDetID(SampleDetID);
   std::cout << "FOUND " << xsec_norms.size() << " norm parameters that affect this sample" << std::endl;
@@ -772,21 +733,18 @@ void samplePDFFDBase::SetupNormParameters(){
   int counter;
 
   for (int iSample = 0; iSample < int(MCSamples.size()); ++iSample) {
-	for (int iEvent = 0; iEvent < MCSamples[iSample].nEvents; ++iEvent) {
-	  counter = 0;
+    for (int iEvent = 0; iEvent < MCSamples[iSample].nEvents; ++iEvent) {
+      counter = 0;
 
-	  MCSamples[iSample].nxsec_norm_pointers[iEvent] = int(MCSamples[iSample].xsec_norms_bins[iEvent].size());
-	  MCSamples[iSample].xsec_norm_pointers[iEvent].resize(MCSamples[iSample].nxsec_norm_pointers[iEvent]);
+      MCSamples[iSample].nxsec_norm_pointers[iEvent] = int(MCSamples[iSample].xsec_norms_bins[iEvent].size());
+      MCSamples[iSample].xsec_norm_pointers[iEvent].resize(MCSamples[iSample].nxsec_norm_pointers[iEvent]);
 
-	  for(auto const & norm_bin: MCSamples[iSample].xsec_norms_bins[iEvent]) {
-		MCSamples[iSample].xsec_norm_pointers[iEvent][counter] = XsecCov->retPointer(norm_bin);
-		counter += 1;
-	  }
-
-	}
+      for(auto const & norm_bin: MCSamples[iSample].xsec_norms_bins[iEvent]) {
+        MCSamples[iSample].xsec_norm_pointers[iEvent][counter] = XsecCov->retPointer(norm_bin);
+        counter += 1;
+      }
+    }
   }
-
-  return;
 }
 
 //A way to check whether a normalisation parameter applies to an event or not
@@ -942,7 +900,6 @@ void samplePDFFDBase::set1DBinning(std::vector<double> &XVec){
       samplePDFFD_array_w2[yBin][xBin] = 0.;
     }
   }
-  
   FindNominalBinAndEdges1D();
 }
 
@@ -956,7 +913,6 @@ void samplePDFFDBase::set2DBinning(std::vector<double> &XVec, std::vector<double
   _hPDF2D->Reset();
   _hPDF2D->SetBins(int(XVec.size()-1), XVec.data(), int(YVec.size()-1), YVec.data());
   dathist2d->SetBins(int(XVec.size()-1), XVec.data(), int(YVec.size()-1), YVec.data());
-
 
   //ETA - maybe need to be careful here
   int nXBins = int(XVec.size()-1);
@@ -977,9 +933,9 @@ void samplePDFFDBase::set2DBinning(std::vector<double> &XVec, std::vector<double
 }
 
 //ETA
-//New versions of set binning funcitons is samplePDFBase
+//New versions of set binning functions is samplePDFBase
 //so that we can set the values of the bin and lower/upper
-//edges in the skmc_base. Hopefully we can use this to make 
+//edges in the skmc_base. Hopefully we can use this to make
 //fill1Dhist and fill2Dhist quicker
 void samplePDFFDBase::set1DBinning(int nbins, double* boundaries)
 {
@@ -1051,12 +1007,10 @@ void samplePDFFDBase::set1DBinning(int nbins, double low, double high)
       samplePDFFD_array_w2[yBin][xBin] = 0.;
     }
   }
-
   FindNominalBinAndEdges1D();
 }
 
 void samplePDFFDBase::FindNominalBinAndEdges1D() {
-
   //Set rw_pdf_bin and rw_upper_xbinedge and rw_lower_xbinedge for each skmc_base
   for(int mc_i = 0 ; mc_i < int(MCSamples.size()) ; mc_i++){
     for(int event_i = 0 ; event_i < MCSamples[mc_i].nEvents ; event_i++){
@@ -1101,7 +1055,6 @@ void samplePDFFDBase::FindNominalBinAndEdges1D() {
       MCSamples[mc_i].rw_upper_upper_xbinedge[event_i] = upper_upper_edge;
     }
   }
-  
 }
 
 void samplePDFFDBase::set2DBinning(int nbins1, double* boundaries1, int nbins2, double* boundaries2)
@@ -1231,12 +1184,9 @@ void samplePDFFDBase::FindNominalBinAndEdges2D() {
       MCSamples[mc_i].rw_upper_upper_xbinedge[event_i] = upper_upper_edge;
     }
   }
-  return;
 }
 
 void samplePDFFDBase::addData(std::vector<double> &data) {
-  dataSample = new std::vector<double>(data);
-  dataSample2D = nullptr;
   dathist2d = nullptr;
   dathist->Reset(); 
   
@@ -1246,8 +1196,8 @@ void samplePDFFDBase::addData(std::vector<double> &data) {
     throw MaCh3Exception(__FILE__, __LINE__);
   }
   
-  for (int i = 0; i < int(dataSample->size()); i++) {
-    dathist->Fill(dataSample->at(i));
+  for (int i = 0; i < int(data.size()); i++) {
+    dathist->Fill(data.at(i));
   }
   
   int nXBins = int(XBinEdges.size()-1);
@@ -1260,13 +1210,9 @@ void samplePDFFDBase::addData(std::vector<double> &data) {
       samplePDFFD_data[yBin][xBin] = dathist->GetBinContent(xBin+1);
     }
   }
-
-  return;
 }
 
 void samplePDFFDBase::addData(std::vector< std::vector <double> > &data) {
-  dataSample2D = new std::vector< std::vector <double> >(data);
-  dataSample = nullptr;
   dathist = nullptr;
   dathist2d->Reset();                                                       
 
@@ -1276,8 +1222,8 @@ void samplePDFFDBase::addData(std::vector< std::vector <double> > &data) {
     throw MaCh3Exception(__FILE__, __LINE__);
   }
 
-  for (int i = 0; i < int(dataSample2D->size()); i++) {
-    dathist2d->Fill(dataSample2D->at(0)[i],dataSample2D->at(1)[i]);
+  for (int i = 0; i < int(data.size()); i++) {
+    dathist2d->Fill(data.at(0)[i],data.at(1)[i]);
   }
 
   int nXBins = int(XBinEdges.size()-1);
@@ -1290,16 +1236,12 @@ void samplePDFFDBase::addData(std::vector< std::vector <double> > &data) {
       samplePDFFD_data[yBin][xBin] = dathist2d->GetBinContent(xBin+1,yBin+1);
     }
   }
-
-  return;
 }
 
 void samplePDFFDBase::addData(TH1D* Data) {
   MACH3LOG_INFO("Adding 1D data histogram : {} with {} events", Data->GetName(), Data->Integral());
   dathist2d = nullptr;
   dathist = Data;
-  dataSample = nullptr;
-  dataSample2D = nullptr;
   
   if (GetNDim()!=1) {
     MACH3LOG_ERROR("Trying to set a 1D 'data' histogram in a 2D sample - Quitting"); 
@@ -1315,16 +1257,12 @@ void samplePDFFDBase::addData(TH1D* Data) {
       samplePDFFD_data[yBin][xBin] = Data->GetBinContent(xBin+1);
     }
   }
-
-  return;
 }
 
 void samplePDFFDBase::addData(TH2D* Data) {
   MACH3LOG_INFO("Adding 2D data histogram : {} with {} events", Data->GetName(), Data->Integral());
   dathist2d = Data;
   dathist = nullptr;
-  dataSample = nullptr;
-  dataSample2D = nullptr;
 
   if (GetNDim()!=2) {
     MACH3LOG_ERROR("Trying to set a 2D 'data' histogram in a 1D sample - Quitting"); 
@@ -1376,9 +1314,7 @@ void samplePDFFDBase::SetupNuOscillator() {
 
           NuOscProbCalcers[iSample]->SetCosineZArrayInCalcer(CosineZArray);
         }
-        //============================================================================
       }
-
       NuOscProbCalcers[iSample]->Setup();
     } 
 
@@ -1481,8 +1417,6 @@ void samplePDFFDBase::fillSplineBins() {
       }
     }
   }
-
-  return;
 }
 
 double samplePDFFDBase::GetLikelihood() {
@@ -1495,21 +1429,17 @@ double samplePDFFDBase::GetLikelihood() {
   int nXBins = int(XBinEdges.size()-1);
   int nYBins = int(YBinEdges.size()-1);
   
-  int xBin;
-  int yBin;
-
   double negLogL = 0.;
-
-#ifdef MULTITHREAD
-#pragma omp parallel for reduction(+:negLogL) private(xBin, yBin)
-#endif
-  for (xBin = 0; xBin < nXBins; xBin++) 
+  #ifdef MULTITHREAD
+  #pragma omp parallel for reduction(+:negLogL)
+  #endif
+  for (int xBin = 0; xBin < nXBins; ++xBin)
   {
-    for (yBin = 0; yBin < nYBins; yBin++) 
+    for (int yBin = 0; yBin < nYBins; ++yBin)
     {
-      double DataVal = samplePDFFD_data[yBin][xBin];
-      double MCPred = samplePDFFD_array[yBin][xBin];
-      double w2 = samplePDFFD_array_w2[yBin][xBin];
+      const double DataVal = samplePDFFD_data[yBin][xBin];
+      const double MCPred = samplePDFFD_array[yBin][xBin];
+      const double w2 = samplePDFFD_array_w2[yBin][xBin];
       
       //KS: Calculate likelihood using Barlow-Beeston Poisson or even IceCube
       negLogL += getTestStatLLH(DataVal, MCPred, w2);
@@ -1565,8 +1495,6 @@ void samplePDFFDBase::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
   for(int iEvent = 0 ; iEvent < fdobj->nEvents ; ++iEvent){
     fdobj->isNC[iEvent] = false;
   }
-
-  return;
 }
 
 void samplePDFFDBase::InitialiseSplineObject() {

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -17,9 +17,8 @@ class samplePDFFDBase :  public samplePDFBase
 {
 public:
   //######################################### Functions #########################################
-
-  samplePDFFDBase(){};
-  samplePDFFDBase(std::string mc_version, covarianceXsec* xsec_cov, covarianceOsc* osc_cov = nullptr);
+  /// @param ConfigFileName Name of config to initialise the sample object
+  samplePDFFDBase(std::string ConfigFileName, covarianceXsec* xsec_cov, covarianceOsc* osc_cov = nullptr);
   virtual ~samplePDFFDBase();
 
   int GetNDim(){return nDimensions;} //DB Function to differentiate 1D or 2D binning
@@ -30,15 +29,15 @@ public:
 
   //ETA - abstract these to samplePDFFDBase
   //DB Require these four functions to allow conversion from TH1(2)D to array for multi-threaded GetLikelihood
-  void addData(TH1D* Data);
-  void addData(TH2D* Data);
-  void addData(std::vector<double> &data);
-  void addData(std::vector< std::vector <double> > &data);
+  void addData(TH1D* Data) override;
+  void addData(TH2D* Data) override;
+  void addData(std::vector<double> &data) override;
+  void addData(std::vector< std::vector <double> > &data) override;
   /// @brief DB Multi-threaded GetLikelihood
-  double GetLikelihood();
+  double GetLikelihood() override;
   //===============================================================================
 
-  void reweight();
+  void reweight() override;
   M3::float_t GetEventWeight(int iSample, int iEntry);
 
   ///  @brief including Dan's magic NuOscillator
@@ -48,7 +47,7 @@ public:
 
   void ReadSampleConfig();
 
-  int getNMCSamples() {return int(MCSamples.size());}
+  int getNMCSamples() override {return int(MCSamples.size());}
 
   int getNEventsInSample(int iSample) {
     if (iSample < 0 || iSample > getNMCSamples()) {
@@ -146,7 +145,7 @@ public:
   void SetupNormParameters();
 
   //===============================================================================
-  //DB Functions required for reweighting functions  
+  //DB Functions required for reweighting functions
   //DB Replace previous implementation with reading bin contents from samplePDF_array
   void fill1DHist();
   void fill2DHist();
@@ -233,14 +232,6 @@ public:
   std::unique_ptr<manager> SampleManager;
   void InitialiseSingleFDMCObject(int iSample, int nEvents);
   void InitialiseSplineObject();
-
-  double Unity = 1.;
-  double Zero = 0.;
-  
-  float Unity_F = 1.;
-  float Zero_F = 0.;
-
-  int Unity_Int = 1;
 
   std::vector<std::string> mc_files;
   std::vector<std::string> spline_files;


### PR DESCRIPTION
# Pull request description
Minor tidy of sample pdf

## Changes or fixes
- dataSample was pointer to vector... this is terrible... I am speachless... either way it wasn't use so removed
- We were resetting histogram in ResetHistohgram and in FillArray now we do this once
- Remove lot of legacy stuff from PDF base
- Moved unityf to struct instead as meber of SamplePDF
- reuturn at the end of void is just noise


## Examples
Nothing critical so I don't think valdiations other than bots are neccessary