### PR TITLE
feat: Improve spline printouts and remove redundancies

### DIFF
--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -1485,7 +1485,7 @@ void samplePDFFDBase::InitialiseSplineObject() {
   }
   
   SplineHandler->AddSample(samplename, SampleDetID, spline_filepaths, SplineVarNames);
-  SplineHandler->PrintArrayDimension();
+  SplineHandler->PrintArrayDimension(samplename);
   SplineHandler->CountNumberOfLoadedSplines(false, 1);
   SplineHandler->TransferToMonolith();
 

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -1485,7 +1485,6 @@ void samplePDFFDBase::InitialiseSplineObject() {
   }
   
   SplineHandler->AddSample(samplename, SampleDetID, spline_filepaths, SplineVarNames);
-  SplineHandler->PrintArrayDimension(samplename);
   SplineHandler->CountNumberOfLoadedSplines(false, 1);
   SplineHandler->TransferToMonolith();
 

--- a/splines/splineFDBase.cpp
+++ b/splines/splineFDBase.cpp
@@ -825,30 +825,20 @@ void splineFDBase::PrintArrayDetails(std::string SampleName)
     int nSysts = int(indexvec[iSample][iOscChan].size());
     MACH3LOG_INFO("Oscillation channel {} has {} systematics", iOscChan, nSysts);	  
   }
+
+  MACH3LOG_INFO("#----------------------------------------------------------------------------------------------------------------------------------#");
+  MACH3LOG_INFO("Printing no. of modes affected by each systematic for each oscillation channel");
+  for (unsigned int iOscChan = 0; iOscChan < indexvec[iSample].size(); iOscChan++) {
+    std::string modes = fmt::format("OscChan: {}\t", iOscChan);
+    for (unsigned int iSyst = 0; iSyst < indexvec[iSample][iOscChan].size(); iSyst++) {
+      modes += fmt::format("{} ", indexvec[iSample][iOscChan][iSyst].size());
+    }
+    MACH3LOG_INFO("{}", modes);
+  }
+  MACH3LOG_INFO("#----------------------------------------------------------------------------------------------------------------------------------#");
+
 }
 
-//****************************************
-void splineFDBase::PrintArrayDimension(std::string SampleName) {
-//****************************************
-  // This function merely prints the number of modes that are affected by a particular systematic for each oscillation channel
-  // While it is indeed "Array Dimension", it was not clear what exactly was being printed in the logger
-  MACH3LOG_INFO("#----------------------------------------------------------------------------------------------------------------------------------#");
-  MACH3LOG_INFO("On sample {}",SampleName);
-  MACH3LOG_INFO("Printing no. of modes affected by each systematic for each oscillation channel");
-  
-  for (unsigned int iSample = 0; iSample < indexvec.size(); iSample++) {
-    for (unsigned int iOscChan = 0; iOscChan < indexvec[iSample].size(); iOscChan++) {
-      std::string modes = fmt::format("OscChan: {}\t", iOscChan);
-      for (unsigned int iSyst = 0; iSyst < indexvec[iSample][iOscChan].size(); iSyst++) {
-        modes += fmt::format("{} ", indexvec[iSample][iOscChan][iSyst].size());
-      }
-      MACH3LOG_INFO("{}", modes);
-    }
-    MACH3LOG_INFO("");  // Empty line for spacing
-  }
-  
-  MACH3LOG_INFO("#----------------------------------------------------------------------------------------------------------------------------------#");
-}
 //****************************************
 bool splineFDBase::isValidSplineIndex(std::string SampleName, int iOscChan, int iSyst, int iMode, int iVar1, int iVar2, int iVar3)
 //****************************************

--- a/splines/splineFDBase.cpp
+++ b/splines/splineFDBase.cpp
@@ -836,12 +836,15 @@ void splineFDBase::PrintArrayDimension(std::string SampleName) {
   MACH3LOG_INFO("On sample {}",SampleName);
   MACH3LOG_INFO("Printing no. of modes affected by each systematic for each oscillation channel");
   
-  for (unsigned int iOscChan = 0; iOscChan < indexvec[iSample].size(); iOscChan++) {
-    std::string modes = fmt::format("\t\tOscChan: {}\t", iOscChan);
-    for (unsigned int iSyst = 0; iSyst < indexvec[iSample][iOscChan].size(); iSyst++) {
-      modes += fmt::format("{} ", indexvec[iSample][iOscChan][iSyst].size());
+  for (unsigned int iSample = 0; iSample < indexvec.size(); iSample++) {
+    for (unsigned int iOscChan = 0; iOscChan < indexvec[iSample].size(); iOscChan++) {
+      std::string modes = fmt::format("OscChan: {}\t", iOscChan);
+      for (unsigned int iSyst = 0; iSyst < indexvec[iSample][iOscChan].size(); iSyst++) {
+        modes += fmt::format("{} ", indexvec[iSample][iOscChan][iSyst].size());
+      }
+      MACH3LOG_INFO("{}", modes);
     }
-    MACH3LOG_INFO("{}", modes);
+    MACH3LOG_INFO("");  // Empty line for spacing
   }
   
   MACH3LOG_INFO("#----------------------------------------------------------------------------------------------------------------------------------#");

--- a/splines/splineFDBase.cpp
+++ b/splines/splineFDBase.cpp
@@ -828,40 +828,22 @@ void splineFDBase::PrintArrayDetails(std::string SampleName)
 }
 
 //****************************************
-void splineFDBase::PrintArrayDimension() {
+void splineFDBase::PrintArrayDimension(std::string SampleName) {
 //****************************************
+  // This function merely prints the number of modes that are affected by a particular systematic for each oscillation channel
+  // While it is indeed "Array Dimension", it was not clear what exactly was being printed in the logger
   MACH3LOG_INFO("#----------------------------------------------------------------------------------------------------------------------------------#");
-  MACH3LOG_INFO("Array dimensions..");
-  MACH3LOG_INFO("{:<20}{}", "nSamples:", indexvec.size());
-
-  MACH3LOG_INFO("{:<20}", "nOscChans:");
-  std::string oscChans;
-  for (unsigned int iSample = 0; iSample < indexvec.size(); iSample++) {
-    oscChans += fmt::format("{} ", indexvec[iSample].size());
-  }
-  MACH3LOG_INFO("{}", oscChans);
-
-  MACH3LOG_INFO("{:<20}", "nSysts:");
-  for (unsigned int iSample = 0; iSample < indexvec.size(); iSample++) {
-    std::string systs = fmt::format("\tSample: {}\t", iSample);
-    for (unsigned int iOscChan = 0; iOscChan < indexvec[iSample].size(); iOscChan++) {
-      systs += fmt::format("{} ", indexvec[iSample][iOscChan].size());
+  MACH3LOG_INFO("On sample {}",SampleName);
+  MACH3LOG_INFO("Printing no. of modes affected by each systematic for each oscillation channel");
+  
+  for (unsigned int iOscChan = 0; iOscChan < indexvec[iSample].size(); iOscChan++) {
+    std::string modes = fmt::format("\t\tOscChan: {}\t", iOscChan);
+    for (unsigned int iSyst = 0; iSyst < indexvec[iSample][iOscChan].size(); iSyst++) {
+      modes += fmt::format("{} ", indexvec[iSample][iOscChan][iSyst].size());
     }
-    MACH3LOG_INFO("{}", systs);
+    MACH3LOG_INFO("{}", modes);
   }
-
-  MACH3LOG_INFO("{:<20}", "nModes:");
-  for (unsigned int iSample = 0; iSample < indexvec.size(); iSample++) {
-    MACH3LOG_INFO("\tSample: {}\t--------------------------", iSample);
-    for (unsigned int iOscChan = 0; iOscChan < indexvec[iSample].size(); iOscChan++) {
-      std::string modes = fmt::format("\t\tOscChan: {}\t", iOscChan);
-      for (unsigned int iSyst = 0; iSyst < indexvec[iSample][iOscChan].size(); iSyst++) {
-        modes += fmt::format("{} ", indexvec[iSample][iOscChan][iSyst].size());
-      }
-      MACH3LOG_INFO("{}", modes);
-    }
-    MACH3LOG_INFO("");  // Empty line for spacing
-  }
+  
   MACH3LOG_INFO("#----------------------------------------------------------------------------------------------------------------------------------#");
 }
 //****************************************

--- a/splines/splineFDBase.cpp
+++ b/splines/splineFDBase.cpp
@@ -818,7 +818,7 @@ void splineFDBase::PrintArrayDetails(std::string SampleName)
 {
   int iSample = getSampleIndex(SampleName);
   int nOscChannels = int(indexvec[iSample].size());
-  MACH3LOG_INFO("Sample {} has {} oscillation channels", iSample, nOscChannels);	
+  MACH3LOG_INFO("Sample {} has {} oscillation channels", SampleName, nOscChannels);	
   
   for (int iOscChan = 0; iOscChan < nOscChannels; iOscChan++)
   {

--- a/splines/splineFDBase.h
+++ b/splines/splineFDBase.h
@@ -66,7 +66,7 @@ class splineFDBase : public SplineBase {
 	void PrintBinning(TAxis* Axis);
 	void PrintSampleDetails(std::string SampleName);
 	void PrintArrayDetails(std::string SampleName);
-	void PrintArrayDimension();
+	void PrintArrayDimension(std::string SampleName);
 
 	const M3::float_t* retPointer(int sample, int oscchan, int syst, int mode, int var1bin, int var2bin, int var3bin){
 	  int index = indexvec[sample][oscchan][syst][mode][var1bin][var2bin][var3bin];

--- a/splines/splineFDBase.h
+++ b/splines/splineFDBase.h
@@ -66,8 +66,7 @@ class splineFDBase : public SplineBase {
 	void PrintBinning(TAxis* Axis);
 	void PrintSampleDetails(std::string SampleName);
 	void PrintArrayDetails(std::string SampleName);
-	void PrintArrayDimension(std::string SampleName);
-
+	
 	const M3::float_t* retPointer(int sample, int oscchan, int syst, int mode, int var1bin, int var2bin, int var3bin){
 	  int index = indexvec[sample][oscchan][syst][mode][var1bin][var2bin][var3bin];
 	  return &weightvec_Monolith[index];


### PR DESCRIPTION
# Pull request description
The loggers in SplineFDBase showed some redundant and unclear information. I tidied it up a bit while preserving necessary printouts.

## Changes or fixes

- Merge PrintArrayDetails and PrintArrayDimensions functions and remove the latter
- Update SamplePDFFDBase after this change.

## Examples
Before the fix, splineFDBase would show this output:
<img width="1417" alt="Screenshot 2025-01-25 at 09 34 36" src="https://github.com/user-attachments/assets/919f4510-04bc-4bde-8832-3d832e25110f" />

And after the update, it shows this:
<img width="1273" alt="Screenshot 2025-01-25 at 10 28 41" src="https://github.com/user-attachments/assets/7a6a8cde-034e-4832-9dd6-12b3e2c075b0" />

