### PR TITLE
breaking: Improve Det Id tremtent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 # CMake version check
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
-project(MaCh3 VERSION 1.3.2 LANGUAGES CXX)
+project(MaCh3 VERSION 1.4.0 LANGUAGES CXX)
 set(MaCh3_VERSION ${PROJECT_VERSION})
 
 #LP - This option name is confusing, but I wont change it now.

--- a/Doc/Doxyfile
+++ b/Doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "MaCh3"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.3.2
+PROJECT_NUMBER         = 1.4.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/covariance/covarianceBase.h
+++ b/covariance/covarianceBase.h
@@ -425,6 +425,11 @@ protected:
   /// @cite haario2001adaptive
   void updateAdaptiveCovariance();
 
+  /// @brief Check if parameter is affecting given det ID
+  /// @param SystIndex number of parameter
+  /// @param DetID The Detector ID used to filter parameters.
+  bool AppliesToDetID(const int SystIndex, const std::string& DetID) const;
+
   /// The input root file we read in
   const std::string inputFile;
 
@@ -476,6 +481,8 @@ protected:
   std::vector<double> _fIndivStepScale;
   /// Whether to apply flat prior or not
   std::vector<bool> _fFlatPrior;
+  /// Tells to which samples object param should be applied
+  std::vector<std::vector<std::string>> _fDetID;
 
   /// perform PCA or not
   bool pca;

--- a/covariance/covarianceOsc.cpp
+++ b/covariance/covarianceOsc.cpp
@@ -81,11 +81,34 @@ void covarianceOsc::Print() {
   MACH3LOG_INFO("Number of pars: {}", _fNumPar);
   MACH3LOG_INFO("Current: {} parameters:", matrixName);
 
-  MACH3LOG_INFO("{:<5} | {:<25} | {:<10} | {:<15} | {:<15} | {:<10}",
-                "#", "Name", "Nom.", "IndivStepScale", "_fError", "FlatPrior");
+  MACH3LOG_INFO("=================================================================================================================================");
+  MACH3LOG_INFO("{:<5} {:2} {:<25} {:2} {:<10} {:2} {:<15} {:2} {:<15} {:2} {:<10} {:2} {:<10}",
+                "#", "|", "Name", "|", "Prior", "|", "IndivStepScale", "|", "Error", "|", "FlatPrior", "|", "DetID");
+  MACH3LOG_INFO("---------------------------------------------------------------------------------------------------------------------------------");
+  for (int i = 0; i < _fNumPar; i++) {
+    std::string detIdString = "";
+    for (const auto& detID : _fDetID[i]) {
+      if (!detIdString.empty()) {
+        detIdString += ", ";
+      }
+      detIdString += detID;
+    }
 
-  for(int i = 0; i < _fNumPar; i++) {
-    MACH3LOG_INFO("{:<5} | {:<25} | {:<10.4f} | {:<15.2f} | {:<15.4f} | {:<10}",
-                  i, _fNames[i].c_str(), _fPreFitValue[i], _fIndivStepScale[i], _fError[i], _fFlatPrior[i]);
+    MACH3LOG_INFO("{:<5} {:2} {:<25} {:2} {:<10.4f} {:2} {:<15.2f} {:2} {:<15.4f} {:2} {:<10} {:2} {:<10}",
+                  i, "|", _fNames[i].c_str(), "|", _fPreFitValue[i], "|", _fIndivStepScale[i], "|", _fError[i], "|", _fFlatPrior[i], "|", detIdString);
   }
+  MACH3LOG_INFO("=================================================================================================================================");
+}
+
+// ********************************************
+// DB Grab the Normalisation parameters for the relevant DetID
+std::vector<const double*> covarianceOsc::GetOscParsFromDetID(const std::string& DetID) {
+// ********************************************
+  std::vector<const double*> returnVec;
+  for (int i = 0; i < _fNumPar; ++i) {
+    if (AppliesToDetID(i, DetID)) {
+      returnVec.push_back(retPointer(i));
+    }
+  }
+  return returnVec;
 }

--- a/covariance/covarianceOsc.h
+++ b/covariance/covarianceOsc.h
@@ -17,7 +17,8 @@ class covarianceOsc : public covarianceBase
   void proposeStep() override;
   /// @brief Sets whether to flip delta M23.
   void setFlipDeltaM23(bool flip){flipdelM = flip;}
-
+  /// @brief Get pointers to Osc params from detId
+  std::vector<const double*> GetOscParsFromDetID(const std::string& DetID);
   /// @brief KS: Print all useful information's after initialization
   void Print();
 

--- a/covariance/covarianceXsec.cpp
+++ b/covariance/covarianceXsec.cpp
@@ -28,7 +28,6 @@ void covarianceXsec::InitXsecFromConfig() {
 // ********************************************
   _fSystToGlobalSystIndexMap.resize(SystType::kSystTypes);
 
-  _fDetID = std::vector<int>(_fNumPar);
   _fParamType = std::vector<SystType>(_fNumPar);
   _ParameterGroup = std::vector<std::string>(_fNumPar);
 
@@ -43,7 +42,6 @@ void covarianceXsec::InitXsecFromConfig() {
   //PreFitValues etc etc.
   for (auto const &param : _fYAMLDoc["Systematics"])
   {
-    _fDetID[i] = Get<int>(param["Systematic"]["DetID"], __FILE__ , __LINE__);
     _ParameterGroup[i] = Get<std::string>(param["Systematic"]["ParameterGroup"], __FILE__ , __LINE__);
 
     //Fill the map to get the correlations later as well
@@ -105,7 +103,7 @@ covarianceXsec::~covarianceXsec() {
 
 // ********************************************
 // DB Grab the Spline Names for the relevant DetID
-const std::vector<std::string> covarianceXsec::GetSplineParsNamesFromDetID(const int DetID) {
+const std::vector<std::string> covarianceXsec::GetSplineParsNamesFromDetID(const std::string& DetID) {
 // ********************************************
   std::vector<std::string> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kSpline]) {
@@ -120,7 +118,7 @@ const std::vector<std::string> covarianceXsec::GetSplineParsNamesFromDetID(const
 }
 
 // ********************************************
-const std::vector<SplineInterpolation> covarianceXsec::GetSplineInterpolationFromDetID(const int DetID) {
+const std::vector<SplineInterpolation> covarianceXsec::GetSplineInterpolationFromDetID(const std::string& DetID) {
 // ********************************************
   std::vector<SplineInterpolation> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kSpline]) {
@@ -136,7 +134,7 @@ const std::vector<SplineInterpolation> covarianceXsec::GetSplineInterpolationFro
 
 // ********************************************
 // DB Grab the Spline Modes for the relevant DetID
-const std::vector< std::vector<int> > covarianceXsec::GetSplineModeVecFromDetID(const int DetID) {
+const std::vector< std::vector<int> > covarianceXsec::GetSplineModeVecFromDetID(const std::string& DetID) {
 // ********************************************
   std::vector< std::vector<int> > returnVec;
   //Need a counter or something to correctly get the index in _fSplineModes since it's not of length nPars
@@ -144,7 +142,7 @@ const std::vector< std::vector<int> > covarianceXsec::GetSplineModeVecFromDetID(
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kSpline]) {
     auto &SplineIndex = pair.first;
     auto &SystIndex = pair.second;
-    if ((GetParDetID(SystIndex) & DetID)) { //If parameter applies to required DetID
+    if (AppliesToDetID(SystIndex, DetID)) { //If parameter applies to required DetID
       returnVec.push_back(SplineParams.at(SplineIndex)._fSplineModes);
     }
   }
@@ -213,7 +211,7 @@ XsecNorms4 covarianceXsec::GetXsecNorm(const YAML::Node& param, const int Index)
 // ********************************************
 // Grab the global syst index for the relevant DetID
 // i.e. get a vector of size nSplines where each entry is filled with the global syst number
-const std::vector<int> covarianceXsec::GetGlobalSystIndexFromDetID(const int DetID, const SystType Type) {
+const std::vector<int> covarianceXsec::GetGlobalSystIndexFromDetID(const std::string& DetID, const SystType Type) {
 // ********************************************
   std::vector<int> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[Type]) {
@@ -228,7 +226,7 @@ const std::vector<int> covarianceXsec::GetGlobalSystIndexFromDetID(const int Det
 // ********************************************
 // Grab the global syst index for the relevant DetID
 // i.e. get a vector of size nSplines where each entry is filled with the global syst number
-const std::vector<int> covarianceXsec::GetSystIndexFromDetID(int DetID,  const SystType Type) {
+const std::vector<int> covarianceXsec::GetSystIndexFromDetID(const std::string& DetID,  const SystType Type) {
 // ********************************************
   std::vector<int> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[Type]) {
@@ -267,7 +265,7 @@ XsecSplines1 covarianceXsec::GetXsecSpline(const YAML::Node& param) {
 
 // ********************************************
 // DB Grab the Normalisation parameters for the relevant DetID
-const std::vector<XsecNorms4> covarianceXsec::GetNormParsFromDetID(const int DetID) {
+const std::vector<XsecNorms4> covarianceXsec::GetNormParsFromDetID(const std::string& DetID) {
 // ********************************************
   std::vector<XsecNorms4> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kNorm]) {
@@ -282,7 +280,7 @@ const std::vector<XsecNorms4> covarianceXsec::GetNormParsFromDetID(const int Det
 
 // ********************************************
 // DB Grab the number of parameters for the relevant DetID
-int covarianceXsec::GetNumParamsFromDetID(const int DetID, const SystType Type) {
+int covarianceXsec::GetNumParamsFromDetID(const std::string& DetID, const SystType Type) {
 // ********************************************
   int returnVal = 0;
   IterateOverParams(DetID,
@@ -294,7 +292,7 @@ int covarianceXsec::GetNumParamsFromDetID(const int DetID, const SystType Type) 
 
 // ********************************************
 // DB Grab the parameter names for the relevant DetID
-const std::vector<std::string> covarianceXsec::GetParsNamesFromDetID(const int DetID, const SystType Type) {
+const std::vector<std::string> covarianceXsec::GetParsNamesFromDetID(const std::string& DetID, const SystType Type) {
 // ********************************************
   std::vector<std::string> returnVec;
   IterateOverParams(DetID,
@@ -306,7 +304,7 @@ const std::vector<std::string> covarianceXsec::GetParsNamesFromDetID(const int D
 
 // ********************************************
 // DB DB Grab the parameter indices for the relevant DetID
-const std::vector<int> covarianceXsec::GetParsIndexFromDetID(const int DetID, const SystType Type) {
+const std::vector<int> covarianceXsec::GetParsIndexFromDetID(const std::string& DetID, const SystType Type) {
 // ********************************************
   std::vector<int> returnVec;
   IterateOverParams(DetID,
@@ -318,7 +316,7 @@ const std::vector<int> covarianceXsec::GetParsIndexFromDetID(const int DetID, co
 
 // ********************************************
 template <typename FilterFunc, typename ActionFunc>
-void covarianceXsec::IterateOverParams(const int DetID, FilterFunc filter, ActionFunc action) {
+void covarianceXsec::IterateOverParams(const std::string& DetID, FilterFunc filter, ActionFunc action) {
 // ********************************************
   for (int i = 0; i < _fNumPar; ++i) {
     if ((AppliesToDetID(i, DetID)) && filter(i)) { // Common filter logic
@@ -383,11 +381,18 @@ void covarianceXsec::Print() {
 void covarianceXsec::PrintGlobablInfo() {
 // ********************************************
   MACH3LOG_INFO("============================================================================================================================================================");
-  MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<5} {:2} {:<10}", "#", "|", "Name", "|", "Gen.", "|", "Prior", "|", "Error", "|", "Lower", "|", "Upper", "|", "StepScale", "|", "DetID", "|", "Type");
+  MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10}", "#", "|", "Name", "|", "Gen.", "|", "Prior", "|", "Error", "|", "Lower", "|", "Upper", "|", "StepScale", "|", "DetID", "|", "Type");
   MACH3LOG_INFO("------------------------------------------------------------------------------------------------------------------------------------------------------------");
   for (int i = 0; i < GetNumParams(); i++) {
     std::string ErrString = fmt::format("{:.2f}", _fError[i]);
-    MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<5} {:2} {:<10}", i, "|", GetParFancyName(i), "|", _fGenerated[i], "|", _fPreFitValue[i], "|", "+/- " + ErrString, "|", _fLowBound[i], "|", _fUpBound[i], "|", _fIndivStepScale[i], "|", _fDetID[i], "|", SystType_ToString(_fParamType[i]));
+    std::string detIdString = "";
+    for (const auto& detID : _fDetID[i]) {
+      if (!detIdString.empty()) {
+        detIdString += ", ";
+      }
+      detIdString += detID;
+    }
+    MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10}", i, "|", GetParFancyName(i), "|", _fGenerated[i], "|", _fPreFitValue[i], "|", "+/- " + ErrString, "|", _fLowBound[i], "|", _fUpBound[i], "|", _fIndivStepScale[i], "|", detIdString, "|", SystType_ToString(_fParamType[i]));
   }
   MACH3LOG_INFO("============================================================================================================================================================");
 }
@@ -590,9 +595,7 @@ void covarianceXsec::DumpMatrixToFile(const std::string& Name) {
 
   TVectorD* xsec_param_knot_weight_lb = new TVectorD(_fNumPar);
   TVectorD* xsec_param_knot_weight_ub = new TVectorD(_fNumPar);
-
   TVectorD* xsec_error = new TVectorD(_fNumPar);
-  TVectorD* xsec_param_id = new TVectorD(_fNumPar);
 
   for(int i = 0; i < _fNumPar; ++i)
   {
@@ -610,7 +613,6 @@ void covarianceXsec::DumpMatrixToFile(const std::string& Name) {
     (*xsec_flat_prior)[i] = _fFlatPrior[i];
     (*xsec_stepscale)[i] = _fIndivStepScale[i];
     (*xsec_error)[i] = _fError[i];
-    (*xsec_param_id)[i] = _fDetID[i];
 
     (*xsec_param_lb)[i] = _fLowBound[i];
     (*xsec_param_ub)[i] = _fUpBound[i];
@@ -657,9 +659,6 @@ void covarianceXsec::DumpMatrixToFile(const std::string& Name) {
   delete xsec_param_knot_weight_lb;
   xsec_param_knot_weight_ub->Write("xsec_param_knot_weight_ub");
   delete xsec_param_knot_weight_ub;
-
-  xsec_param_id->Write("xsec_param_id");
-  delete xsec_param_id;
   xsec_error->Write("xsec_error");
   delete xsec_error;
 

--- a/covariance/covarianceXsec.h
+++ b/covariance/covarianceXsec.h
@@ -24,7 +24,7 @@ class covarianceXsec : public covarianceBase {
     // General Getter functions not split by detector
     /// @brief ETA - just return the int of the DetID, this can be removed to do a string comp at some point.
     /// @param i parameter index
-    inline int GetParDetID(const int i) const { return _fDetID[i];};
+    inline std::vector<std::string> GetParDetID(const int i) const { return _fDetID[i];};
     /// @brief ETA - just return a string of "spline", "norm" or "functional"
     /// @param i parameter index
     inline std::string GetParamTypeString(const int i) const { return SystType_ToString(_fParamType[i]); }
@@ -36,13 +36,13 @@ class covarianceXsec : public covarianceBase {
     /// @param i spline parameter index, not confuse with global index
     inline SplineInterpolation GetParSplineInterpolation(const int i) {return SplineParams.at(i)._SplineInterpolationType;}
     /// @brief Get the interpolation types for splines affecting a particular DetID
-    const std::vector<SplineInterpolation> GetSplineInterpolationFromDetID(int DetID);
+    const std::vector<SplineInterpolation> GetSplineInterpolationFromDetID(const std::string& DetID);
     /// @brief Get the name of the spline associated with the spline at index i
     /// @param i spline parameter index, not to be confused with global index
     std::string GetParSplineName(const int i) {return _fSplineNames[i];}
 
-    //DB Get spline parameters depending on given DetID
-    const std::vector<int> GetGlobalSystIndexFromDetID(const int DetID, const SystType Type);
+    /// @brief DB Get spline parameters depending on given DetID
+    const std::vector<int> GetGlobalSystIndexFromDetID(const std::string& DetID, const SystType Type);
     /// @brief EM: value at which we cap spline knot weight
     /// @param i spline parameter index, not confuse with global index
     inline double GetParSplineKnotUpperBound(const int i) {return SplineParams.at(i)._SplineKnotUpBound;}
@@ -52,26 +52,26 @@ class covarianceXsec : public covarianceBase {
 
     /// @brief DB Grab the number of parameters for the relevant DetID
     /// @param Type Type of syst, for example kNorm, kSpline etc
-    int GetNumParamsFromDetID(const int DetID, const SystType Type);
+    int GetNumParamsFromDetID(const std::string& DetID, const SystType Type);
     /// @brief DB Grab the parameter names for the relevant DetID
     /// @param Type Type of syst, for example kNorm, kSpline etc
-    const std::vector<std::string> GetParsNamesFromDetID(const int DetID, const SystType Type);
+    const std::vector<std::string> GetParsNamesFromDetID(const std::string& DetID, const SystType Type);
     /// @brief DB Grab the parameter indices for the relevant DetID
     /// @param Type Type of syst, for example kNorm, kSpline etc
-    const std::vector<int> GetParsIndexFromDetID(const int DetID, const SystType Type);
+    const std::vector<int> GetParsIndexFromDetID(const std::string& DetID, const SystType Type);
 
     /// @brief DB Get spline parameters depending on given DetID
-    const std::vector<std::string> GetSplineParsNamesFromDetID(const int DetID);
+    const std::vector<std::string> GetSplineParsNamesFromDetID(const std::string& DetID);
     /// @brief DB Get spline parameters depending on given DetID
-    const std::vector<std::string> GetSplineFileParsNamesFromDetID(const int DetID);
+    const std::vector<std::string> GetSplineFileParsNamesFromDetID(const std::string& DetID);
 
     /// @brief DB Grab the Spline Modes for the relevant DetID
-    const std::vector< std::vector<int> > GetSplineModeVecFromDetID(const int DetID);
+    const std::vector< std::vector<int> > GetSplineModeVecFromDetID(const std::string& DetID);
     /// @brief Grab the index of the syst relative to global numbering.
     /// @param Type Type of syst, for example kNorm, kSpline etc
-    const std::vector<int> GetSystIndexFromDetID(const int DetID, const SystType Type);
+    const std::vector<int> GetSystIndexFromDetID(const std::string& DetID, const SystType Type);
     /// @brief DB Get norm/func parameters depending on given DetID
-    const std::vector<XsecNorms4> GetNormParsFromDetID(const int DetID);
+    const std::vector<XsecNorms4> GetNormParsFromDetID(const std::string& DetID);
 
     /// @brief KS: For most covariances prior and fparInit (prior) are the same, however for Xsec those can be different
     std::vector<double> getNominalArray() override
@@ -126,13 +126,8 @@ class covarianceXsec : public covarianceBase {
     /// parameter.
     /// @param DetID The Detector ID used to filter parameters.
     template <typename FilterFunc, typename ActionFunc>
-    void IterateOverParams(const int DetID, FilterFunc filter, ActionFunc action);
-    /// @brief Check if parameter is affecting given det ID
-    /// @param SystIndex number of parameter
-    /// @param DetID The Detector ID used to filter parameters.
-    bool AppliesToDetID(const int SystIndex, const int DetID) const {
-      return (GetParDetID(SystIndex) & DetID) != 0;
-    }
+    void IterateOverParams(const std::string& DetID, FilterFunc filter, ActionFunc action);
+
     /// @brief Initializes the systematic parameters from the configuration file.
     /// This function loads parameters like normalizations and splines from the provided YAML file.
     /// @note This is used internally during the object's initialization process.
@@ -148,8 +143,6 @@ class covarianceXsec : public covarianceBase {
     /// @param param Yaml node describing param
     inline XsecSplines1 GetXsecSpline(const YAML::Node& param);
 
-    /// Tells to which samples object param should be applied
-    std::vector<int> _fDetID;
     /// Type of parameter like norm, spline etc.
     std::vector<SystType> _fParamType;
 

--- a/samplePDF/FarDetectorCoreInfoStruct.h
+++ b/samplePDF/FarDetectorCoreInfoStruct.h
@@ -22,8 +22,6 @@ struct FarDetectorCoreInfo {
   std::vector<const int*> nupdg;
   std::vector<const int*> nupdgUnosc;
 
-  int SampleDetID;
-
   //THe x_var and y_vars that you're binning in
   std::vector<const double*> x_var;
   std::vector<const double*> y_var;

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -563,19 +563,4 @@ namespace MaCh3Utils {
     return NuOscillatorFlavour;
   }
   // ***************************
-
-  /// @brief DB Anything added here must be of the form 2^X, where X is an integer
-  /// @warning DB Used to contain which DetIDs are supported
-  static const std::unordered_map<int,int>KnownDetIDsMap({
-    {0,1},    //ND
-    {1,8},    //FD
-    {2,16},   //SK1Rmu
-    {3,32},   //Nova
-    {4,64},   //Atm SubGeV e-like
-    {5,128},  //Atm SubGeV mu-like
-    {6,256},  //Atm MultiGeV e-like
-    {7,512},  //Atm MultiGeV mu-like
-  });
-  static const int nKnownDetIDs = int(KnownDetIDsMap.size());
-
 } // end MaCh3Utils namespace

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -29,7 +29,7 @@ samplePDFFDBase::samplePDFFDBase(std::string ConfigFileName, covarianceXsec* xse
   
   samplePDFFD_array = nullptr;
   samplePDFFD_data = nullptr;
-  
+  SampleDetID = "";
   SampleManager = std::unique_ptr<manager>(new manager(ConfigFileName.c_str()));
 }
 
@@ -72,7 +72,7 @@ void samplePDFFDBase::ReadSampleConfig()
     MACH3LOG_ERROR("ID not defined in {}, please add this!", SampleManager->GetFileName());
     throw MaCh3Exception(__FILE__, __LINE__);
   }
-  SampleDetID = SampleManager->raw()["DetID"].as<int>();
+  SampleDetID = SampleManager->raw()["DetID"].as<std::string>();
 
   if (!CheckNodeExists(SampleManager->raw(), "NuOsc", "NuOscConfigFile")) {
     MACH3LOG_ERROR("NuOsc::NuOscConfigFile is not defined in {}, please add this!", SampleManager->GetFileName());
@@ -349,14 +349,14 @@ void samplePDFFDBase::reweight() {
   //You only need to do these things if OscCov has been initialised
   //if not then you're not considering oscillations
   if (OscCov) {
-    std::vector<M3::float_t> OscVec(OscCov->GetNumParams());
-    for (int iPar=0;iPar<OscCov->GetNumParams();iPar++) {
+    std::vector<M3::float_t> OscVec(OscParams.size());
+    for (size_t iPar = 0; iPar < OscParams.size(); ++iPar) {
       #pragma GCC diagnostic push
       #pragma GCC diagnostic ignored "-Wuseless-cast"
-      OscVec[iPar] = M3::float_t(OscCov->getParProp(iPar));
+      OscVec[iPar] = M3::float_t(*OscParams[iPar]);
       #pragma GCC diagnostic pop
     } 
-    for (int iSample=0;iSample<int(MCSamples.size());iSample++) {
+    for (int iSample = 0;iSample < int(MCSamples.size()); ++iSample) {
       NuOscProbCalcers[iSample]->CalculateProbabilities(OscVec);
     }
   }
@@ -859,17 +859,15 @@ void samplePDFFDBase::CalcXsecNormsBins(int iSample){
         // All normalisations are just 1 bin for 2015, so bin = index (where index is just the bin for that normalisation)
         int bin = (*it).index;
 
-        //If syst on applies to a particular detector
-        if ((XsecCov->GetParDetID(bin) & SampleDetID)==SampleDetID) {
-          XsecBins.push_back(bin);
-          MACH3LOG_TRACE("Event {}, will be affected by dial {}", iEvent, (*it).name);
-          #ifdef DEBUG
-          VerboseCounter[std::distance(xsec_norms.begin(), it)]++;
-          #endif
-        }
+        XsecBins.push_back(bin);
+        MACH3LOG_TRACE("Event {}, will be affected by dial {}", iEvent, (*it).name);
+        #ifdef DEBUG
+        VerboseCounter[std::distance(xsec_norms.begin(), it)]++;
+        #endif
+        //}
       } // end iteration over xsec_norms
     } // end if (xsecCov)
-    fdobj->xsec_norms_bins[iEvent]=XsecBins;
+    fdobj->xsec_norms_bins[iEvent] = XsecBins;
   }//end loop over events
   #ifdef DEBUG
   MACH3LOG_DEBUG("Channel {}", iSample);
@@ -1386,6 +1384,8 @@ void samplePDFFDBase::SetupNuOscillator() {
   }// end loop over channels
   
   delete OscillFactory;
+
+  OscParams = OscCov->GetOscParsFromDetID(SampleDetID);
 }
 
 M3::float_t samplePDFFDBase::GetEventWeight(int iSample, int iEntry) {
@@ -1507,7 +1507,6 @@ void samplePDFFDBase::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
 #else
   fdobj->osc_w_pointer.resize(nEvents, &Unity); 
 #endif
-  fdobj->SampleDetID = -1;
 
   for(int iEvent = 0 ; iEvent < fdobj->nEvents ; ++iEvent){
     fdobj->isNC[iEvent] = false;

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -201,7 +201,7 @@ public:
   /// @brief Keep track of the dimensions of the sample binning
   int nDimensions = _BAD_INT_;
   /// @brief A unique ID for each sample based on powers of two for quick binary operator comparisons 
-  int SampleDetID = _BAD_INT_;
+  std::string SampleDetID;
   /// holds "TrueNeutrinoEnergy" and the strings used for the sample binning.
   std::vector<std::string> SplineBinnedVars;
 
@@ -211,6 +211,7 @@ public:
   /// @brief Information to store for normalisation pars
   std::vector<XsecNorms4> xsec_norms;
 
+  std::vector<const double*> OscParams;
   //===========================================================================
   //DB Vectors to store which kinematic cuts we apply
   //like in XsecNorms but for events in sample. Read in from sample yaml file 

--- a/splines/splineFDBase.cpp
+++ b/splines/splineFDBase.cpp
@@ -54,7 +54,7 @@ void splineFDBase::cleanUpMemory() {
 }
 
 //****************************************
-bool splineFDBase::AddSample(std::string SampleName, int DetID, std::vector<std::string> OscChanFileNames, std::vector<std::string> SplineVarNames)
+bool splineFDBase::AddSample(std::string SampleName, const std::string& DetID, std::vector<std::string> OscChanFileNames, std::vector<std::string> SplineVarNames)
 //Adds samples to the large array
 //****************************************
 {

--- a/splines/splineFDBase.h
+++ b/splines/splineFDBase.h
@@ -31,7 +31,7 @@ class splineFDBase : public SplineBase {
 	//Spline Monolith things
 	//Essential methods used externally
 	//Move these to splineFDBase in core
-	bool AddSample(std::string SampleName, int DetID, std::vector<std::string> OscChanFileNames, std::vector<std::string> SplineVarNames);
+	bool AddSample(std::string SampleName, const std::string& DetID, std::vector<std::string> OscChanFileNames, std::vector<std::string> SplineVarNames);
 	void TransferToMonolith();	
 	void cleanUpMemory();
 
@@ -80,7 +80,7 @@ class splineFDBase : public SplineBase {
 	std::vector<int> BinningOpts;
 	std::vector<int> Dimensions;
 	std::vector<std::vector<std::string>> DimensionLabels;
-	std::vector<int> DetIDs;
+	std::vector<std::string> DetIDs;
 	std::vector<int> nSplineParams;
 	std::vector<int> nOscChans;
 


### PR DESCRIPTION
# Pull request description
See also: https://github.com/mach3-software/MaCh3Tutorial/pull/71

Instead of hardcoded names let's have string:det id

Sample PDF can only have 1 string, and no wildcards

However now each syst can have several "det ids" to which applies"
For example     **DetID: ["Tutorial *"]** or    **DetID: ["Tutorial *", "Blarb *"]**

In addition now DetId applies to Osc params. For example delta CP will aply to all but baseline only to beam.
You can see in this example that parameters with **DetID: ["Tutorial *"]**
```
Found 3 for Tutorial Beam Params of type Norm
Found 5 for Tutorial Beam Params of type Spline
Found 4 for Tutorial Beam Params of type Functional
Found 3 for Tutorial Beam From GetNormParsFromDetID
Found 3 for Tutorial ATM Params of type Norm
Found 5 for Tutorial ATM Params of type Spline
Found 4 for Tutorial ATM Params of type Functional
Found 3 for Tutorial ATM From GetNormParsFromDetID
Found 3 for tutorial beam Params of type Norm
Found 5 for tutorial beam Params of type Spline
Found 4 for tutorial beam Params of type Functional
Found 3 for tutorial beam From GetNormParsFromDetID
Found 0 for blarbATM Params of type Norm
Found 0 for blarbATM Params of type Spline
Found 0 for blarbATM Params of type Functional
Found 0 for blarbATM From GetNormParsFromDetID
```

## Changes or fixes


## Examples
<img width="999" alt="CovOsc" src="https://github.com/user-attachments/assets/1e8b2a7a-2423-4311-91d2-f66a0d06262a" />
<img width="1027" alt="CovModel" src="https://github.com/user-attachments/assets/ac40a5ff-d485-47f9-a435-36cfa72533ec" />