### PR TITLE
bugfix: Correctly read Signal FDMC variable from config

### DIFF
--- a/samplePDF/FarDetectorCoreInfoStruct.h
+++ b/samplePDF/FarDetectorCoreInfoStruct.h
@@ -13,7 +13,6 @@ struct FarDetectorCoreInfo {
 
   ~FarDetectorCoreInfo(){ delete [] isNC; }
 
-  bool signal; ///< true if signue
   int nEvents; ///< how many MC events are there
   double ChannelIndex;
   std::string flavourName;

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -14,7 +14,7 @@ samplePDFFDBase::samplePDFFDBase(std::string ConfigFileName, covarianceXsec* xse
 {
   MACH3LOG_INFO("-------------------------------------------------------------------");
   MACH3LOG_INFO("Creating SamplePDFFDBase object");
-  
+
   //ETA - safety feature so you can't pass a NULL xsec_cov
   if(!xsec_cov){
     MACH3LOG_ERROR("You've passed me a nullptr to a covarianceXsec... I need this to setup splines!");
@@ -759,7 +759,7 @@ void samplePDFFDBase::CalcXsecNormsBins(int iSample){
       // Not strictly needed, but these events don't get included in oscillated predictions, so
       // no need to waste our time calculating and storing information about xsec parameters
       // that will never be used.
-      if (fdobj->isNC[iEvent] && (fdobj->nupdg[iEvent] != fdobj->nupdgUnosc[iEvent]) ) {
+      if (fdobj->isNC[iEvent] && (*fdobj->nupdg[iEvent] != *fdobj->nupdgUnosc[iEvent]) ) {
         MACH3LOG_TRACE("Event {}, missed NC/signal check", iEvent);
         continue;
       } //DB Abstract check on MaCh3Modes to determine which apply to neutral current
@@ -1347,7 +1347,7 @@ void samplePDFFDBase::SetupNuOscillator() {
       MCSamples[iSample].osc_w_pointer[iEvent] = &Unity;
 #endif
       if (MCSamples[iSample].isNC[iEvent]) {
-        if (MCSamples[iSample].nupdg[iEvent] != MCSamples[iSample].nupdgUnosc[iEvent]) {
+        if (*MCSamples[iSample].nupdg[iEvent] != *MCSamples[iSample].nupdgUnosc[iEvent]) {
 #ifdef _LOW_MEMORY_STRUCTS_
           MCSamples[iSample].osc_w_pointer[iEvent] = &Zero_F;
 #else
@@ -1482,6 +1482,7 @@ void samplePDFFDBase::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
   
   fdobj->nEvents = nEvents_;
   fdobj->flavourName = oscchan_flavnames[iSample];
+  fdobj->ChannelIndex = iSample;
   
   int nEvents = fdobj->nEvents;
   fdobj->x_var.resize(nEvents, &Unity);

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -758,7 +758,7 @@ void samplePDFFDBase::CalcXsecNormsBins(int iSample){
       // Not strictly needed, but these events don't get included in oscillated predictions, so
       // no need to waste our time calculating and storing information about xsec parameters
       // that will never be used.
-      if (fdobj->isNC[iEvent] && (fdobj->nupdg[iEvent] == fdobj->nupdgUnosc[iEvent]) ) {
+      if (fdobj->isNC[iEvent] && (fdobj->nupdg[iEvent] != fdobj->nupdgUnosc[iEvent]) ) {
         MACH3LOG_TRACE("Event {}, missed NC/signal check", iEvent);
         continue;
       } //DB Abstract check on MaCh3Modes to determine which apply to neutral current
@@ -1346,7 +1346,7 @@ void samplePDFFDBase::SetupNuOscillator() {
       MCSamples[iSample].osc_w_pointer[iEvent] = &Unity;
 #endif
       if (MCSamples[iSample].isNC[iEvent]) {
-        if (MCSamples[iSample].nupdg[iEvent] == MCSamples[iSample].nupdgUnosc[iEvent]) {
+        if (MCSamples[iSample].nupdg[iEvent] != MCSamples[iSample].nupdgUnosc[iEvent]) {
 #ifdef _LOW_MEMORY_STRUCTS_
           MCSamples[iSample].osc_w_pointer[iEvent] = &Zero_F;
 #else

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -142,7 +142,6 @@ void samplePDFFDBase::ReadSampleConfig()
     sample_vecno.push_back(osc_channel["samplevecno"].as<int>());
     sample_nupdgunosc.push_back(static_cast<NuPDG>(osc_channel["nutype"].as<int>()));
     sample_nupdg.push_back(static_cast<NuPDG>(osc_channel["oscnutype"].as<int>()));
-    sample_signal.push_back(osc_channel["signal"].as<bool>());
   }
 
   //Now get selection cuts
@@ -759,7 +758,7 @@ void samplePDFFDBase::CalcXsecNormsBins(int iSample){
       // Not strictly needed, but these events don't get included in oscillated predictions, so
       // no need to waste our time calculating and storing information about xsec parameters
       // that will never be used.
-      if (fdobj->isNC[iEvent] && fdobj->signal) {
+      if (fdobj->isNC[iEvent] && (fdobj->nupdg[iEvent] == fdobj->nupdgUnosc[iEvent]) ) {
         MACH3LOG_TRACE("Event {}, missed NC/signal check", iEvent);
         continue;
       } //DB Abstract check on MaCh3Modes to determine which apply to neutral current
@@ -1347,7 +1346,7 @@ void samplePDFFDBase::SetupNuOscillator() {
       MCSamples[iSample].osc_w_pointer[iEvent] = &Unity;
 #endif
       if (MCSamples[iSample].isNC[iEvent]) {
-        if (MCSamples[iSample].signal) {
+        if (MCSamples[iSample].nupdg[iEvent] == MCSamples[iSample].nupdgUnosc[iEvent]) {
 #ifdef _LOW_MEMORY_STRUCTS_
           MCSamples[iSample].osc_w_pointer[iEvent] = &Zero_F;
 #else
@@ -1481,7 +1480,6 @@ void samplePDFFDBase::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
   FarDetectorCoreInfo *fdobj = &MCSamples[iSample];
   
   fdobj->nEvents = nEvents_;
-  fdobj->signal = false;
   
   int nEvents = fdobj->nEvents;
   fdobj->x_var.resize(nEvents, &Unity);

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -137,6 +137,7 @@ void samplePDFFDBase::ReadSampleConfig()
   std::string splinesuffix = SampleManager->raw()["InputFiles"]["splinesuffix"].as<std::string>();
   
   for (auto const &osc_channel : SampleManager->raw()["SubSamples"]) {
+    oscchan_flavnames.push_back(osc_channel["name"].as<std::string>());
     mc_files.push_back(mtupleprefix+osc_channel["mtuplefile"].as<std::string>()+mtuplesuffix);
     spline_files.push_back(splineprefix+osc_channel["splinefile"].as<std::string>()+splinesuffix);
     sample_vecno.push_back(osc_channel["samplevecno"].as<int>());
@@ -1480,6 +1481,7 @@ void samplePDFFDBase::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
   FarDetectorCoreInfo *fdobj = &MCSamples[iSample];
   
   fdobj->nEvents = nEvents_;
+  fdobj->flavourName = oscchan_flavnames[iSample];
   
   int nEvents = fdobj->nEvents;
   fdobj->x_var.resize(nEvents, &Unity);

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -235,6 +235,7 @@ public:
   void InitialiseSingleFDMCObject(int iSample, int nEvents);
   void InitialiseSplineObject();
 
+  std::vector<std::string> oscchan_flavnames;
   std::vector<std::string> mc_files;
   std::vector<std::string> spline_files;
   std::vector<int> sample_vecno;

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -240,5 +240,4 @@ public:
   std::vector<int> sample_vecno;
   std::vector<int> sample_nupdg;
   std::vector<int> sample_nupdgunosc;
-  std::vector<bool> sample_signal;
 };


### PR DESCRIPTION
# Pull request description
Previous treatment of reading the 'signal' variable from the sample config was not being done in the core code. This meant that it was always false. Consequently (unless it was specifically filled in experiment specific code), NC signal events were being applied an oscillation weight. This will likely result in a small event rate change.

*** Relies upon https://github.com/mach3-software/MaCh3/pull/293 being merged first ***

## Changes or fixes
Rather than rely upon signal variable, just directly check the nupdg and nupdgUnosc variables are the same. Consequently can remove the signal entry from sample configs.

## Examples
