### PR TITLE
bugfix: Add missing unistd.h include for newer ROOT versions

### DIFF
--- a/Diagnostics/CombineMaCh3Chains.cpp
+++ b/Diagnostics/CombineMaCh3Chains.cpp
@@ -5,6 +5,9 @@
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+// C++ includes
+#include <unistd.h>
+
 // ROOT includes
 #include "TList.h"
 #include "TFile.h"


### PR DESCRIPTION
# Pull request description
`<unistd.h>` is required for `getopt`, `optind`, and `optarg`. It seems with older ROOT versions, it may be included here indirectly, but will give compilation errors on newer versions.

## Changes or fixes
Explicitly including it shouldn't change any behavior, and make MaCh3 compile on more environments.