### PR TITLE
tidy: Step Scale Sanity chekc et. al.

### DIFF
--- a/.github/workflows/CIValidations.yml
+++ b/.github/workflows/CIValidations.yml
@@ -25,7 +25,7 @@ jobs:
             test_1: ./CIValidations/SplineValidations
             test_2: ./CIValidations/SamplePDFValidations
             test_3: ./CIValidations/NuOscillatorInterfaceValidations
-            test_4: empty
+            test_4: ./CIValidations/LLHValidation
             test_5: empty
             test_6: empty
             test_7: empty

--- a/Doc/bibliography.bib
+++ b/Doc/bibliography.bib
@@ -223,3 +223,26 @@
   url          = {https://search.r-project.org/CRAN/refmans/BayesianTools/html/WAIC.html},
   institution  = {CRAN},
 }
+
+@article{luengo2020survey,
+  author = {Luengo, D. and Martino, L. and Bugallo, M. and others},
+  title = {A survey of Monte Carlo methods for parameter estimation},
+  journal = {EURASIP Journal on Advances in Signal Processing},
+  year = {2020},
+  doi = {10.1186/s13634-020-00675-6},
+  url = {https://doi.org/10.1186/s13634-020-00675-6},
+  note = {Relevant discussion in Section 3.2.1},
+  published = {29 May 2020}
+}
+
+@article{haario2001adaptive,
+  author       = {Heikki Haario and Eero Saksman and Johanna Tamminen},
+  title        = {An adaptive Metropolis algorithm},
+  journal      = {Bernoulli},
+  volume       = {7},
+  number       = {2},
+  pages        = {223--242},
+  year         = {2001},
+  month        = {April},
+  doi          = {10.3150/bj/1080222083}
+}

--- a/covariance/AdaptiveMCMCHandler.h
+++ b/covariance/AdaptiveMCMCHandler.h
@@ -7,7 +7,8 @@
 namespace adaptive_mcmc{
 
 /// @brief Contains information about adaptive covariance matrix
-/// @see An adaptive Metropolis algorithm, H.Haario et al., 2001 for more info!
+/// @cite haario2001adaptive
+/// @author Henry Wallace
 /// @details struct encapsulating all adaptive MCMC information
 class AdaptiveMCMCHandler{
  public:
@@ -16,7 +17,7 @@ class AdaptiveMCMCHandler{
   AdaptiveMCMCHandler();
 
   /// @brief Destructor
-  ~AdaptiveMCMCHandler();
+  virtual ~AdaptiveMCMCHandler();
 
   /// @brief Print all class members
   void Print();
@@ -46,7 +47,7 @@ class AdaptiveMCMCHandler{
                               const int Npars);
 
   /// @brief Method to update adaptive MCMC
-  /// @see https://projecteuclid.org/journals/bernoulli/volume-7/issue-2/An-adaptive-Metropolis-algorithm/bj/1080222083.full
+  /// @cite haario2001adaptive
   /// @param _fCurrVal Value of each parameter necessary for updating throw matrix
   void UpdateAdaptiveCovariance(const std::vector<double>& _fCurrVal, const int Npars);
 

--- a/covariance/PCAHandler.h
+++ b/covariance/PCAHandler.h
@@ -33,7 +33,7 @@ class PCAHandler{
   PCAHandler();
 
   /// @brief Destructor
-  ~PCAHandler();
+  virtual ~PCAHandler();
 
   /// @brief CW: Calculate eigen values, prepare transition matrices and remove param based on defined threshold
   void ConstructPCA(TMatrixDSym * covMatrix, const int firstPCAd, const int lastPCAd, const double eigen_thresh, int& _fNumParPCA);

--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -888,8 +888,8 @@ void covarianceBase::SetBranches(TTree &tree, bool SaveProposal) {
 // ********************************************
 void covarianceBase::setStepScale(const double scale) {
 // ********************************************
-  if(scale == 0) {
-    MACH3LOG_ERROR("You are trying so set StepScale to 0 this will not work");
+  if(scale <= 0) {
+    MACH3LOG_ERROR("You are trying so set StepScale to 0 or negative this will not work");
     throw MaCh3Exception(__FILE__ , __LINE__ );
   }
   MACH3LOG_INFO("{} setStepScale() = {}", getName(), scale);

--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -60,16 +60,11 @@ covarianceBase::~covarianceBase(){
   if (covMatrix != nullptr) delete covMatrix;
   if (invCovMatrix != nullptr) delete invCovMatrix;
   if (throwMatrix_CholDecomp != nullptr) delete throwMatrix_CholDecomp;
-
-  for(int i = 0; i < _fNumPar; i++)
-  {
-    delete[] InvertCovMatrix[i];
+  if (throwMatrix != nullptr) delete throwMatrix;
+  for(int i = 0; i < _fNumPar; i++) {
     delete[] throwMatrixCholDecomp[i];
   }
-  delete[] InvertCovMatrix;
   delete[] throwMatrixCholDecomp;
-  
-  if (throwMatrix != nullptr) delete throwMatrix;
 }
 
 // ********************************************
@@ -112,7 +107,6 @@ void covarianceBase::ConstructPCA() {
 // ********************************************
 void covarianceBase::init(std::string name, std::string file) {
 // ********************************************
-
   // Set the covariance matrix from input ROOT file (e.g. flux, ND280, NIWG)
   TFile *infile = new TFile(file.c_str(), "READ");
   if (infile->IsZombie()) {
@@ -144,8 +138,14 @@ void covarianceBase::init(std::string name, std::string file) {
   _fNumPar = CovMat->GetNrows();
     
   InvertCovMatrix.resize(_fNumPar, std::vector<double>(_fNumPar, 0.0));
-  throwMatrixCholDecomp.resize(_fNumPar, std::vector<double>(_fNumPar, 0.0));
-
+  throwMatrixCholDecomp = new double*[_fNumPar]();
+  // Set the defaults to true
+  for(int i = 0; i < _fNumPar; i++) {
+    throwMatrixCholDecomp[i] = new double[_fNumPar]();
+    for (int j = 0; j < _fNumPar; j++) {
+      throwMatrixCholDecomp[i][j] = 0.;
+    }
+  }
   setName(name);
   MakePosDef(CovMat);
   setCovMatrix(CovMat);
@@ -195,12 +195,16 @@ void covarianceBase::init(const std::vector<std::string>& YAMLFile) {
   use_adaptive = false;
 
   InvertCovMatrix.resize(_fNumPar, std::vector<double>(_fNumPar, 0.0));
-  throwMatrixCholDecomp.resize(_fNumPar, std::vector<double>(_fNumPar, 0.0));
+  throwMatrixCholDecomp = new double*[_fNumPar]();
+  for(int i = 0; i < _fNumPar; i++) {
+    throwMatrixCholDecomp[i] = new double[_fNumPar]();
+    for (int j = 0; j < _fNumPar; j++) {
+      throwMatrixCholDecomp[i][j] = 0.;
+    }
+  }
   ReserveMemory(_fNumPar);
 
   TMatrixDSym* _fCovMatrix = new TMatrixDSym(_fNumPar);
-  //_fDetString = std::vector<std::string>(_fNumPar);
-
   int i = 0;
   std::vector<std::map<std::string,double>> Correlations(_fNumPar);
   std::map<std::string, int> CorrNamesMap;
@@ -244,12 +248,14 @@ void covarianceBase::init(const std::vector<std::string>& YAMLFile) {
     }
     i++;
   }
-
-  //ETA
-  //Now that we've been through all systematic let's fill the covmatrix
+  if(i != _fNumPar) {
+    MACH3LOG_CRITICAL("Inconsitnent number of params in Yaml  {} vs {}, this indicate wrong syntax", i, i, _fNumPar);
+    throw MaCh3Exception(__FILE__ , __LINE__ );
+  }
+  // ETA Now that we've been through all systematic let's fill the covmatrix
   //This makes the root TCov from YAML
-  for(int j = 0; j < _fNumPar;j++) {
-    (*_fCovMatrix)(j, j)=_fError[j]*_fError[j];
+  for(int j = 0; j < _fNumPar; j++) {
+    (*_fCovMatrix)(j, j) = _fError[j]*_fError[j];
     //Get the map of parameter name to correlation from the Correlations object
     for (auto const& pair : Correlations[j]) {
       auto const& key = pair.first;
@@ -346,7 +352,7 @@ void covarianceBase::ReserveMemory(const int SizeVec) {
   for(int i = 0; i < SizeVec; i++) {
     _fGenerated.at(i) = 1.;
     _fPreFitValue.at(i) = 1.;
-    _fError.at(i) = 0.;
+    _fError.at(i) = 1.;
     _fCurrVal.at(i) = 0.;
     _fPropVal.at(i) = 0.;
     _fLowBound.at(i) = -999.99;
@@ -799,8 +805,7 @@ double covarianceBase::GetLikelihood() {
   // Default behaviour is to reject negative values + do std llh calculation
   const int NOutside = CheckBounds();
   
-  if(NOutside > 0)
-    return NOutside*_LARGE_LOGL_;
+  if(NOutside > 0) return NOutside*_LARGE_LOGL_;
 
   return CalcLikelihood();
 }
@@ -883,12 +888,16 @@ void covarianceBase::SetBranches(TTree &tree, bool SaveProposal) {
 // ********************************************
 void covarianceBase::setStepScale(const double scale) {
 // ********************************************
-  if(scale == 0)
-  {
+  if(scale == 0) {
     MACH3LOG_ERROR("You are trying so set StepScale to 0 this will not work");
     throw MaCh3Exception(__FILE__ , __LINE__ );
   }
   MACH3LOG_INFO("{} setStepScale() = {}", getName(), scale);
+  const double SuggestedScale = 2.38*2.38/_fNumPar;
+  if(std::fabs(scale - SuggestedScale)/SuggestedScale > 1) {
+    MACH3LOG_WARN("Defined Global StepScale is {}, while suggested suggested {}", scale, SuggestedScale);
+  }
+
   _fGlobalStepScale = scale;
 }
 
@@ -896,8 +905,7 @@ void covarianceBase::setStepScale(const double scale) {
 void covarianceBase::toggleFixAllParameters() {
 // ********************************************
   // fix or unfix all parameters by multiplying by -1
-  if(!pca)
-  {
+  if(!pca) {
     for (int i = 0; i < _fNumPar; i++) _fError[i] *= -1.0;
   } else{
      for (int i = 0; i < _fNumParPCA; i++) fParSigma_PCA[i] *= -1.0;
@@ -1150,18 +1158,15 @@ void covarianceBase::updateThrowMatrix(TMatrixDSym *cov){
 // HW : Here be adaption
 void covarianceBase::initialiseAdaption(const YAML::Node& adapt_manager){
 // ********************************************
-  // need to cast matrixName to string
-  std::string matrix_name_str(matrixName);
-
   // Now we read the general settings [these SHOULD be common across all matrices!]
-  bool success = AdaptiveHandler.InitFromConfig(adapt_manager, matrix_name_str, getNpars());
+  bool success = AdaptiveHandler.InitFromConfig(adapt_manager, matrixName, getNpars());
   if(!success) return;
   AdaptiveHandler.Print();
 
   // Next let"s check for external matrices
   // We"re going to grab this info from the YAML manager
-  if(!GetFromManager<bool>(adapt_manager["AdaptionOptions"]["Covariance"][matrix_name_str]["UseExternalMatrix"], false)) {
-    MACH3LOG_WARN("Not using external matrix for {}, initialising adaption from scratch", matrix_name_str);
+  if(!GetFromManager<bool>(adapt_manager["AdaptionOptions"]["Covariance"][matrixName]["UseExternalMatrix"], false)) {
+    MACH3LOG_WARN("Not using external matrix for {}, initialising adaption from scratch", matrixName);
     // If we don't have a covariance matrix to start from for adaptive tune we need to make one!
     use_adaptive = true;
     AdaptiveHandler.CreateNewAdaptiveCovariance(_fNumPar);
@@ -1169,9 +1174,9 @@ void covarianceBase::initialiseAdaption(const YAML::Node& adapt_manager){
   }
 
   // Finally, we accept that we want to read the matrix from a file!
-  std::string external_file_name = GetFromManager<std::string>(adapt_manager["AdaptionOptions"]["Covariance"][matrix_name_str]["ExternalMatrixFileName"], "");
-  std::string external_matrix_name = GetFromManager<std::string>(adapt_manager["AdaptionOptions"]["Covariance"][matrix_name_str]["ExternalMatrixName"], "");
-  std::string external_mean_name = GetFromManager<std::string>(adapt_manager["AdaptionOptions"]["Covariance"][matrix_name_str]["ExternalMeansName"], "");
+  std::string external_file_name = GetFromManager<std::string>(adapt_manager["AdaptionOptions"]["Covariance"][matrixName]["ExternalMatrixFileName"], "");
+  std::string external_matrix_name = GetFromManager<std::string>(adapt_manager["AdaptionOptions"]["Covariance"][matrixName]["ExternalMatrixName"], "");
+  std::string external_mean_name = GetFromManager<std::string>(adapt_manager["AdaptionOptions"]["Covariance"][matrixName]["ExternalMeansName"], "");
 
   AdaptiveHandler.SetThrowMatrixFromFile(external_file_name, external_matrix_name, external_mean_name, use_adaptive, _fNumPar);
   setThrowMatrix(AdaptiveHandler.adaptive_covariance);

--- a/covariance/covarianceBase.h
+++ b/covariance/covarianceBase.h
@@ -69,6 +69,7 @@ class covarianceBase {
   void SetBranches(TTree &tree, bool SaveProposal = false);
   /// @brief Set global step scale for covariance object
   /// @param scale Value of global step scale
+  /// @cite luengo2020survey
   void setStepScale(const double scale);
   /// @brief DB Function to set fIndivStepScale from a vector (Can be used from execs and inside covariance constructors)
   /// @param ParameterIndex Parameter Index
@@ -461,7 +462,7 @@ protected:
   /// Matrix which we use for step proposal after Cholesky decomposition
   TMatrixD* throwMatrix_CholDecomp;
   /// Throw matrix that is being used in the fit, much faster as TMatrixDSym cache miss
-  std::vector<std::vector<double>> throwMatrixCholDecomp;
+  double** throwMatrixCholDecomp;
 
   /// Are we using AMCMC?
   bool use_adaptive;

--- a/covariance/covarianceBase.h
+++ b/covariance/covarianceBase.h
@@ -391,7 +391,7 @@ protected:
   /// The inverse covariance matrix
   TMatrixDSym *invCovMatrix;
   /// KS: Same as above but much faster as TMatrixDSym cache miss
-  double **InvertCovMatrix;
+  std::vector<std::vector<double>> InvertCovMatrix;
     
   /// KS: Set Random numbers for each thread so each thread has different seed
   std::vector<std::unique_ptr<TRandom3>> random_number;
@@ -463,7 +463,7 @@ protected:
   /// Matrix which we use for step proposal after Cholesky decomposition
   TMatrixD* throwMatrix_CholDecomp;
   /// Throw matrix that is being used in the fit, much faster as TMatrixDSym cache miss
-  double **throwMatrixCholDecomp;
+  std::vector<std::vector<double>> throwMatrixCholDecomp;
 
   /// Are we using AMCMC?
   bool use_adaptive;

--- a/mcmc/FitterBase.cpp
+++ b/mcmc/FitterBase.cpp
@@ -956,7 +956,6 @@ void FitterBase::Run2DLLHScan() {
           MACH3LOG_INFO("lower {} = {:.2f}", i, lower_y);
           MACH3LOG_INFO("upper {} = {:.2f}", i, upper_y);
           MACH3LOG_INFO("nSigma = {:.2f}", nSigma);
-
         }
 
         // Cross-section and flux parameters have boundaries that we scan between, check that these are respected in setting lower and upper variables

--- a/plotting/plottingUtils/inputManager.cpp
+++ b/plotting/plottingUtils/inputManager.cpp
@@ -35,7 +35,6 @@ InputManager::InputManager(const std::string &translationConfigName) {
         MACH3LOG_DEBUG("  - Found {}!", tags.size());
       }
     }
-
     _paramToTagsMap[param] = tags;
   }
 
@@ -55,7 +54,6 @@ InputManager::InputManager(const std::string &translationConfigName) {
         MACH3LOG_DEBUG("  - Found {}!", tags.size());
       }
     }
-
     _sampleToTagsMap[samp] = tags;
   }
 }
@@ -227,10 +225,8 @@ std::vector<std::string> InputManager::getTaggedValues(const std::vector<std::st
       if ( tagCount == valTags.size() ) retVec.push_back(val);
     }
   }
-
   MACH3LOG_DEBUG("Found {} values matching the specified tags", retVec.size());
   return retVec;
-
 }
 
 std::vector<std::string> InputManager::parseLocation(const std::string &rawLocationString, std::string &fitter,
@@ -315,7 +311,6 @@ std::shared_ptr<TObject> InputManager::findRootObject(const InputFile &fileDef,
     {
       object = nullptr;
     }
-
     else
     {
       // loop through the keys in the directory and find objects whose name matches the specified
@@ -330,7 +325,6 @@ std::shared_ptr<TObject> InputManager::findRootObject(const InputFile &fileDef,
         }
       }
     }
-
     // check that only one object matched the pattern
     if (nMatchingObjects > 1)
     {
@@ -339,11 +333,8 @@ std::shared_ptr<TObject> InputManager::findRootObject(const InputFile &fileDef,
 
       throw MaCh3Exception(__FILE__ , __LINE__ );
     }
-
   }
-
-  // Vector too big!!
-  else
+  else // Vector too big!!
   {
     MACH3LOG_CRITICAL("Invalid object location vector");
     MACH3LOG_CRITICAL("Should have two elements: [ (directory to look in), (end of the name of the object) ]");
@@ -351,14 +342,11 @@ std::shared_ptr<TObject> InputManager::findRootObject(const InputFile &fileDef,
     
     throw MaCh3Exception(__FILE__ , __LINE__ );
   }
-
   return object;
 }
 
-
 bool InputManager::findBySampleLLH(InputFile &inputFileDef, const std::string &parameter,
                                    std::string &fitter, const std::string &sample, bool setInputFileScan) {
-
   YAML::Node thisFitterSpec_config = _fitterSpecConfig[fitter];
 
   // EM: Get where the by sample LLH scan for this parameter *should* live if it exists
@@ -402,14 +390,12 @@ bool InputManager::findBySampleLLH(InputFile &inputFileDef, const std::string &p
 
     inputFileDef.LLHScansBySample_map[sample][parameter] = LLHGraph;
   }
-
   return true;
 }
 
 // check the input file for raw MCMC step values for a particular parameter
 bool InputManager::findRawChainSteps(InputFile &inputFileDef, const std::string &parameter, std::string &fitter, bool setInputBranch) const {
   // we'll assume for now that the chain is in the form of a TTree and the branch names are parameter names
-
   bool wasFound = false;
 
   // make sure that the filedef object has all the necessary stuff to read from the posterior tree
@@ -436,19 +422,15 @@ bool InputManager::findRawChainSteps(InputFile &inputFileDef, const std::string 
           inputFileDef.MCMCstepParamsMap[parameter] = new double( _BAD_DOUBLE_ ); // <- initialise the parameter step values 
           inputFileDef.posteriorTree->SetBranchAddress( branchNames[paramIdx], inputFileDef.MCMCstepParamsMap.at(parameter) );
         }
-
         break;
       }
     }
   }
-
   return wasFound;
-
 }
 
 // check the input file for processed 1d posteriors for a particular parameter
 bool InputManager::find1dPosterior(InputFile &inputFileDef, const std::string &parameter, std::string &fitter, bool setFileData) const {
-  
   bool wasFound = false;
   
   YAML::Node thisFitterSpec_config = _fitterSpecConfig[fitter];
@@ -471,9 +453,7 @@ bool InputManager::find1dPosterior(InputFile &inputFileDef, const std::string &p
         break;
       }
     }
-
   }
-
   return wasFound;
 }
 
@@ -540,7 +520,6 @@ void InputManager::fillFileInfo(InputFile &inputFileDef, bool printThoughts) {
 
   for (std::string fitter: _knownFitters)
   {
-
     // flag for whether or not the current fitter is the correct one
     bool foundFitter = false;
     if (printThoughts)
@@ -631,7 +610,6 @@ void InputManager::fillFileInfo(InputFile &inputFileDef, bool printThoughts) {
       {
         MACH3LOG_DEBUG("  No default location specified");
       }
-      
     }
 
     int numPostFitParams = 0;
@@ -833,7 +811,6 @@ void InputManager::fillFileData(InputFile &inputFileDef, bool printThoughts) {
     // EM: now get the objects from the file
     for (const std::string &parameter : inputFileDef.availableParams_LLH)
     {
-
       std::shared_ptr<TObject> LLHObj = nullptr;
 
       // check the locations for the object
@@ -908,5 +885,4 @@ void InputManager::fillFileData(InputFile &inputFileDef, bool printThoughts) {
     find1dPosterior(inputFileDef, parameter, inputFileDef.fitter, true);
   }
 }
-
 } // namespace MaCh3Plotting

--- a/plotting/plottingUtils/inputManager.h
+++ b/plotting/plottingUtils/inputManager.h
@@ -324,7 +324,6 @@ public:
     }
 
     return *_fileVec[fileNum].MCMCstepParamsMap.at(paramName);
-
   }
 
   /// @brief Get the 1d posterior particular parameter from a particular input file.
@@ -392,7 +391,6 @@ public:
 
   inline TGraph getSampleSpecificLLHScan_TGraph(int fileNum, std::string paramName,
                                          std::string sample) const {
-    
     if (!getEnabledLLHBySample(fileNum, paramName, sample))
     {
       MACH3LOG_WARN("file at index {} does not have LLH scan for sample {} for parameter {}", fileNum, sample, paramName);
@@ -519,7 +517,6 @@ public:
   /// @}
 
 private:
-
   // Helper function to get tagged values from a vector of values
   // specify the initial list of *values*, the map of values to their tags, the tags to check,
   // and the type of check to perform (see getTaggedParameter() for details)
@@ -573,7 +570,6 @@ private:
                                YAML::Node subConfig) const{
     if (subConfig[parameter])
     {
-
       // EM: this is config definition of fitter specific names for this parameter
       YAML::Node paramTranslation = subConfig[parameter];
 
@@ -642,9 +638,7 @@ private:
     return false;
   }
 
-
 private:
-
   // all parameters which are known to this InputManager: all the ones defined in the translation
   // config used to create it
   std::vector<std::string> _knownParameters;


### PR DESCRIPTION
# Pull request description
We often use defined step scale. However we know based on literature what it should be. Now simply throw warning if step scale is very different. This should help spot mistakes.

## Changes or fixes
- No longer have to covnert const char to string in adaptive code
- Now default error is 1 not 0. error being 0 can be interpeted as fixed param and we don't want this
- remove a lot of blank line in plotting
- raw pointer -> std::vecotr in cov
- more bibliography (hope is usefull)
- use new LLH scan bot

## Examples
