### PR TITLE
bugfix: Print output from MaCh3Logger fancy logging function if error is thrown

### DIFF
--- a/cmake/Modules/NuOscillatorSetup.cmake
+++ b/cmake/Modules/NuOscillatorSetup.cmake
@@ -70,7 +70,7 @@ CPMAddPackage(
   NAME NuOscillator
     VERSION 1.1.0
     GITHUB_REPOSITORY "dbarrow257/NuOscillator"
-    GIT_TAG "v1.1.0"
+    GIT_TAG "dbarrow257/feature/BetterThrowing"
     GIT_SHALLOW YES
     OPTIONS
     "UseGPU ${DAN_USE_GPU}"

--- a/cmake/Modules/NuOscillatorSetup.cmake
+++ b/cmake/Modules/NuOscillatorSetup.cmake
@@ -70,7 +70,7 @@ CPMAddPackage(
   NAME NuOscillator
     VERSION 1.1.0
     GITHUB_REPOSITORY "dbarrow257/NuOscillator"
-    GIT_TAG "dbarrow257/feature/BetterThrowing"
+    GIT_TAG "v1.1.1"
     GIT_SHALLOW YES
     OPTIONS
     "UseGPU ${DAN_USE_GPU}"


### PR DESCRIPTION
# Pull request description
Issue was found where if an error occurred in NuOscillator, the new fancy logging system wouldn't post the output to the console so the error was very difficult to solve. Now catch any runtime error and redirect stringstream buffer to console so error can printed to screen

## Changes or fixes


## Examples
