### PR TITLE
feat: Minor Speedup and Tidy of SamplePDF

### DIFF
--- a/samplePDF/FarDetectorCoreInfoStruct.h
+++ b/samplePDF/FarDetectorCoreInfoStruct.h
@@ -11,7 +11,7 @@ struct FarDetectorCoreInfo {
   FarDetectorCoreInfo& operator=(FarDetectorCoreInfo const &other) = delete;
   FarDetectorCoreInfo& operator=(FarDetectorCoreInfo &&other) = delete;
 
-  ~FarDetectorCoreInfo(){ delete [] isNC; }
+  ~FarDetectorCoreInfo(){if(isNC != nullptr) delete [] isNC;}
 
   int nEvents; ///< how many MC events are there
   double ChannelIndex;

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -132,9 +132,9 @@ public:
   /// @brief Check whether a normalisation systematic affects an event or not
   void CalcXsecNormsBins(int iSample);
   /// @brief Calculate the spline weight for a given event
-  M3::float_t CalcXsecWeightSpline(const int iSample, const int iEvent) const;
+  M3::float_t CalcWeightSpline(const int iSample, const int iEvent) const;
   /// @brief Calculate the norm weight for a given event
-  M3::float_t CalcXsecWeightNorm(const int iSample, const int iEvent) const;
+  M3::float_t CalcWeightNorm(const int iSample, const int iEvent) const;
 
   /// @brief Calculate weights for function parameters
   ///


### PR DESCRIPTION
# Pull request description


## Changes or fixes
- CalcXsecWeight -> CalcWeight. Xsec is confusing
- Use collapse to make LLH sliglhy faster
- *= CalcWeight -> = CalcWeight. Mulitplying 1 by weight is pointless. This give two less multiplaction per event. Super minor I know
- Safer Destructor of isNC

## Examples
LLH before
```
[FitterBase.cpp][info] It took 0.0092 s to calculate  GetLikelihood 10000 times sample:  Tutorial
[FitterBase.cpp][info] On average 0.000001
```
LLH after:
```
[FitterBase.cpp][info] It took 0.0081 s to calculate  GetLikelihood 10000 times sample:  Tutorial
[FitterBase.cpp][info] On average 0.000001
```