### PR TITLE
bugfix: Remove a reference to TLorentzVector

### DIFF
--- a/samplePDF/HistogramUtils.h
+++ b/samplePDF/HistogramUtils.h
@@ -9,7 +9,6 @@
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 // ROOT include
 #include "TGraphAsymmErrors.h"
-#include "TLorentzVector.h"
 #include "TObjString.h"
 #include "TRandom3.h"
 #pragma GCC diagnostic pop


### PR DESCRIPTION
# Pull request description
Removed a reference to TLorentVector as it is now a legacy class and doesn't work with ROOT version 6-32-08. 

Info here: https://root.cern.ch/doc/master/classTLorentzVector.html

## Changes or fixes

## Examples
