### PR TITLE
feat: Manager Factory

### DIFF
--- a/manager/Monitor.cpp
+++ b/manager/Monitor.cpp
@@ -44,7 +44,6 @@ void MaCh3Welcome() {
 // KS: Get version of MaCh3
 std::string GetMaCh3Version() {
 // ************************
-
   //KS: Find MaCh3 version based on header file. There could be better way to just include version.h but as long as we don't have to hardcode version I am content
   std::string MaCh3_VERSION = "";
 
@@ -87,7 +86,6 @@ std::string GetMaCh3Version() {
 // KS: Find out more about operational system
 void GetOSInfo() {
 // ************************
-
   MACH3LOG_INFO("Operating System Information:");
 
   // Distribution and version
@@ -99,7 +97,6 @@ void GetOSInfo() {
 //KS: Simple function retrieving CPU info
 void GetCPUInfo() {
 // ************************
-
   //KS: Use -m 1 to limit to only one grep because in one computing node there is a lot of CPU which are the same
   MACH3LOG_INFO("Using following CPU:");
 
@@ -121,7 +118,6 @@ void GetCPUInfo() {
 //KS: Simple function retrieving GPU info
 void GetGPUInfo(){
 // ************************
-
 #ifdef CUDA
   MACH3LOG_INFO("Using following GPU:");
   // Print GPU name
@@ -170,7 +166,6 @@ std::string TerminalToString(std::string cmd) {
 //KS: Simple to retrieve speed of get entry inspired by
 void EstimateDataTransferRate(TChain* chain, const Long64_t entry){
 // ************************
-
   TStopwatch timer;
 
   timer.Start();
@@ -188,7 +183,6 @@ void EstimateDataTransferRate(TChain* chain, const Long64_t entry){
 //KS: Simply print progress bar
 void PrintProgressBar(const Long64_t Done, const Long64_t All){
 // ************************
-
   double progress = double(Done)/double(All);
   const int barWidth = 20;
   std::ostringstream progressBar;
@@ -254,7 +248,6 @@ int getValue(const std::string& Type){ //Note: this value is in KB!
     MACH3LOG_ERROR("Not supported getValue: {}", Type);
     throw MaCh3Exception(__FILE__, __LINE__);
   }
-
   return result;
 }
 

--- a/mcmc/MaCh3Factory.cpp
+++ b/mcmc/MaCh3Factory.cpp
@@ -50,7 +50,8 @@ std::unique_ptr<manager> MaCh3ManagerFactory(int argc, char **argv) {
     if (Name.find("Systematics") != std::string::npos ||
         Name.find("Samples") != std::string::npos)
     {
-      MACH3LOG_WARN("You are overwriting settings ({}) that are highly likely intended to be committed.", Name);
+      MACH3LOG_CRITICAL("You are overwriting settings ({}) that are highly likely intended to be committed.", Name);
+      throw MaCh3Exception(__FILE__ , __LINE__ );
     }
   };
   

--- a/mcmc/MaCh3Factory.cpp
+++ b/mcmc/MaCh3Factory.cpp
@@ -31,3 +31,60 @@ covarianceXsec* MaCh3CovarianceFactory(manager *FitManager, const std::string& P
 // ********************************************
   return MaCh3CovarianceFactory<covarianceXsec>(FitManager, PreFix);
 }
+
+// ********************************************
+std::unique_ptr<manager> MaCh3ManagerFactory(int argc, char **argv) {
+// ********************************************
+  if (argc < 2) {
+    MACH3LOG_ERROR("Wrong usage of MaCh3 executable!");
+    MACH3LOG_ERROR("Syntax is $: {} config.yaml", argv[0]);
+    MACH3LOG_ERROR("Where config.yaml is a valid config file, compatible with the manager class (manager/manager.cpp/h)");
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+
+  // Initialise manger responsible for config handling
+  auto FitManager = std::make_unique<manager>(argv[1]);
+
+  for (int i = 2; i < argc; ++i)
+  {
+    const std::string arg = argv[i];
+    const size_t colonCount = std::count(arg.begin(), arg.end(), ':');
+
+    /// @todo KS: May need some recursive magic to reduce amount of hardcoding
+    if (colonCount == 1) {
+      const size_t firstColon = arg.find(':');
+      const std::string section = arg.substr(0, firstColon);
+      const std::string value = arg.substr(firstColon + 1);
+
+      MACH3LOG_INFO("Overriding setting: Section={}, Value={}", section, value);
+      FitManager->OverrideSettings(section, value);
+    } else if (colonCount == 2) {
+      const size_t firstColon = arg.find(':');
+      const size_t secondColon = arg.find(':', firstColon + 1);
+
+      const std::string section = arg.substr(0, firstColon);
+      const std::string key = arg.substr(firstColon + 1, secondColon - firstColon - 1);
+      const std::string value = arg.substr(secondColon + 1);
+
+      MACH3LOG_INFO("Overriding setting: Section={}, Key={}, Value={}", section, key, value);
+      FitManager->OverrideSettings(section, key, value);
+    } else if (colonCount == 3) {
+      const size_t firstColon = arg.find(':');
+      const size_t secondColon = arg.find(':', firstColon + 1);
+      const size_t thridColon = arg.find(':', secondColon + 1);
+
+      const std::string section = arg.substr(0, firstColon);
+      const std::string key = arg.substr(firstColon + 1, secondColon - firstColon - 1);
+      const std::string key2 = arg.substr(secondColon + 1, thridColon - secondColon - 1);
+      const std::string value = arg.substr(thridColon + 1);
+
+      MACH3LOG_INFO("Overriding setting: Section={}, Key={}, Key={}, Value={}", section, key, key2, value);
+      FitManager->OverrideSettings(section, key, key2, value);
+    } else {
+      MACH3LOG_ERROR("Invalid override argument format: {}", arg);
+      MACH3LOG_ERROR("Expected format:Section:Key:Key:Valu, Section:Key:Value or Section:Value");
+      throw MaCh3Exception(__FILE__, __LINE__);
+    }
+  }
+  return FitManager;
+}

--- a/mcmc/MaCh3Factory.h
+++ b/mcmc/MaCh3Factory.h
@@ -12,6 +12,9 @@
 #include "covariance/covarianceXsec.h"
 #include "covariance/covarianceOsc.h"
 
+/// @file MaCh3Factory.h
+/// @brief Factory methods for MaCh3 software which streamline initialisation of different objects
+/// @author Kamil Skwarczynski
 
 /// @brief MaCh3 Factory initiates one of implemented fitting algorithms
 /// @param fitMan pointer to Manager class
@@ -23,6 +26,17 @@
 /// General:
 ///   FittingAlgorithm: ["MCMC"]
 std::unique_ptr<FitterBase> MaCh3FitterFactory(manager *fitMan);
+
+/// @brief Initializes the config manager class and allows overriding settings via command-line arguments.
+/// @param argc number of arguments
+/// @param argv name of arguments
+/// @return A unique pointer to the initialized `manager` instance with optional overrides applied.
+/// @example Usage examples:
+/// ```
+/// ./bin/MCMCTutorial Inputs/FitterConfig.yaml General:OutputFile:blarb.root
+/// ./bin/MCMCTutorial Inputs/FitterConfig.yaml General:OutputFile:blarb.root General:MCMC:NSteps:50000
+/// ```
+std::unique_ptr<manager> MaCh3ManagerFactory(int argc, char **argv);
 
 /// @brief Factory function for creating a covariance class for systematic handling.
 covarianceXsec* MaCh3CovarianceFactory(manager *FitManager, const std::string& PreFix);


### PR DESCRIPTION
# Pull request description
New manager factory inspired by random chat with Henry some time ago.

Main motivation is to allow override config via comand line.
Normally one would have to change config to change filename.
This feature allow to do stuff like this
`./bin/MCMCTutorial Inputs/FitterConfig.yaml General:OutputFile:blarb.root`

Which should be super handy if running running batch jobes
## Changes or fixes


## Examples
<img width="672" alt="blarb" src="https://github.com/user-attachments/assets/cda4e352-d6c6-4a35-b004-b2b0834c47bf" />
<img width="602" alt="blarb2" src="https://github.com/user-attachments/assets/cb3ef571-3451-439a-96ac-327cbbe4dffe" />


Warning after Dan't comment
![image](https://github.com/user-attachments/assets/69d52849-33ff-4958-a6ae-dfe17c30a104)
