### PR TITLE
tidy: Safe Include

### DIFF
--- a/Diagnostics/CombineMaCh3Chains.cpp
+++ b/Diagnostics/CombineMaCh3Chains.cpp
@@ -1,13 +1,11 @@
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 // C++ includes
 #include <unistd.h>
 
+// MaCh3 includes
+#include "manager/manager.h"
+#include "samplePDF/Structs.h"
+
+_MaCh3_Safe_Include_Start_ //{
 // ROOT includes
 #include "TList.h"
 #include "TFile.h"
@@ -17,10 +15,7 @@
 #include "TFileMerger.h"
 #include "TKey.h"
 #include "TROOT.h"
-#pragma GCC diagnostic pop
-
-// MaCh3 includes
-#include "manager/manager.h"
+_MaCh3_Safe_Include_End_ //}
 
 /// @file CombineMaCh3Chains
 /// @author Ewan Miller

--- a/Diagnostics/GetPenaltyTerm.cpp
+++ b/Diagnostics/GetPenaltyTerm.cpp
@@ -1,10 +1,8 @@
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+// MaCh3 includes
+#include "manager/manager.h"
+#include "samplePDF/Structs.h"
+
+_MaCh3_Safe_Include_Start_ //{
 // ROOT includes
 #include "TFile.h"
 #include "TBranch.h"
@@ -22,14 +20,7 @@
 #include "TColor.h"
 #include "TObjString.h"
 #include "TROOT.h"
-#pragma GCC diagnostic pop
-
-#ifdef MULTITHREAD
-#include "omp.h"
-#endif
-
-#include "manager/manager.h"
-
+_MaCh3_Safe_Include_End_ //}
 
 /// @file GetPenaltyTerm.cpp
 /// @brief KS: This file contains the implementation of the function to extract specific penalty terms from systematic chains.

--- a/Diagnostics/RHat.cpp
+++ b/Diagnostics/RHat.cpp
@@ -1,10 +1,8 @@
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+// MaCh3 includes
+#include "manager/manager.h"
+#include "samplePDF/Structs.h"
+
+_MaCh3_Safe_Include_Start_ //{
 // ROOT includes
 #include "TObjArray.h"
 #include "TChain.h"
@@ -20,14 +18,7 @@
 #include "TColor.h"
 #include "TStyle.h"
 #include "TROOT.h"
-#pragma GCC diagnostic pop
-
-#ifdef MULTITHREAD
-#include "omp.h"
-#endif
-
-// MaCh3 includes
-#include "manager/manager.h"
+_MaCh3_Safe_Include_End_ //}
 
 /// @file RHat.cpp
 /// @brief This executable calculates the \f$ \hat{R} \f$ estimator for Markov Chain Monte Carlo (MCMC) convergence.

--- a/Diagnostics/RHat_HighMem.cpp
+++ b/Diagnostics/RHat_HighMem.cpp
@@ -1,10 +1,8 @@
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+// MaCh3 includes
+#include "manager/manager.h"
+#include "samplePDF/Structs.h"
+
+_MaCh3_Safe_Include_Start_ //{
 // ROOT includes
 #include "TObjArray.h"
 #include "TChain.h"
@@ -20,14 +18,7 @@
 #include "TColor.h"
 #include "TStyle.h"
 #include "TROOT.h"
-#pragma GCC diagnostic pop
-
-#ifdef MULTITHREAD
-#include "omp.h"
-#endif
-
-// MaCh3 includes
-#include "manager/manager.h"
+_MaCh3_Safe_Include_End_ //}
 
 /// @file RHat.cpp
 /// @brief This executable calculates the \f$ \hat{R} \f$ estimator for Markov Chain Monte Carlo (MCMC) convergence.

--- a/covariance/CovarianceUtils.h
+++ b/covariance/CovarianceUtils.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+// MaCh3 includes
+#include "samplePDF/Structs.h"
+
+_MaCh3_Safe_Include_Start_ //{
 // ROOT includes
 #include "TMatrixT.h"
 #include "TMatrixDSym.h"
@@ -24,13 +21,9 @@
 #include "TMatrixDSymEigen.h"
 #include "TMatrixDEigen.h"
 #include "TDecompSVD.h"
-#pragma GCC diagnostic pop
+_MaCh3_Safe_Include_End_ //}
 
-#ifdef MULTITHREAD
-#include "omp.h"
-#endif
-
-namespace MaCh3Utils
+namespace M3
 {
   /// @brief number of threads which we need for example for TRandom3
   inline int GetNThreads()

--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -117,7 +117,7 @@ void covarianceBase::init(std::string name, std::string file) {
 
   PrintLength = 35;
 
-  const int nThreads = MaCh3Utils::GetNThreads();
+  const int nThreads = M3::GetNThreads();
   //KS: set Random numbers for each thread so each thread has different seed
   //or for one thread if without MULTITHREAD
   random_number.reserve(nThreads);
@@ -172,7 +172,7 @@ void covarianceBase::init(const std::vector<std::string>& YAMLFile) {
     }
   }
 
-  const int nThreads = MaCh3Utils::GetNThreads();
+  const int nThreads = M3::GetNThreads();
   //KS: set Random numbers for each thread so each thread has different seed
   //or for one thread if without MULTITHREAD
   random_number.reserve(nThreads);

--- a/mcmc/MCMCProcessor.cpp
+++ b/mcmc/MCMCProcessor.cpp
@@ -1,15 +1,9 @@
 #include "MCMCProcessor.h"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+_MaCh3_Safe_Include_Start_ //{
 #include "TChain.h"
 #include "TF1.h"
-#pragma GCC diagnostic pop
+_MaCh3_Safe_Include_End_ //}
 
 //Only if GPU is enabled
 #ifdef CUDA

--- a/mcmc/MCMCProcessor.h
+++ b/mcmc/MCMCProcessor.h
@@ -8,13 +8,11 @@
 #include <complex>
 #include <cstdio>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+// MaCh3 includes
+#include "mcmc/StatisticalUtils.h"
+#include "samplePDF/HistogramUtils.h"
+
+_MaCh3_Safe_Include_Start_ //{
 // ROOT includes
 #include "TFile.h"
 #include "TBranch.h"
@@ -38,12 +36,8 @@
 #include "TMath.h"
 #include "TMatrixDSymEigen.h"
 #include "TVirtualFFT.h"
-#pragma GCC diagnostic pop
+_MaCh3_Safe_Include_End_ //}
 
-
-// MaCh3 includes
-#include "mcmc/StatisticalUtils.h"
-#include "samplePDF/HistogramUtils.h"
 
 //KS: Joy of forward declaration https://gieseanw.wordpress.com/2018/02/25/the-joys-of-forward-declarations-results-from-the-real-world/
 class TChain;

--- a/plotting/GetPostfitParamPlots.cpp
+++ b/plotting/GetPostfitParamPlots.cpp
@@ -3,13 +3,11 @@
 #include <iomanip>
 #include <algorithm>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#include "plottingUtils/plottingUtils.h"
+#include "plottingUtils/plottingManager.h"
+#include "samplePDF/Structs.h"
+
+_MaCh3_Safe_Include_Start_ //{
 #include "TROOT.h"
 #include "TGaxis.h"
 #include "TString.h"
@@ -26,10 +24,7 @@
 #include "TCandle.h"
 #include "TFrame.h"
 #include "TGraphAsymmErrors.h"
-#pragma GCC diagnostic pop
-
-#include "plottingUtils/plottingUtils.h"
-#include "plottingUtils/plottingManager.h"
+_MaCh3_Safe_Include_End_ //}
 
 /// @file GetPostfitParamPlots
 /// This script generates post-fit parameter plots. The central postfit value is

--- a/samplePDF/HistogramUtils.cpp
+++ b/samplePDF/HistogramUtils.cpp
@@ -1,15 +1,9 @@
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#include "samplePDF/HistogramUtils.h"
+
+_MaCh3_Safe_Include_Start_ //{
 #include "TList.h"
 #include "TObjArray.h"
-#pragma GCC diagnostic pop
-
-#include "samplePDF/HistogramUtils.h"
+_MaCh3_Safe_Include_End_ //}
 
 // **************************************************
 //KS: ROOT changes something with binning when moving from ROOT 5 to ROOT 6. If you open ROOT5 produced file with ROOT6 you will be missing 9 last bins

--- a/samplePDF/HistogramUtils.h
+++ b/samplePDF/HistogramUtils.h
@@ -1,20 +1,14 @@
 #pragma once
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+// MaCh3 includes
+#include "samplePDF/Structs.h"
+
+_MaCh3_Safe_Include_Start_ //{
 // ROOT include
 #include "TGraphAsymmErrors.h"
 #include "TObjString.h"
 #include "TRandom3.h"
-#pragma GCC diagnostic pop
-
-// MaCh3 inlcudes
-#include "samplePDF/Structs.h"
+_MaCh3_Safe_Include_End_ //}
 
 /// @file HistogramUtils.h
 /// @author Will Parker

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -62,15 +62,27 @@ constexpr static const int Unity_Int = 1;
 #include "omp.h"
 #endif
 
+// MaCh3 includes
 #include "manager/MaCh3Exception.h"
 #include "manager/MaCh3Logger.h"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
+/// @brief KS: Avoiding warning checking for headers
+/// @details Many external files don't strictly adhere to rigorous C++ standards.
+/// Inline functions in such headers may cause errors when compiled with strict MaCh3 compiler flags.
+/// @warning Use this for any external header file to avoid warnings.
+#define _MaCh3_Safe_Include_Start_ \
+_Pragma("GCC diagnostic push") \
+_Pragma("GCC diagnostic ignored \"-Wuseless-cast\"") \
+_Pragma("GCC diagnostic ignored \"-Wfloat-conversion\"") \
+_Pragma("GCC diagnostic ignored \"-Wold-style-cast\"") \
+_Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"") \
+_Pragma("GCC diagnostic ignored \"-Wconversion\"")
+
+/// @brief KS: Restore warning checking after including external headers
+#define _MaCh3_Safe_Include_End_ \
+_Pragma("GCC diagnostic pop")
+
+_MaCh3_Safe_Include_Start_ //{
 // ROOT include
 #include "TSpline.h"
 #include "TObjString.h"
@@ -80,7 +92,7 @@ constexpr static const int Unity_Int = 1;
 #include "TH1.h"
 // NuOscillator includes
 #include "Constants/OscillatorConstants.h"
-#pragma GCC diagnostic pop
+_MaCh3_Safe_Include_End_ //}
 
 
 /// @file Structs.h

--- a/samplePDF/samplePDFBase.h
+++ b/samplePDF/samplePDFBase.h
@@ -3,13 +3,12 @@
 //C++ includes
 #include <assert.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+//MaCh3 includes
+#include "samplePDF/Structs.h"
+#include "samplePDF/HistogramUtils.h"
+#include "manager/manager.h"
+
+_MaCh3_Safe_Include_Start_ //{
 //ROOT includes
 #include "TTree.h"
 #include "TH1D.h"
@@ -19,12 +18,7 @@
 #include "TROOT.h"
 #include "TRandom3.h"
 #include "TString.h"
-#pragma GCC diagnostic pop
-
-//MaCh3 includes
-#include "samplePDF/Structs.h"
-#include "samplePDF/HistogramUtils.h"
-#include "manager/manager.h"
+_MaCh3_Safe_Include_End_ //}
 
 /// @brief Class responsible for handling implementation of samples used in analysis, reweighting and returning LLH
 class samplePDFBase

--- a/splines/SplineBase.h
+++ b/splines/SplineBase.h
@@ -4,13 +4,12 @@
 #include <cstdlib>
 #include <iomanip>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+// MaCh3  includes
+#include "manager/MaCh3Logger.h"
+#include "splines/SplineStructs.h"
+#include "splines/SplineCommon.h"
+
+_MaCh3_Safe_Include_Start_ //{
 // ROOT include
 #include "TFile.h"
 #include "TH1F.h"
@@ -21,16 +20,7 @@
 #include "TCanvas.h"
 #include "TStyle.h"
 #include "TTree.h"
-#pragma GCC diagnostic pop
-
-#ifdef MULTITHREAD
-#include "omp.h"
-#endif
-
-// MaCh3  includes
-#include "manager/MaCh3Logger.h"
-#include "splines/SplineStructs.h"
-#include "splines/SplineCommon.h"
+_MaCh3_Safe_Include_End_ //}
 
 /// @brief Base class for calculating weight from spline
 class SplineBase {

--- a/splines/SplineStructs.h
+++ b/splines/SplineStructs.h
@@ -11,7 +11,6 @@
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
 #pragma GCC diagnostic ignored "-Wnull-dereference"
 
-
 /// @file SplineStructs.h
 /// @brief Contains structures and helper functions for handling spline representations of systematic parameters in the MaCh3.
 /// @author Clarence Wret

--- a/splines/splineFDBase.cpp
+++ b/splines/splineFDBase.cpp
@@ -189,7 +189,7 @@ void splineFDBase::TransferToMonolith()
                     xcoeff_arr[iCoeff+i]=tmpXCoeffArr[i];
 
                     for(int j=0; j<4; j++){
-			manycoeff_arr[(iCoeff+i)*4+j]=tmpManyCoeffArr[i*4+j];
+                      manycoeff_arr[(iCoeff+i)*4+j]=tmpManyCoeffArr[i*4+j];
                     }
                   }
                   delete[] tmpXCoeffArr;
@@ -205,6 +205,10 @@ void splineFDBase::TransferToMonolith()
       }//syst2 loop end
     }//osc loop end
   }//syst1 loop end
+
+  // No longer needs it so shrink size to save RAM
+  splinevec_Monolith.clear();
+  splinevec_Monolith.shrink_to_fit();
 }
 
 // *****************************************

--- a/splines/splineFDBase.h
+++ b/splines/splineFDBase.h
@@ -1,19 +1,13 @@
 #pragma once
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-// ROOT includes
-#include "TH3F.h"
-#pragma GCC diagnostic pop
-
-//MaCh3
+//MaCh3 includes
 #include "samplePDF/Structs.h"
 #include "splines/SplineBase.h"
+
+_MaCh3_Safe_Include_Start_ //{
+// ROOT includes
+#include "TH3F.h"
+_MaCh3_Safe_Include_End_ //}
 
 /// @brief Bin-by-bin class calculating response for spline parameters.
 /// @see For more details, visit the [Wiki](https://github.com/mach3-software/MaCh3/wiki/05.-Splines).
@@ -84,7 +78,6 @@ class splineFDBase : public SplineBase {
 
 	//And now the actual member variables	
 	std::vector<std::string> SampleNames;
-	std::vector<int> BinningOpts;
 	std::vector<int> Dimensions;
 	std::vector<std::vector<std::string>> DimensionLabels;
 	std::vector<std::string> DetIDs;
@@ -94,9 +87,9 @@ class splineFDBase : public SplineBase {
 	std::vector< std::vector<int> > SplineParsIndex;
 	std::vector< std::vector< std::vector<TAxis*> > > SplineBinning;
 	std::vector< std::vector<std::string> > SplineFileParPrefixNames;
-	//A vector of vectors of the spline modes that a systematic applies to
-	//This gets compared against the event mode to figure out if a syst should 
-	//apply to an event or not
+	/// A vector of vectors of the spline modes that a systematic applies to
+	/// This gets compared against the event mode to figure out if a syst should
+	/// apply to an event or not
 	std::vector< std::vector< std::vector<int> > > SplineModeVecs;
 	/// @brief This holds the global spline index and is used to grab the current parameter value
 	/// to evaluate splines at. Each internal vector will be of size of the number of spline
@@ -124,11 +117,14 @@ class splineFDBase : public SplineBase {
 	int MonolithIndex;
 	int CoeffIndex;
 
-	//Probably need to clear these arrays up at some point
+	/// Probably need to clear these arrays up at some point
 	M3::float_t *xVarArray;
-	bool *isflatarray;    // Need to keep track of which splines are flat and which aren't
-	M3::float_t *xcoeff_arr;    //x coefficients for each spline
-	M3::float_t *manycoeff_arr; //ybcd coefficients for each spline
+	/// Need to keep track of which splines are flat and which aren't
+	bool *isflatarray;
+	/// x coefficients for each spline
+	M3::float_t *xcoeff_arr;
+	/// ybcd coefficients for each spline
+	M3::float_t *manycoeff_arr;
 
 	std::vector<M3::float_t> weightvec_Monolith;
 	std::vector<int> uniquesplinevec_Monolith;


### PR DESCRIPTION
# Pull request description
To properly use Werror we need lot of protection around extranl headers.
Sadly this forced us to add several lines in many parts of code. This feature is supposed to make this part nicer and tidier

## Changes or fixes
- Safe inlcude define
- BinningOpts is removed
- splinevec_Monolith is shirnked adter elements are removed to save tiny bit of RAM

## Examples
