### PR TITLE
tidy: ROOT includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 # CMake version check
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
-project(MaCh3 VERSION 1.3.2 LANGUAGES CXX)
+project(MaCh3 VERSION 1.3.3 LANGUAGES CXX)
 set(MaCh3_VERSION ${PROJECT_VERSION})
 
 #LP - This option name is confusing, but I wont change it now.

--- a/Diagnostics/CombineMaCh3Chains.cpp
+++ b/Diagnostics/CombineMaCh3Chains.cpp
@@ -1,3 +1,10 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 // ROOT includes
 #include "TList.h"
 #include "TFile.h"
@@ -7,6 +14,7 @@
 #include "TFileMerger.h"
 #include "TKey.h"
 #include "TROOT.h"
+#pragma GCC diagnostic pop
 
 // MaCh3 includes
 #include "manager/manager.h"

--- a/Diagnostics/GetPenaltyTerm.cpp
+++ b/Diagnostics/GetPenaltyTerm.cpp
@@ -1,3 +1,10 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 // ROOT includes
 #include "TFile.h"
 #include "TBranch.h"
@@ -15,6 +22,7 @@
 #include "TColor.h"
 #include "TObjString.h"
 #include "TROOT.h"
+#pragma GCC diagnostic pop
 
 #ifdef MULTITHREAD
 #include "omp.h"

--- a/Diagnostics/RHat.cpp
+++ b/Diagnostics/RHat.cpp
@@ -1,3 +1,10 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 // ROOT includes
 #include "TObjArray.h"
 #include "TChain.h"
@@ -13,6 +20,7 @@
 #include "TColor.h"
 #include "TStyle.h"
 #include "TROOT.h"
+#pragma GCC diagnostic pop
 
 #ifdef MULTITHREAD
 #include "omp.h"

--- a/Diagnostics/RHat_HighMem.cpp
+++ b/Diagnostics/RHat_HighMem.cpp
@@ -1,3 +1,10 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 // ROOT includes
 #include "TObjArray.h"
 #include "TChain.h"
@@ -13,6 +20,7 @@
 #include "TColor.h"
 #include "TStyle.h"
 #include "TROOT.h"
+#pragma GCC diagnostic pop
 
 #ifdef MULTITHREAD
 #include "omp.h"

--- a/Doc/Doxyfile
+++ b/Doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "MaCh3"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.3.2
+PROJECT_NUMBER         = 1.3.3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/covariance/CovarianceUtils.h
+++ b/covariance/CovarianceUtils.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 // ROOT includes
 #include "TMatrixT.h"
 #include "TMatrixDSym.h"
@@ -17,6 +24,7 @@
 #include "TMatrixDSymEigen.h"
 #include "TMatrixDEigen.h"
 #include "TDecompSVD.h"
+#pragma GCC diagnostic pop
 
 #ifdef MULTITHREAD
 #include "omp.h"

--- a/manager/CMakeLists.txt
+++ b/manager/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT CPU_ONLY)
 endif()
 
 #If compiling with GPU is not enabled MaCh3GPUCompilerOptions will be empty
-target_link_libraries(Manager PUBLIC MaCh3CompilerOptions MaCh3GPUCompilerOptions yaml-cpp spdlog NuOscillator ROOT::Tree ROOT::Hist)
+target_link_libraries(Manager PUBLIC MaCh3CompilerOptions MaCh3GPUCompilerOptions yaml-cpp spdlog NuOscillator ROOT::Tree ROOT::Hist ROOT::Physics)
 target_link_libraries(Manager PRIVATE MaCh3Warnings)
 
 target_include_directories(Manager PUBLIC

--- a/manager/Monitor.h
+++ b/manager/Monitor.h
@@ -7,12 +7,15 @@
 #include <vector>
 #include <cstdlib>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
 // ROOT include
 #include "TTree.h"
 #include "TBranch.h"
 #include "TMacro.h"
 #include "TChain.h"
 #include "TStopwatch.h"
+#pragma GCC diagnostic pop
 
 // MaCh3 includes
 #include "manager/MaCh3Logger.h"

--- a/manager/Monitor.h
+++ b/manager/Monitor.h
@@ -8,7 +8,11 @@
 #include <cstdlib>
 
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
 // ROOT include
 #include "TTree.h"
 #include "TBranch.h"

--- a/manager/YamlHelper.h
+++ b/manager/YamlHelper.h
@@ -6,10 +6,17 @@
 #include <string>
 #include <cxxabi.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
 // ROOT Includes
 #include "TMacro.h"
 #include "TList.h"
 #include "TObjString.h"
+#pragma GCC diagnostic pop
 
 // yaml Includes
 #include "yaml-cpp/yaml.h"

--- a/manager/manager.cpp
+++ b/manager/manager.cpp
@@ -1,4 +1,12 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+// ROOT include
 #include "TFile.h"
+#pragma GCC diagnostic pop
 
 #include "manager/manager.h"
 

--- a/mcmc/MCMCProcessor.cpp
+++ b/mcmc/MCMCProcessor.cpp
@@ -1,7 +1,15 @@
 #include "MCMCProcessor.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #include "TChain.h"
 #include "TF1.h"
+#pragma GCC diagnostic pop
 
 //Only if GPU is enabled
 #ifdef CUDA

--- a/mcmc/MCMCProcessor.h
+++ b/mcmc/MCMCProcessor.h
@@ -8,6 +8,13 @@
 #include <complex>
 #include <cstdio>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 // ROOT includes
 #include "TFile.h"
 #include "TBranch.h"
@@ -31,6 +38,8 @@
 #include "TMath.h"
 #include "TMatrixDSymEigen.h"
 #include "TVirtualFFT.h"
+#pragma GCC diagnostic pop
+
 
 // MaCh3 includes
 #include "mcmc/StatisticalUtils.h"

--- a/mcmc/MaCh3Factory.cpp
+++ b/mcmc/MaCh3Factory.cpp
@@ -1,7 +1,6 @@
 // MaCh3 includes
 #include "mcmc/MaCh3Factory.h"
 
-
 // ********************************************
 std::unique_ptr<FitterBase> MaCh3FitterFactory(manager *fitMan) {
 // ********************************************

--- a/mcmc/SampleSummary.h
+++ b/mcmc/SampleSummary.h
@@ -1,8 +1,5 @@
 #pragma once
 
-// ROOT includes
-#include "TROOT.h"
-
 // MaCh3 includes
 #include "samplePDF/samplePDFBase.h"
 #include "mcmc/StatisticalUtils.h"

--- a/plotting/GetPostfitParamPlots.cpp
+++ b/plotting/GetPostfitParamPlots.cpp
@@ -3,6 +3,13 @@
 #include <iomanip>
 #include <algorithm>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #include "TROOT.h"
 #include "TGaxis.h"
 #include "TString.h"
@@ -19,6 +26,7 @@
 #include "TCandle.h"
 #include "TFrame.h"
 #include "TGraphAsymmErrors.h"
+#pragma GCC diagnostic pop
 
 #include "plottingUtils/plottingUtils.h"
 #include "plottingUtils/plottingManager.h"

--- a/plotting/MatrixPlotter.cpp
+++ b/plotting/MatrixPlotter.cpp
@@ -1,14 +1,4 @@
-#include <iostream>
-#include <algorithm>
-
-#include "TFile.h"
-#include "TH2D.h"
-#include "TCanvas.h"
-#include "TStyle.h"
-#include "TError.h"
-#include "TPaletteAxis.h"
-#include "TColor.h"
-
+//MaCh3 Includes
 #include "plottingUtils/plottingUtils.h"
 #include "plottingUtils/plottingManager.h"
 

--- a/plotting/plottingUtils/plottingManager.h
+++ b/plotting/plottingUtils/plottingManager.h
@@ -9,11 +9,6 @@
 #include <unistd.h>
 #include <vector>
 
-// ROOT includes
-#include "TColor.h"
-#include "TH1.h"
-#include "TStyle.h"
-
 // MaCh3 Includes
 #include "manager/MaCh3Logger.h"
 #include "manager/YamlHelper.h"

--- a/plotting/plottingUtils/plottingUtils.h
+++ b/plotting/plottingUtils/plottingUtils.h
@@ -10,6 +10,13 @@
 #include <iostream>
 #include <map>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 // ROOT
 #include "TCanvas.h"
 #include "TGraph2D.h"
@@ -29,6 +36,7 @@
 #include "TROOT.h"
 #include "TStyle.h"
 #include "TMultiGraph.h"
+#pragma GCC diagnostic pop
 
 namespace MaCh3Plotting {
 /// @defgroup Utils Plotting Utility Functions

--- a/plotting/plottingUtils/styleManager.h
+++ b/plotting/plottingUtils/styleManager.h
@@ -5,10 +5,18 @@
 #include "manager/YamlHelper.h"
 #include "manager/MaCh3Exception.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 // ROOT Things
 #include "TColor.h"
 #include "TH1.h"
 #include "TStyle.h"
+#pragma GCC diagnostic pop
 
 namespace MaCh3Plotting {
 /// @author Ewan Miller

--- a/samplePDF/HistogramUtils.cpp
+++ b/samplePDF/HistogramUtils.cpp
@@ -1,5 +1,13 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #include "TList.h"
 #include "TObjArray.h"
+#pragma GCC diagnostic pop
 
 #include "samplePDF/HistogramUtils.h"
 

--- a/samplePDF/HistogramUtils.h
+++ b/samplePDF/HistogramUtils.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
 // ROOT include
 #include "TGraphAsymmErrors.h"
 #include "TLorentzVector.h"
 #include "TObjString.h"
+#pragma GCC diagnostic pop
 
 // MaCh3 inlcudes
 #include "samplePDF/Structs.h"

--- a/samplePDF/HistogramUtils.h
+++ b/samplePDF/HistogramUtils.h
@@ -1,7 +1,12 @@
 #pragma once
 
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 // ROOT include
 #include "TGraphAsymmErrors.h"
 #include "TLorentzVector.h"

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -66,7 +66,11 @@ constexpr static const int Unity_Int = 1;
 #include "manager/MaCh3Logger.h"
 
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
 // ROOT include
 #include "TSpline.h"
 #include "TObjString.h"

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -58,14 +58,6 @@ constexpr static const int Unity_Int = 1;
 #include <list>
 #include <unordered_map>
 
-// ROOT include
-#include "TSpline.h"
-#include "TObjString.h"
-#include "TFile.h"
-#include "TF1.h"
-#include "TH2Poly.h"
-#include "TH1.h"
-
 #ifdef MULTITHREAD
 #include "omp.h"
 #endif
@@ -75,6 +67,14 @@ constexpr static const int Unity_Int = 1;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
+// ROOT include
+#include "TSpline.h"
+#include "TObjString.h"
+#include "TFile.h"
+#include "TF1.h"
+#include "TH2Poly.h"
+#include "TH1.h"
+// NuOscillator includes
 #include "Constants/OscillatorConstants.h"
 #pragma GCC diagnostic pop
 

--- a/samplePDF/samplePDFBase.h
+++ b/samplePDF/samplePDFBase.h
@@ -3,6 +3,13 @@
 //C++ includes
 #include <assert.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 //ROOT includes
 #include "TTree.h"
 #include "TH1D.h"
@@ -12,6 +19,7 @@
 #include "TROOT.h"
 #include "TRandom3.h"
 #include "TString.h"
+#pragma GCC diagnostic pop
 
 //MaCh3 includes
 #include "samplePDF/Structs.h"

--- a/splines/SplineBase.h
+++ b/splines/SplineBase.h
@@ -4,6 +4,8 @@
 #include <cstdlib>
 #include <iomanip>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
 // ROOT include
 #include "TFile.h"
 #include "TH1F.h"
@@ -14,6 +16,7 @@
 #include "TCanvas.h"
 #include "TStyle.h"
 #include "TTree.h"
+#pragma GCC diagnostic pop
 
 #ifdef MULTITHREAD
 #include "omp.h"

--- a/splines/SplineBase.h
+++ b/splines/SplineBase.h
@@ -5,7 +5,12 @@
 #include <iomanip>
 
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 // ROOT include
 #include "TFile.h"
 #include "TH1F.h"

--- a/splines/splineFDBase.cpp
+++ b/splines/splineFDBase.cpp
@@ -189,7 +189,7 @@ void splineFDBase::TransferToMonolith()
                     xcoeff_arr[iCoeff+i]=tmpXCoeffArr[i];
 
                     for(int j=0; j<4; j++){
-					  manycoeff_arr[(iCoeff+i)*4+j]=tmpManyCoeffArr[i*4+j];
+			manycoeff_arr[(iCoeff+i)*4+j]=tmpManyCoeffArr[i*4+j];
                     }
                   }
                   delete[] tmpXCoeffArr;
@@ -205,14 +205,11 @@ void splineFDBase::TransferToMonolith()
       }//syst2 loop end
     }//osc loop end
   }//syst1 loop end
-
-  return;
 }
 
 // *****************************************
 void splineFDBase::Evaluate() {
 // *****************************************
-
   // There's a parameter mapping that goes from spline parameter to a global parameter index
   // Find the spline segments
   FindSplineSegment();
@@ -222,8 +219,6 @@ void splineFDBase::Evaluate() {
 
   //KS: Huge MP loop over all events calculating total weight
   ModifyWeights();
-
-  return;
 }
 
 //****************************************
@@ -646,10 +641,10 @@ void splineFDBase::PrepForReweight() {
             break;
           }
         }//osc loop end
-		 //ETA - only push back unique name if a non-flat response has been found
-		if(FoundNonFlatSpline){
-		  UniqueSystNames.push_back(SystName);
-		}
+	//ETA - only push back unique name if a non-flat response has been found
+	if(FoundNonFlatSpline){
+	  UniqueSystNames.push_back(SystName);
+	}
 
         if (!FoundNonFlatSpline)
         {
@@ -815,8 +810,6 @@ void splineFDBase::PrintSampleDetails(std::string SampleName)
   MACH3LOG_INFO("\t DetID: {:<35}", DetIDs[iSample]);
   MACH3LOG_INFO("\t nSplineParam: {:<35}", nSplineParams[iSample]);
   MACH3LOG_INFO("\t nOscChan: {:<35}", nOscChans[iSample]);
-
-  return;
 }
 
 //****************************************
@@ -941,8 +934,9 @@ void splineFDBase::PrintBinning(TAxis *Axis)
 //****************************************
 {
   const int NBins = Axis->GetNbins();
-  for (int iBin = 0; iBin < (NBins + 1); iBin++)
-  {
-    MACH3LOG_INFO("{}", Axis->GetXbins()->GetAt(iBin));
+  std::string text = "";
+  for (int iBin = 0; iBin <= NBins; iBin++) {
+    text += fmt::format("{} ", Axis->GetXbins()->GetAt(iBin));
   }
+  MACH3LOG_INFO("{}", text);
 }

--- a/splines/splineFDBase.h
+++ b/splines/splineFDBase.h
@@ -1,7 +1,15 @@
 #pragma once
 
-//ROOT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+// ROOT includes
 #include "TH3F.h"
+#pragma GCC diagnostic pop
 
 //MaCh3
 #include "samplePDF/Structs.h"


### PR DESCRIPTION
# Pull request description
While testing MaCh3 on one of clusters I coudln't compile code due to ROOT header only funciton being compiled with MaCh3 very restrictive Werror.

In future we should have better treamtnet of external headers but right now let's throw such protection

Such protection is neccessary for all ROOT headers as every user has access to sliglhy different ROOT version

## Changes or fixes


## Examples
