### PR TITLE
bugfix: Move throw to within expected if statement in splineFDBase dimension checking

### DIFF
--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -599,7 +599,6 @@ void samplePDFFDBase::fillArray_MP()  {
         }
         //DB - Second, check to see if the event is outside of the binning range and skip event if it is
         else if (XVar < XBinEdges[0] || XVar >= XBinEdges[nXBins]) {
-          MACH3LOG_WARN("XVAR BEYOND BIN EDGES!!");
           continue;
         }
         //DB - Thirdly, check the adjacent bins first as Eb+CC+EScale shifts aren't likely to move an Erec more than 1bin width

--- a/splines/splineFDBase.cpp
+++ b/splines/splineFDBase.cpp
@@ -460,8 +460,8 @@ std::vector<TAxis *> splineFDBase::FindSplineBinning(std::string FileName, std::
     if (Dimensions[iSample] != 2)
     {
       MACH3LOG_ERROR("Trying to load a 2D spline template when nDim={}", Dimensions[iSample]);
-    }
       throw MaCh3Exception(__FILE__, __LINE__);
+    }
     //Hist2D = std::unique_ptr<TH2F>(File->Get<TH2F>("dev_tmp_0_0"));
     Hist2D = File->Get<TH2F>(TemplateName.c_str());
   }


### PR DESCRIPTION
# Pull request description
Fix where throw is launched from in splineFD dimension checking and remove obnoxious console output

## Changes or fixes


## Examples
