### PR TITLE
feat: Safer Yaml openning

### DIFF
--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -165,7 +165,7 @@ void covarianceBase::init(const std::vector<std::string>& YAMLFile) {
   _fYAMLDoc["Systematics"] = YAML::Node(YAML::NodeType::Sequence);
   for(unsigned int i = 0; i < YAMLFile.size(); i++)
   {
-    YAML::Node YAMLDocTemp = YAML::LoadFile(YAMLFile[i]);
+    YAML::Node YAMLDocTemp = M3OpenConfig(YAMLFile[i]);
     for (const auto& item : YAMLDocTemp["Systematics"]) {
       _fYAMLDoc["Systematics"].push_back(item);
     }

--- a/covariance/covarianceXsec.cpp
+++ b/covariance/covarianceXsec.cpp
@@ -179,8 +179,7 @@ XsecNorms4 covarianceXsec::GetXsecNorm(const YAML::Node& param, const int Index)
     std::vector<std::vector<double>> TempKinematicBounds;
     //First element of TempKinematicBounds is always -999, and size is then 3
     for(int KinVar_i = 0 ; KinVar_i < NumKinematicCuts ; ++KinVar_i){
-      //ETA
-      //This is a bit messy, Kinematic cuts is a list of maps
+      //ETA: This is a bit messy, Kinematic cuts is a list of maps
       for (YAML::const_iterator it = param["KinematicCuts"][KinVar_i].begin();it!=param["KinematicCuts"][KinVar_i].end();++it) {
         TempKinematicStrings.push_back(it->first.as<std::string>());
         TempKinematicBounds.push_back(it->second.as<std::vector<double>>());

--- a/manager/YamlHelper.h
+++ b/manager/YamlHelper.h
@@ -298,3 +298,21 @@ Type GetFromManager(const YAML::Node& node, Type defval, const std::string File 
   }
 }
 
+// **********************
+/// @brief Open YAML file
+/// @param filename name of filename to open
+/// @param File name of file where function is called
+/// @param Line number where function is called
+inline YAML::Node LoadYamlConfig(const std::string& filename, const std::string& File, const int Line) {
+// **********************
+  try {
+    return YAML::LoadFile(filename);
+  } catch (const std::exception& e) {
+    MACH3LOG_ERROR("{}", e.what());
+    MACH3LOG_ERROR("Can't open file {}", filename);
+    throw MaCh3Exception(File, Line);
+  }
+}
+
+/// Macro to simplify calling LoadYaml with file and line info
+#define M3OpenConfig(filename) LoadYamlConfig((filename), __FILE__, __LINE__)

--- a/manager/gpuUtils.cuh
+++ b/manager/gpuUtils.cuh
@@ -27,6 +27,8 @@
 
 /// @file gpuUtils.cuh
 /// @brief Common CUDA utilities and definitions for shared GPU functionality.
+/// @author Richard Calland
+/// @author Kamil Skwarczynski
 
 /// @todo KS: There is plenty of useful stuff here https://github.com/NVIDIA/cuda-samples/blob/master/Samples/1_Utilities/deviceQuery/deviceQuery.cpp
 /// @todo KS: We might want to port some of these utilities, for example having bool if there is unified memory etc.

--- a/manager/manager.cpp
+++ b/manager/manager.cpp
@@ -15,27 +15,6 @@ manager::manager(std::string const &filename)
   MACH3LOG_INFO("Config is now: ");
   MaCh3Utils::PrintConfig(config);
 
-  if (config["LikelihoodOptions"])
-  {
-    auto likelihood = GetFromManager<std::string>(config["LikelihoodOptions"]["TestStatistic"], "Barlow-Beeston", __FILE__ , __LINE__);
-    if (likelihood == "Barlow-Beeston")                 mc_stat_llh = kBarlowBeeston;
-    else if (likelihood == "IceCube")                   mc_stat_llh = kIceCube;
-    else if (likelihood == "Poisson")                   mc_stat_llh = kPoisson;
-    else if (likelihood == "Pearson")                   mc_stat_llh = kPearson;
-    else if (likelihood == "Dembinski-Abdelmotteleb")   mc_stat_llh = kDembinskiAbdelmottele;
-    else {
-      MACH3LOG_ERROR("Wrong form of test-statistic specified!");
-      MACH3LOG_ERROR("You gave {} and I only support:", likelihood);
-      for(int i = 0; i < kNTestStatistics; i++)
-      {
-        MACH3LOG_ERROR("{}", TestStatistic_ToString(TestStatistic(i)));
-      }
-      throw MaCh3Exception(__FILE__ , __LINE__ );
-    }
-  } else {
-    mc_stat_llh = kPoisson;
-  }
-
   Modes = nullptr;
   auto ModeInput = GetFromManager<std::string>(config["General"]["MaCh3Modes"], "null", __FILE__ , __LINE__);
   if(ModeInput != "null") Modes = new MaCh3Modes(ModeInput);
@@ -66,7 +45,6 @@ void manager::SaveSettings(TFile* const OutputFile) {
 
   // Fill the doubles
   SaveBranch->Branch("Output", &OutputFilename);
-  SaveBranch->Branch("TestStatistic", &mc_stat_llh);
 
   // Get settings defined by pre-processor directives, e.g. CPU MP and GPU
   #ifdef MULTITHREAD
@@ -100,3 +78,32 @@ void manager::Print() {
   MaCh3Utils::PrintConfig(config);
   MACH3LOG_INFO("---------------------------------");
 }
+
+// *************************
+int manager::GetMCStatLLH() {
+// *************************
+  int mc_stat_llh;
+  if (config["LikelihoodOptions"])
+  {
+    auto likelihood = GetFromManager<std::string>(config["LikelihoodOptions"]["TestStatistic"], "Barlow-Beeston", __FILE__ , __LINE__);
+    if (likelihood == "Barlow-Beeston")                 mc_stat_llh = kBarlowBeeston;
+    else if (likelihood == "IceCube")                   mc_stat_llh = kIceCube;
+    else if (likelihood == "Poisson")                   mc_stat_llh = kPoisson;
+    else if (likelihood == "Pearson")                   mc_stat_llh = kPearson;
+    else if (likelihood == "Dembinski-Abdelmotteleb")   mc_stat_llh = kDembinskiAbdelmottele;
+    else {
+      MACH3LOG_ERROR("Wrong form of test-statistic specified!");
+      MACH3LOG_ERROR("You gave {} and I only support:", likelihood);
+      for(int i = 0; i < kNTestStatistics; i++)
+      {
+        MACH3LOG_ERROR("{}", TestStatistic_ToString(TestStatistic(i)));
+      }
+      throw MaCh3Exception(__FILE__ , __LINE__ );
+    }
+  } else {
+    mc_stat_llh = kPoisson;
+  }
+  return mc_stat_llh;
+}
+
+

--- a/manager/manager.cpp
+++ b/manager/manager.cpp
@@ -4,7 +4,7 @@
 
 // *************************
 manager::manager(std::string const &filename)
-    : config(YAML::LoadFile(filename)) {
+    : config(M3OpenConfig(filename)) {
 // *************************
   FileName = filename;
   SetMaCh3LoggerFormat();
@@ -100,4 +100,3 @@ void manager::Print() {
   MaCh3Utils::PrintConfig(config);
   MACH3LOG_INFO("---------------------------------");
 }
-

--- a/manager/manager.h
+++ b/manager/manager.h
@@ -31,7 +31,7 @@ public:
   void Print();
 
   /// @brief Get likelihood type defined in the config
-  inline int GetMCStatLLH(){return mc_stat_llh;}
+  int GetMCStatLLH();
   /// @brief Return name of config
   inline std::string GetFileName(){return FileName;}
   /// @brief Return config
@@ -56,8 +56,6 @@ private:
   YAML::Node config;
   /// The name of the configuration file.
   std::string FileName;
-  /// The likelihood type defined in the configuration.
-  int mc_stat_llh;
   /// MaCh3 Modes
   MaCh3Modes* Modes;
 };

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -1309,7 +1309,6 @@ void samplePDFFDBase::SetupNuOscillator() {
                   [this, iSample, &OscillFactory]() {
                     this->NuOscProbCalcers[iSample] = OscillFactory->CreateOscillator(this->NuOscillatorConfigFile);
                   });
-      //NuOscProbCalcers[iSample] = OscillFactory->CreateOscillator(NuOscillatorConfigFile);
 
       if (!NuOscProbCalcers[iSample]->EvalPointsSetInConstructor()) {
         std::vector<M3::float_t> EnergyArray;


### PR DESCRIPTION
# Pull request description
Introduce new wrapper around `YAML::LoadFile`, whole implementation is being handled by yaml, but by having wrapper we can easily intorudce additional checks and in case of error we can pass file, line which should make debugging much easier

## Changes or fixes
- test_stat is no longer member of manager. For example we use manager for samplePDF cofnig. In this case test_stat make no sense. Now we have simply getter so all code should work fine

## Examples
<img width="517" alt="plot" src="https://github.com/user-attachments/assets/c69e9c18-da2c-4416-951c-b8ce04516246" />
