### PR TITLE
breaking: Less stinky Cov Osc

### DIFF
--- a/Diagnostics/README.md
+++ b/Diagnostics/README.md
@@ -13,6 +13,8 @@
 
 **DiagMCMC** - Perform MCMC diagnostic like autocorrelation or trace plots.
 
+**PlotMCMCDiag** - Plot output of **DiagMCMC**, can compare multiple files if more than one argument is used
+
 **RHat** - Performs RHat diagnostic to study if all used chains converged to the same stationary distribution.
 ```bash
 ./RHat Ntoys MCMCchain_1.root MCMCchain_2.root MCMCchain_3.root ... [how many you like]

--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -721,7 +721,7 @@ void covarianceBase::throwParCurr(const double mag) {
 }
 // ********************************************
 // Function to print the prior values
-void covarianceBase::printNominal() {
+void covarianceBase::printNominal() const {
 // ********************************************
   MACH3LOG_INFO("Prior values for {} covarianceBase:", getName());
   for (int i = 0; i < _fNumPar; i++) {
@@ -731,7 +731,7 @@ void covarianceBase::printNominal() {
 
 // ********************************************
 // Function to print the prior, current and proposed values
-void covarianceBase::printNominalCurrProp() {
+void covarianceBase::printNominalCurrProp() const {
 // ********************************************
   MACH3LOG_INFO("Printing parameters for {}", getName());
   // Dump out the PCA parameters too
@@ -774,7 +774,7 @@ double covarianceBase::CalcLikelihood() _noexcept_ {
 }
 
 // ********************************************
-int covarianceBase::CheckBounds() {
+int covarianceBase::CheckBounds() const {
 // ********************************************
   int NOutside = 0;
   #ifdef MULTITHREAD
@@ -932,7 +932,7 @@ void covarianceBase::toggleFixParameter(const std::string& name) {
 }
 
 // ********************************************
-bool covarianceBase::isParameterFixed(const std::string& name) {
+bool covarianceBase::isParameterFixed(const std::string& name) const {
 // ********************************************
   for (int i = 0; i <_fNumPar; ++i) {
     if(name == _fFancyNames[i]) {

--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -45,15 +45,6 @@ covarianceBase::covarianceBase(const std::vector<std::string>& YAMLFile, std::st
 //Destructor
 covarianceBase::~covarianceBase(){
 // ********************************************
-  _fPreFitValue.clear();
-  _fError.clear();
-  _fCurrVal.clear();
-  _fPropVal.clear();
-  _fLowBound.clear();
-  _fUpBound.clear();
-  _fIndivStepScale.clear();
-  _fFlatPrior.clear();
-
   delete[] randParams;
   delete[] corr_throw;
 
@@ -810,16 +801,6 @@ double covarianceBase::GetLikelihood() {
 }
 
 // ********************************************
-void covarianceBase::printPars() {
-// ********************************************
-  MACH3LOG_INFO("Number of pars: {}", _fNumPar);
-  MACH3LOG_INFO("Current {} parameters:", matrixName);
-  for(int i = 0; i < _fNumPar; i++) {
-    MACH3LOG_INFO("{:s} current: \t{:.5f}   \tproposed: \t{:.5f}", _fNames[i], _fCurrVal[i], _fPropVal[i]);
-  }
-}
-
-// ********************************************
 // Sets the proposed parameters to the prior values
 void covarianceBase::setParameters(const std::vector<double>& pars) {
 // ********************************************
@@ -1033,7 +1014,7 @@ void covarianceBase::setIndivStepScale(const std::vector<double>& stepscale) {
 }
 
 // ********************************************
-void covarianceBase::printIndivStepScale() {
+void covarianceBase::printIndivStepScale() const {
 // ********************************************
   MACH3LOG_INFO("============================================================");
   MACH3LOG_INFO("{:<{}} | {:<11}", "Parameter:", PrintLength, "Step scale:");
@@ -1047,12 +1028,13 @@ void covarianceBase::printIndivStepScale() {
 //Makes sure that matrix is positive-definite by adding a small number to on-diagonal elements
 void covarianceBase::MakePosDef(TMatrixDSym *cov) {
 // ********************************************
-  //DB Save original warning state and then increase it in this function to suppress 'matrix not positive definite' messages
-  //Means we no longer need to overload
   if(cov == nullptr){
     cov = &*covMatrix;
+    MACH3LOG_WARN("Passed nullptr to cov matrix in {}", matrixName);
   }
 
+  //DB Save original warning state and then increase it in this function to suppress 'matrix not positive definite' messages
+  //Means we no longer need to overload
   int originalErrorWarning = gErrorIgnoreLevel;
   gErrorIgnoreLevel = kFatal;
   
@@ -1213,7 +1195,6 @@ void covarianceBase::updateAdaptiveCovariance(){
 // then does Euclidean norm)
 void covarianceBase::makeClosestPosDef(TMatrixDSym *cov) {
 // ********************************************
-
   // Want to get cov' = (cov_sym+cov_polar)/2
   // cov_sym=(cov+cov^T)/2
   // cov_polar-> SVD cov to cov=USV^T then cov_polar=VSV^T

--- a/covariance/covarianceBase.h
+++ b/covariance/covarianceBase.h
@@ -32,43 +32,55 @@ class covarianceBase {
   /// @brief Destructor
   virtual ~covarianceBase();
   
+  /// \defgroup Setters
+  /// Group of functions to set various parameters, names, and values.
+
   // ETA - maybe need to add checks to index on the setters? i.e. if( i > _fPropVal.size()){throw;}
   /// @brief Set covariance matrix
   /// @param cov Covariance matrix which we set and will be used later for evaluation of penalty term
+  /// \ingroup Setters
   void setCovMatrix(TMatrixDSym *cov);
   /// @brief Set matrix name
   void setName(std::string name) { matrixName = name; }
   /// @brief change parameter name
   /// @param i Parameter index
   /// @param name new name which will be set
+  /// \ingroup Setters
   void setParName(int i, std::string name) { _fNames.at(i) = name; }
+  /// \ingroup Setters
   void setSingleParameter(const int parNo, const double parVal);
   /// @brief Set all the covariance matrix parameters to a user-defined value
   /// @param i Parameter index
   /// @param val new value which will be set
+  /// \ingroup Setters
   void setPar(const int i, const double val);
   /// @brief Set current parameter value
   /// @param i Parameter index
   /// @param val new value which will be set
+  /// \ingroup Setters
   void setParCurrProp(const int i, const double val);
   /// @brief Set proposed parameter value
   /// @param i Parameter index
   /// @param val new value which will be set
+  /// \ingroup Setters
   void setParProp(const int i, const double val) {
     _fPropVal[i] = val;
     if (pca) TransferToPCA();
   }
   /// @brief Set parameter values using vector, it has to have same size as covariance class
   /// @param pars Vector holding new values for every parameter
+  /// \ingroup Setters
   void setParameters(const std::vector<double>& pars = {});
   /// @brief Set if parameter should have flat prior or not
   /// @param i Parameter index
   /// @param eL bool telling if it will be flat or not
+  /// \ingroup Setters
   void setFlatPrior(const int i, const bool eL);
   
   /// @brief Set random value useful for debugging/CI
   /// @param i Parameter index
   /// @param rand New value for random number
+  /// \ingroup Setters
   void SetRandomThrow(const int i, const double rand) { randParams[i] = rand;}
   /// @brief Get random value useful for debugging/CI
   /// @param i Parameter index
@@ -77,19 +89,24 @@ class covarianceBase {
   /// @brief set branches for output file
   /// @param tree Tree to which we will save branches
   /// @param SaveProposal Normally we only save parameter after is accepted, for debugging purpose it is helpful to see also proposed values. That's what this variable controls
+  /// \ingroup Setters
   void SetBranches(TTree &tree, bool SaveProposal = false);
   /// @brief Set global step scale for covariance object
   /// @param scale Value of global step scale
   /// @cite luengo2020survey
+  /// \ingroup Setters
   void setStepScale(const double scale);
   /// @brief DB Function to set fIndivStepScale from a vector (Can be used from execs and inside covariance constructors)
   /// @param ParameterIndex Parameter Index
   /// @param StepScale Value of individual step scale
+  /// \ingroup Setters
   void setIndivStepScale(const int ParameterIndex, const double StepScale){ _fIndivStepScale.at(ParameterIndex) = StepScale; }
   /// @brief DB Function to set fIndivStepScale from a vector (Can be used from execs and inside covariance constructors)
   /// @param stepscale Vector of individual step scale, should have same
+  /// \ingroup Setters
   void setIndivStepScale(const std::vector<double>& stepscale);
   /// @brief KS: In case someone really want to change this
+  /// \ingroup Setters
   inline void setPrintLength(const unsigned int PriLen) { PrintLength = PriLen; }
 
   /// @brief KS: After step scale, prefit etc. value were modified save this modified config.

--- a/covariance/covarianceBase.h
+++ b/covariance/covarianceBase.h
@@ -240,7 +240,7 @@ class covarianceBase {
   inline double getParInit(const int i) const { return _fPreFitValue[i]; }
   /// @brief Return generated value, although is virtual so class inheriting might actual get prior not generated.
   /// @param i Parameter index
-  virtual double getNominal(const int i) const { return getParInit(i); }
+  virtual double getNominal(const int i) { return getParInit(i); }
   /// @brief Return generated value for a given parameter
   /// @param i Parameter index
   inline double GetGenerated(const int i) const { return _fGenerated[i];}

--- a/covariance/covarianceBase.h
+++ b/covariance/covarianceBase.h
@@ -32,7 +32,6 @@ class covarianceBase {
   /// @brief Destructor
   virtual ~covarianceBase();
   
-  // Setters
   // ETA - maybe need to add checks to index on the setters? i.e. if( i > _fPropVal.size()){throw;}
   /// @brief Set covariance matrix
   /// @param cov Covariance matrix which we set and will be used later for evaluation of penalty term
@@ -53,6 +52,7 @@ class covarianceBase {
   /// @param val new value which will be set
   void setParCurrProp(const int i, const double val);
   /// @brief Set proposed parameter value
+  /// @param i Parameter index
   /// @param val new value which will be set
   void setParProp(const int i, const double val) {
     _fPropVal[i] = val;
@@ -67,8 +67,11 @@ class covarianceBase {
   void setFlatPrior(const int i, const bool eL);
   
   /// @brief Set random value useful for debugging/CI
-  void SetRandomThrow(const int i, const double radn) { randParams[i] = radn;}
+  /// @param i Parameter index
+  /// @param rand New value for random number
+  void SetRandomThrow(const int i, const double rand) { randParams[i] = rand;}
   /// @brief Get random value useful for debugging/CI
+  /// @param i Parameter index
   double GetRandomThrow(const int i) { return randParams[i];}
 
   /// @brief set branches for output file
@@ -103,7 +106,7 @@ class covarianceBase {
   void RandomConfiguration();
   
   /// @brief Check if parameters were proposed outside physical boundary
-  virtual int CheckBounds();
+  int CheckBounds();
   /// @brief Calc penalty term based on inverted covariance matrix
   double CalcLikelihood() _noexcept_;
   /// @brief Return CalcLikelihood if some params were thrown out of boundary return _LARGE_LOGL_
@@ -117,6 +120,7 @@ class covarianceBase {
   double GetInvCovMatrix(const int i, const int j) { return InvertCovMatrix[i][j]; }
 
   /// @brief Return correlated throws
+  /// @param i Parameter index
   double GetCorrThrows(const int i) { return corr_throw[i]; }
 
   /// @brief Get if param has flat prior or not
@@ -313,9 +317,11 @@ class covarianceBase {
   void printNominal();
   /// @brief Print prior, current and proposed value for each parameter
   void printNominalCurrProp();
-  void printPars();
+  /// @warning only for backward compatibility
+  /// @todo remove it
+  void printPars() {printNominalCurrProp();};
   /// @brief Print step scale for each parameter
-  void printIndivStepScale();
+  void printIndivStepScale() const;
 
   /// @brief Generate a new proposed state
   virtual void proposeStep();
@@ -386,9 +392,6 @@ protected:
   /// @brief Transfer param values from PCA base to normal base
   void TransferToParam();
 
-  /// @brief Handy function to return 1 for any systs
-  const double* ReturnUnity(){return &Unity;}
-
   /// @brief sets throw matrix from a file
   /// @param matrix_file_name name of file matrix lives in
   /// @param matrix_name name of matrix in file
@@ -396,7 +399,7 @@ protected:
   void setThrowMatrixFromFile(const std::string& matrix_file_name, const std::string& matrix_name, const std::string& means_name);
 
   /// @brief Method to update adaptive MCMC
-  /// @see https://projecteuclid.org/journals/bernoulli/volume-7/issue-2/An-adaptive-Metropolis-algorithm/bj/1080222083.full
+  /// @cite haario2001adaptive
   void updateAdaptiveCovariance();
 
   /// The input root file we read in
@@ -418,7 +421,7 @@ protected:
   double* randParams;
   /// Result of multiplication of Cholesky matrix and randParams
   double* corr_throw;
-  /// Global step scale applied ot all params in this class
+  /// Global step scale applied to all params in this class
   double _fGlobalStepScale;
 
   /// KS: This is used when printing parameters, sometimes we have super long parameters name, we want to flexibly adjust couts
@@ -450,9 +453,6 @@ protected:
   std::vector<double> _fIndivStepScale;
   /// Whether to apply flat prior or not
   std::vector<bool> _fFlatPrior;
-
-  /// Unity for null systs to point back to
-  const double Unity = 1.0;
 
   /// perform PCA or not
   bool pca;

--- a/covariance/covarianceBase.h
+++ b/covariance/covarianceBase.h
@@ -123,7 +123,7 @@ class covarianceBase {
   void RandomConfiguration();
   
   /// @brief Check if parameters were proposed outside physical boundary
-  int CheckBounds();
+  int CheckBounds() const;
   /// @brief Calc penalty term based on inverted covariance matrix
   double CalcLikelihood() _noexcept_;
   /// @brief Return CalcLikelihood if some params were thrown out of boundary return _LARGE_LOGL_
@@ -145,22 +145,28 @@ class covarianceBase {
   inline bool getFlatPrior(const int i) { return _fFlatPrior[i]; }
 
   /// @brief Get name of covariance
-  std::string getName() { return matrixName; }
+  /// \ingroup Setters
+  std::string getName() const { return matrixName; }
   /// @brief Get name of covariance
   /// @param i Parameter index
-  std::string GetParName(const int i) {return _fNames[i];}
+  /// \ingroup Setters
+  std::string GetParName(const int i) const {return _fNames[i];}
   /// @brief Get fancy name of the Parameter
   /// @param i Parameter index
-  std::string GetParFancyName(const int i) {return _fFancyNames[i];}
+  /// \ingroup Setters
+  std::string GetParFancyName(const int i) const {return _fFancyNames[i];}
   /// @brief Get name of input file
+  /// \ingroup Setters
   std::string getInputFile() const { return inputFile; }
 
   /// @brief Get diagonal error for ith parameter
   /// @param i Parameter index
-  inline double getDiagonalError(const int i) { return std::sqrt((*covMatrix)(i,i)); }
+  /// \ingroup Setters
+  inline double getDiagonalError(const int i) const { return std::sqrt((*covMatrix)(i,i)); }
   /// @brief Get the error for the ith parameter
   /// @param i Parameter index
-  inline double GetError(const int i) {return _fError[i];}
+  /// \ingroup Setters
+  inline double GetError(const int i) const {return _fError[i];}
 
   /// @brief Adaptive Step Tuning Stuff
   void resetIndivStepScale();
@@ -214,44 +220,44 @@ class covarianceBase {
 
   //Some Getters
   /// @brief Get total number of parameters
-  inline int  GetNumParams() {return _fNumPar;}
+  inline int  GetNumParams() const {return _fNumPar;}
   /// @brief Get the prior array for parameters.
   virtual std::vector<double> getNominalArray();
   /// @brief Get the pre-fit values of the parameters.
-  std::vector<double> getPreFitValues(){return _fPreFitValue;}
+  std::vector<double> getPreFitValues() const {return _fPreFitValue;}
   /// @brief Get the generated values of the parameters.
-  std::vector<double> getGeneratedValues(){return _fGenerated;}
+  std::vector<double> getGeneratedValues() const {return _fGenerated;}
   /// @brief Get vector of all proposed parameter values
   std::vector<double> getProposed() const;
   /// @brief Get proposed parameter value
   /// @param i Parameter index
-  inline double getParProp(const int i) { return _fPropVal[i]; }
+  inline double getParProp(const int i) const { return _fPropVal[i]; }
   /// @brief Get current parameter value
   /// @param i Parameter index
-  inline double getParCurr(const int i) { return _fCurrVal[i]; }
+  inline double getParCurr(const int i) const { return _fCurrVal[i]; }
   /// @brief Get prior parameter value
   /// @param i Parameter index
-  inline double getParInit(const int i) { return _fPreFitValue[i]; }
+  inline double getParInit(const int i) const { return _fPreFitValue[i]; }
   /// @brief Return generated value, although is virtual so class inheriting might actual get prior not generated.
   /// @param i Parameter index
-  virtual double getNominal(const int i) { return getParInit(i); }
+  virtual double getNominal(const int i) const { return getParInit(i); }
   /// @brief Return generated value for a given parameter
   /// @param i Parameter index
-  inline double GetGenerated(const int i) { return _fGenerated[i];}
+  inline double GetGenerated(const int i) const { return _fGenerated[i];}
   /// @brief Get upper parameter bound in which it is physically valid
   /// @param i Parameter index
-  inline double GetUpperBound(const int i){ return _fUpBound[i];}
+  inline double GetUpperBound(const int i) const { return _fUpBound[i];}
   /// @brief Get lower parameter bound in which it is physically valid
   /// @param i Parameter index
-  inline double GetLowerBound(const int i){ return _fLowBound[i]; }
+  inline double GetLowerBound(const int i) const { return _fLowBound[i]; }
   /// @brief Get individual step scale for selected parameter
   /// @param ParameterIndex Parameter index
-  inline double GetIndivStepScale(const int ParameterIndex){return _fIndivStepScale.at(ParameterIndex); }
+  inline double GetIndivStepScale(const int ParameterIndex) const {return _fIndivStepScale.at(ParameterIndex); }
   /// @brief Get global step scale for covariance object
-  inline double GetGlobalStepScale(){return _fGlobalStepScale; }
+  inline double GetGlobalStepScale() const {return _fGlobalStepScale; }
   /// @brief Get current parameter value using PCA
   /// @param i Parameter index
-  inline double getParProp_PCA(const int i) {
+  inline double getParProp_PCA(const int i)  {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     return fParProp_PCA(i);
   }
@@ -331,12 +337,12 @@ class covarianceBase {
   }
 
   /// @brief Print prior value for every parameter
-  void printNominal();
+  void printNominal() const;
   /// @brief Print prior, current and proposed value for each parameter
-  void printNominalCurrProp();
+  void printNominalCurrProp() const;
   /// @warning only for backward compatibility
   /// @todo remove it
-  void printPars() {printNominalCurrProp();};
+  void printPars() const {printNominalCurrProp();};
   /// @brief Print step scale for each parameter
   void printIndivStepScale() const;
 
@@ -361,13 +367,13 @@ class covarianceBase {
 
   /// @brief Is parameter fixed or not
   /// @param i Parameter index
-  bool isParameterFixed(const int i) {
+  bool isParameterFixed(const int i) const {
     if (_fError[i] < 0) { return true; }
     else                { return false; }
   }
   /// @brief Is parameter fixed or not
   /// @param name Name of parameter you want to check if is fixed
-  bool isParameterFixed(const std::string& name);
+  bool isParameterFixed(const std::string& name) const;
 
   /// @brief CW: Calculate eigen values, prepare transition matrices and remove param based on defined threshold
   /// @see For more details, visit the [Wiki](https://github.com/mach3-software/MaCh3/wiki/03.-Eigen-Decomposition-%E2%80%90-PCA).

--- a/covariance/covarianceOsc.cpp
+++ b/covariance/covarianceOsc.cpp
@@ -4,35 +4,36 @@
 covarianceOsc::covarianceOsc(const std::vector<std::string>& YAMLFile, std::string name, double threshold, int FirstPCA, int LastPCA)
 : covarianceBase(YAMLFile, name, threshold, FirstPCA, LastPCA){
 // *************************************
-
   kDeltaCP = -999;
   kDeltaM23 = -999;
-  kSinTheta23 = -999;
-  kSinTheta23 = -999;
   kSinTheta23 = -999;
   for(int io = 0; io < _fNumPar; io++)
   {
     _fNames[io] = _fFancyNames[io];
-
     if(_fNames[io] == "delta_cp")  kDeltaCP = io;
     if(_fNames[io] == "delm2_23")  kDeltaM23 = io;
     if(_fNames[io] == "sin2th_23") kSinTheta23 = io;
-    if(_fNames[io] == "baseline") kBaseline = io;
-    if(_fNames[io] == "density") kDensity = io;
 
     // Set covarianceBase parameters (Curr = current, Prop = proposed, Sigma = step)
     _fCurrVal[io] = _fPreFitValue[io];
     _fPropVal[io] = _fCurrVal[io];
   }
+  // KS: Check if params have been found. Otherwise things can go wrong
+  auto CheckInitialisation = [](const std::string& paramName, int paramValue) {
+    if (paramValue == -999) {
+      MACH3LOG_WARN("Parameter {} has not been initialized properly.", paramName);
+      MACH3LOG_WARN("Things are unpredictable");
+    }
+  };
+  CheckInitialisation("delta_cp", kDeltaCP);
+  CheckInitialisation("delm2_23", kDeltaM23);
+  CheckInitialisation("sin2th_23", kSinTheta23);
 
   /// @todo KS: Technically if we would like to use PCA we have to initialise parts here...
   flipdelM = false;
 
   randomize();
-
   Print();
-
-  MACH3LOG_INFO("Created oscillation parameter handler");
 }
 
 // *************************************
@@ -42,25 +43,8 @@ covarianceOsc::~covarianceOsc() {
 }
 
 // *************************************
-int covarianceOsc::CheckBounds() {
-// *************************************
-  int NOutside = 0;
-
-  // ensure osc params don't go unphysical
-  if (_fPropVal[0] > 1.0 || _fPropVal[0] < 0 ||
-      _fPropVal[kSinTheta23] > 1.0 || _fPropVal[kSinTheta23] < 0 ||
-      _fPropVal[2] > 1.0 || _fPropVal[2] < 0
-      //|| _fPropVal[kDeltaM23] < 0.0 || _fPropVal[kDeltaM23] > 20E-3 // don't let dm32 go to IH
-      //|| fabs(_fPropVal[kDeltaM23]) > 0.004 || fabs(_fPropVal[kDeltaM23]) < 0.001
-      //|| _fPropVal[kDeltaCP] < -1*TMath::Pi() || _fPropVal[kDeltaCP] > TMath::Pi()
-     ){ NOutside++;}
-  return NOutside;
-}
-
-// *************************************
 void covarianceOsc::proposeStep() {
 // *************************************
-
   covarianceBase::proposeStep();
 
   // HW :: This method is a tad hacky but modular arithmetic gives me a headache.
@@ -88,7 +72,6 @@ void covarianceOsc::proposeStep() {
 //KS: Print all useful information's after initialization
 void covarianceOsc::Print() {
 // *************************************
-
   MACH3LOG_INFO("Number of pars: {}", _fNumPar);
   MACH3LOG_INFO("Current: {} parameters:", matrixName);
 

--- a/covariance/covarianceOsc.h
+++ b/covariance/covarianceOsc.h
@@ -13,19 +13,10 @@ class covarianceOsc : public covarianceBase
   covarianceOsc(const std::vector<std::string>& FileNames, std::string name = "osc_cov", double threshold = -1, int FirstPCAdpar = -999, int LastPCAdpar = -999);
   /// @brief Destructor
   virtual ~covarianceOsc();
-  /// @brief Checks if parameter didn't go outside of physical bounds
-  inline int CheckBounds() override;
-  /// @brief Retrieves the proposed parameters.
-  double *getPropPars();
   /// @brief Propose MCMC step, including mass flipping
   void proposeStep() override;
   /// @brief Sets whether to flip delta M23.
   void setFlipDeltaM23(bool flip){flipdelM = flip;}
-
-  /// @brief Get baseline
-  inline double GetPathLength() { return _fPropVal[kBaseline];}
-  /// @brief Get density
-  inline double GetDensity() { return _fPropVal[kDensity];}
 
   /// @brief KS: Print all useful information's after initialization
   void Print();
@@ -39,8 +30,4 @@ class covarianceOsc : public covarianceBase
     int kDeltaM23;
     /// Enum for special treatment of sin(theta23).
     int kSinTheta23;
-    /// Enum for special treatment of of baseline
-    int kBaseline;
-    /// Enum for special treatment of of density
-    int kDensity;
 };

--- a/covariance/covarianceXsec.h
+++ b/covariance/covarianceXsec.h
@@ -82,10 +82,6 @@ class covarianceXsec : public covarianceBase {
       }
       return prior;
     }
-    /// @brief Get prior for a given param
-    /// @param i parameter index
-    inline double getNominal(const int i) override { return _fPreFitValue.at(i); };
-
     /// @brief Checks if parameter belongs to a given group
     /// @param i parameter index
     /// @param Group name of group, like Xsec or Flux

--- a/python/covariance.cpp
+++ b/python/covariance.cpp
@@ -17,15 +17,6 @@ public:
     using covarianceBase::covarianceBase;
 
     /* Trampoline (need one for each virtual function) */
-    int CheckBounds() {
-        PYBIND11_OVERRIDE_NAME(
-            int,            /* Return type */
-            covarianceBase, /* Parent class */
-            "check_bounds", /* Name in python*/
-            CheckBounds     /* Name of function in C++ (must match Python name) */
-        );
-    }
-
     double GetLikelihood() override {
         PYBIND11_OVERRIDE_NAME(
             double,           /* Return type */

--- a/python/covariance.cpp
+++ b/python/covariance.cpp
@@ -17,7 +17,7 @@ public:
     using covarianceBase::covarianceBase;
 
     /* Trampoline (need one for each virtual function) */
-    int CheckBounds() override {
+    int CheckBounds() {
         PYBIND11_OVERRIDE_NAME(
             int,            /* Return type */
             covarianceBase, /* Parent class */


### PR DESCRIPTION
# Pull request description
Plenty of tidy to cov classes

## Changes or fixes
- With NuOsc we no longer need hacks for baseline and desnity
- Stop with hardcoded checks for Sin for bounds, use actual base check bounds
- We still have special tramtent from ordering so added warning if these are not defined
- Removed some other dpecracated stuff from other covs

## Examples
