### PR TITLE
bugfix: linking splines on ubuntu

### DIFF
--- a/samplePDF/CMakeLists.txt
+++ b/samplePDF/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(SamplePDF SHARED
     HistogramUtils.cpp
 )
 
-target_link_libraries(SamplePDF PUBLIC Splines NuOscillator Covariance)
+target_link_libraries(SamplePDF PUBLIC Splines NuOscillator)
 target_link_libraries(SamplePDF PRIVATE MaCh3Warnings)
 
 target_include_directories(SamplePDF PUBLIC

--- a/splines/CMakeLists.txt
+++ b/splines/CMakeLists.txt
@@ -29,7 +29,7 @@ set_target_properties(Splines PROPERTIES
     PUBLIC_HEADER "${HEADERS}"
     EXPORT_NAME Splines)
 
-target_link_libraries(Splines PUBLIC Manager MaCh3CompilerOptions MaCh3GPUCompilerOptions)
+target_link_libraries(Splines PUBLIC Covariance MaCh3CompilerOptions MaCh3GPUCompilerOptions)
 target_link_libraries(Splines PRIVATE MaCh3Warnings)
 
 target_include_directories(Splines PUBLIC


### PR DESCRIPTION
# Pull request description
This is problem
```
/usr/bin/ld: ../_deps/mach3-build/splines/libSplines.so: undefined reference to covarianceXsec::GetSplineParsNamesFromDetID[abi:cxx11](int)'
/usr/bin/ld: ../_deps/mach3-build/splines/libSplines.so: undefined reference to covarianceXsec::GetSplineInterpolationFromDetID(int)'
/usr/bin/ld: ../_deps/mach3-build/splines/libSplines.so: undefined reference to covarianceXsec::GetGlobalSystIndexFromDetID(int, SystType)'
/usr/bin/ld: ../_deps/mach3-build/splines/libSplines.so: undefined reference to covarianceXsec::GetNumParamsFromDetID(int, SystType)'
/usr/bin/ld: ../_deps/mach3-build/splines/libSplines.so: undefined reference to covarianceXsec::GetSplineModeVecFromDetID(int)'
```

Problem is Splines depend on Covariance, so had to change linking order. Porblem only appeared for ubuntu 
## Changes or fixes


## Examples
![Before](https://github.com/user-attachments/assets/ef8af3d2-1369-4093-9d1b-06a6387c6ab4)

![After](https://github.com/user-attachments/assets/60d7319d-3eda-4a17-a9e7-4c9c9e92766e)
