### PR TITLE
tidy: More Yaml protection and new header to fight circular dependancy

### DIFF
--- a/Diagnostics/DiagMCMC.cpp
+++ b/Diagnostics/DiagMCMC.cpp
@@ -9,7 +9,7 @@ void DiagMCMC(const std::string& inputFile, const std::string& config)
 {
   MACH3LOG_INFO("File for study: {}", inputFile);
 
-  YAML::Node Settings = YAML::LoadFile(config);
+  YAML::Node Settings = M3OpenConfig(config);
 
   // Make the processor
   auto Processor = std::make_unique<MCMCProcessor>(inputFile);

--- a/Diagnostics/GetPenaltyTerm.cpp
+++ b/Diagnostics/GetPenaltyTerm.cpp
@@ -76,7 +76,7 @@ void ReadXSecFile(const std::string& inputFile)
   XSecFile["Systematics"] = YAML::Node(YAML::NodeType::Sequence);
   for(unsigned int i = 0; i < XsecCovPos.size(); i++)
   {
-    YAML::Node YAMLDocTemp = YAML::LoadFile(XsecCovPos[i]);
+    YAML::Node YAMLDocTemp = M3OpenConfig(XsecCovPos[i]);
     for (const auto& item : YAMLDocTemp["Systematics"]) {
       XSecFile["Systematics"].push_back(item);
     }

--- a/Diagnostics/ProcessMCMC.cpp
+++ b/Diagnostics/ProcessMCMC.cpp
@@ -74,7 +74,7 @@ void ProcessMCMC(const std::string& inputFile)
   // Make the processor)
   auto Processor = std::make_unique<MCMCProcessor>(inputFile);
 
-  YAML::Node card_yaml = YAML::LoadFile(config.c_str());
+  YAML::Node card_yaml = M3OpenConfig(config.c_str());
   YAML::Node Settings = card_yaml["ProcessMCMC"];
 
   const bool PlotCorr = GetFromManager<bool>(Settings["PlotCorr"], false);
@@ -152,7 +152,7 @@ void ProcessMCMC(const std::string& inputFile)
 
 void MultipleProcessMCMC()
 {
-  YAML::Node card_yaml = YAML::LoadFile(config.c_str());
+  YAML::Node card_yaml = M3OpenConfig(config.c_str());
   YAML::Node Settings = card_yaml["ProcessMCMC"];
 
   constexpr Color_t PosteriorColor[] = {kBlue-1, kRed, kGreen+2};
@@ -318,7 +318,7 @@ void MultipleProcessMCMC()
 // KS: Calculate Bayes factor for a given hypothesis, most informative are those related to osc params. However, it make relative easy interpretation for switch dials
 void CalcBayesFactor(const std::unique_ptr<MCMCProcessor>& Processor)
 {
-  YAML::Node card_yaml = YAML::LoadFile(config.c_str());
+  YAML::Node card_yaml = M3OpenConfig(config.c_str());
   YAML::Node Settings = card_yaml["ProcessMCMC"];
 
   std::vector<std::string> ParNames;
@@ -338,7 +338,7 @@ void CalcBayesFactor(const std::unique_ptr<MCMCProcessor>& Processor)
 
 void CalcSavageDickey(const std::unique_ptr<MCMCProcessor>& Processor)
 {
-  YAML::Node card_yaml = YAML::LoadFile(config.c_str());
+  YAML::Node card_yaml = M3OpenConfig(config.c_str());
   YAML::Node Settings = card_yaml["ProcessMCMC"];
 
   std::vector<std::string> ParNames;
@@ -356,7 +356,7 @@ void CalcSavageDickey(const std::unique_ptr<MCMCProcessor>& Processor)
 
 void CalcParameterEvolution(const std::unique_ptr<MCMCProcessor>& Processor)
 {
-  YAML::Node card_yaml = YAML::LoadFile(config.c_str());
+  YAML::Node card_yaml = M3OpenConfig(config.c_str());
   YAML::Node Settings = card_yaml["ProcessMCMC"];
 
   std::vector<std::string> ParNames;
@@ -371,7 +371,7 @@ void CalcParameterEvolution(const std::unique_ptr<MCMCProcessor>& Processor)
 
 void CalcBipolarPlot(const std::unique_ptr<MCMCProcessor>& Processor)
 {
-  YAML::Node card_yaml = YAML::LoadFile(config.c_str());
+  YAML::Node card_yaml = M3OpenConfig(config.c_str());
   YAML::Node Settings = card_yaml["ProcessMCMC"];
 
   std::vector<std::string> ParNames;
@@ -383,7 +383,7 @@ void CalcBipolarPlot(const std::unique_ptr<MCMCProcessor>& Processor)
 }
 
 void GetTrianglePlot(const std::unique_ptr<MCMCProcessor>& Processor) {
-  YAML::Node card_yaml = YAML::LoadFile(config.c_str());
+  YAML::Node card_yaml = M3OpenConfig(config.c_str());
   YAML::Node Settings = card_yaml["ProcessMCMC"];
 
   for (const auto& dg : Settings["TrianglePlot"])
@@ -433,7 +433,7 @@ void DiagnoseCovarianceMatrix(const std::unique_ptr<MCMCProcessor>& Processor, c
   Canvas->Print(Form("Correlation_%s.pdf[", OutName.c_str()), "pdf");
   Canvas->Print(Form("Covariance_%s.pdf[", OutName.c_str()), "pdf");
   
-  YAML::Node card_yaml = YAML::LoadFile(config.c_str());
+  YAML::Node card_yaml = M3OpenConfig(config.c_str());
   YAML::Node Settings = card_yaml["ProcessMCMC"];
 
   const int entries = int(Processor->GetnSteps());
@@ -579,7 +579,7 @@ void DiagnoseCovarianceMatrix(const std::unique_ptr<MCMCProcessor>& Processor, c
 
 void ReweightPrior(const std::unique_ptr<MCMCProcessor>& Processor)
 {
-  YAML::Node card_yaml = YAML::LoadFile(config.c_str());
+  YAML::Node card_yaml = M3OpenConfig(config.c_str());
   YAML::Node Settings = card_yaml["ProcessMCMC"];
 
   const auto& Prior = Settings["PriorReweighting"];

--- a/manager/CMakeLists.txt
+++ b/manager/CMakeLists.txt
@@ -6,6 +6,7 @@ set(HEADERS
     Monitor.h
     MaCh3Exception.h
     gpuUtils.cuh
+    Core.h
 )
 
 add_library(Manager SHARED

--- a/manager/Core.h
+++ b/manager/Core.h
@@ -1,0 +1,81 @@
+#pragma once
+
+/// @file Core.h
+/// @author Clarence Wret
+/// @author Kamil Skwarczynski
+/// @author Luke Pickering
+
+/// Run low or high memory versions of structs
+/// N.B. for 64 bit systems sizeof(float) == sizeof(double) so not a huge effect
+/// KS: Need more testing on FD
+namespace M3 {
+  #ifdef _LOW_MEMORY_STRUCTS_
+  /// Custom floating point (float or double)
+  using float_t = float;
+  /// Custom integer (int or short int)
+  using int_t = short;
+  /// Custom unsigned integer (unsigned short int or unsigned int)
+  using uint_t = unsigned short;
+  #else
+  using float_t = double;
+  using int_t = int;
+  using uint_t = unsigned;
+  #endif
+}
+
+/// KS: noexcept can help with performance but is terrible for debugging, this is meant to help easy way of of turning it on or off. In near future move this to struct or other central class.
+//#define SafeException
+#ifndef SafeException
+#define _noexcept_ noexcept
+#else
+#define _noexcept_
+#endif
+
+/// KS: Using restrict limits the effects of pointer aliasing, aiding optimizations. While reading I found that there might be some compilers which don't have __restrict__. As always we use _restrict_ to more easily turn off restrict in the code
+#ifndef DEBUG
+#define _restrict_ __restrict__
+#else
+#define _restrict_
+#endif
+
+/// Number of overflow bins in TH2Poly,
+#define _TH2PolyOverflowBins_ 9
+
+constexpr static const double _BAD_DOUBLE_ = -999.99;
+constexpr static const int _BAD_INT_ = -999;
+
+constexpr static const double _DEFAULT_RETURN_VAL_ = -999999.123456;
+
+// Some commonly used variables to which we set pointers to
+constexpr static const double Unity = 1.;
+constexpr static const double Zero = 0.;
+constexpr static const float Unity_F = 1.;
+constexpr static const float Zero_F = 0.;
+constexpr static const int Unity_Int = 1;
+
+// C++ includes
+#include <sstream>
+#include <fstream>
+#include <iostream>
+#include <vector>
+#include <iomanip>
+
+#ifdef MULTITHREAD
+#include "omp.h"
+#endif
+
+/// @brief KS: Avoiding warning checking for headers
+/// @details Many external files don't strictly adhere to rigorous C++ standards.
+/// Inline functions in such headers may cause errors when compiled with strict MaCh3 compiler flags.
+/// @warning Use this for any external header file to avoid warnings.
+#define _MaCh3_Safe_Include_Start_ \
+_Pragma("GCC diagnostic push") \
+_Pragma("GCC diagnostic ignored \"-Wuseless-cast\"") \
+_Pragma("GCC diagnostic ignored \"-Wfloat-conversion\"") \
+_Pragma("GCC diagnostic ignored \"-Wold-style-cast\"") \
+_Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"") \
+_Pragma("GCC diagnostic ignored \"-Wconversion\"")
+
+/// @brief KS: Restore warning checking after including external headers
+#define _MaCh3_Safe_Include_End_ \
+_Pragma("GCC diagnostic pop")

--- a/manager/MaCh3Exception.h
+++ b/manager/MaCh3Exception.h
@@ -7,6 +7,7 @@
 
 // MaCh3 Includes
 #include "manager/MaCh3Logger.h"
+#include "manager/Core.h"
 
 /// @brief Custom exception class for MaCh3 errors.
 class MaCh3Exception : public std::exception {

--- a/manager/MaCh3Modes.cpp
+++ b/manager/MaCh3Modes.cpp
@@ -6,7 +6,7 @@ MaCh3Modes::MaCh3Modes(std::string const &filename) {
 // *******************
 
   // Load config
-  YAML::Node config = YAML::LoadFile(filename);
+  YAML::Node config = M3OpenConfig(filename);
 
   std::string GetMaCh3ModeName(const int Index);
   NModes = 0;

--- a/manager/Monitor.h
+++ b/manager/Monitor.h
@@ -9,7 +9,6 @@
 
 // MaCh3 includes
 #include "manager/MaCh3Logger.h"
-#include "samplePDF/Structs.h"
 #include "manager/MaCh3Exception.h"
 #include "manager/YamlHelper.h"
 

--- a/manager/Monitor.h
+++ b/manager/Monitor.h
@@ -23,7 +23,6 @@ _MaCh3_Safe_Include_Start_ //{
 _MaCh3_Safe_Include_End_ //}
 
 
-
 /// @file Monitor.h
 /// @brief System and monitoring utilities for printing system information and status updates.
 /// @author Kamil Skwarczynski

--- a/manager/YamlHelper.h
+++ b/manager/YamlHelper.h
@@ -8,7 +8,7 @@
 
 // MaCh3 Includes
 #include "manager/MaCh3Exception.h"
-#include "samplePDF/Structs.h"
+#include "manager/Core.h"
 
 _MaCh3_Safe_Include_Start_ //{
 // ROOT Includes

--- a/manager/YamlHelper.h
+++ b/manager/YamlHelper.h
@@ -6,23 +6,19 @@
 #include <string>
 #include <cxxabi.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wconversion"
+// MaCh3 Includes
+#include "manager/MaCh3Exception.h"
+#include "samplePDF/Structs.h"
+
+_MaCh3_Safe_Include_Start_ //{
 // ROOT Includes
 #include "TMacro.h"
 #include "TList.h"
 #include "TObjString.h"
-#pragma GCC diagnostic pop
+_MaCh3_Safe_Include_End_ //}
 
 // yaml Includes
 #include "yaml-cpp/yaml.h"
-
-// MaCh3 Includes
-#include "manager/MaCh3Exception.h"
 
 /// @file YamlHelper.h
 /// @brief Utility functions for handling YAML nodes
@@ -312,6 +308,13 @@ Type GetFromManager(const YAML::Node& node, Type defval, const std::string File 
 /// @param Line number where function is called
 inline YAML::Node LoadYamlConfig(const std::string& filename, const std::string& File, const int Line) {
 // **********************
+  // KS: YAML can be dumb and not throw error if you pass toml for example...
+  if (!(filename.length() >= 5 && filename.compare(filename.length() - 5, 5, ".yaml") == 0) &&
+    !(filename.length() >= 4 && filename.compare(filename.length() - 4, 4, ".yml") == 0)) {
+    MACH3LOG_ERROR("Invalid file extension: {}", filename);
+    throw MaCh3Exception(File, Line);
+  }
+
   try {
     return YAML::LoadFile(filename);
   } catch (const std::exception& e) {

--- a/mcmc/MCMCProcessor.h
+++ b/mcmc/MCMCProcessor.h
@@ -343,6 +343,11 @@ class MCMCProcessor {
     /// @author Richard Calland
     inline void PowerSpectrumAnalysis();
 
+    /// @brief Get TCanvas margins, to be able to reset them if particular function need different margins
+    std::vector<double> GetMargins(const std::unique_ptr<TCanvas>& Canv) const;
+    /// @brief Set TCanvas margins to specified values
+    void SetMargins(std::unique_ptr<TCanvas>& Canv, const std::vector<double>& margins);
+
     /// Name of MCMC file
     std::string MCMCFile;
     /// Output file suffix useful when running over same file with different settings

--- a/plotting/MatrixPlotter.cpp
+++ b/plotting/MatrixPlotter.cpp
@@ -53,7 +53,7 @@ TH2D* GetSubMatrix(TH2D *MatrixFull, const std::string& Title, const std::vector
 void SetupInfo(const std::string& Config, std::vector<std::string>& Title, std::vector<std::vector<std::string>>& Params)
 {
   // Load the YAML file
-  YAML::Node config = YAML::LoadFile(Config);
+  YAML::Node config = M3OpenConfig(Config);
 
   // Access the "MatrixPlotter" section
   YAML::Node settings = config["MatrixPlotter"];

--- a/plotting/plottingUtils/inputManager.cpp
+++ b/plotting/plottingUtils/inputManager.cpp
@@ -5,7 +5,7 @@ namespace MaCh3Plotting {
 // this is the constructor with user specified translation config file
 InputManager::InputManager(const std::string &translationConfigName) {
   // read the config file
-  _translatorConfig = YAML::LoadFile(translationConfigName);
+  _translatorConfig = M3OpenConfig(translationConfigName);
 
   MACH3LOG_DEBUG("InputManager: have loaded translation config file");
   

--- a/plotting/plottingUtils/plottingManager.cpp
+++ b/plotting/plottingUtils/plottingManager.cpp
@@ -27,7 +27,7 @@ void PlottingManager::initialise() {
   /// config files and make sure that all provided options are valid and all necessary options are provided
   /// as it can be pretty annoying and difficult to identify what's going wrong when yaml just fails
   /// to find an option at runtime
-  _plottingConfig = YAML::LoadFile(_configFileName);
+  _plottingConfig = M3OpenConfig(_configFileName);
 
   MACH3LOG_DEBUG("Initialising PlottingManager with plotting congif {}", _configFileName);
   // read options from the config

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -1,86 +1,14 @@
 #pragma once
 
-/// Run low or high memory versions of structs
-/// N.B. for 64 bit systems sizeof(float) == sizeof(double) so not a huge effect
-/// KS: Need more testing on FD
-namespace M3 {
-#ifdef _LOW_MEMORY_STRUCTS_
-/// Custom floating point (float or double)
-using float_t = float;
-/// Custom integer (int or short int)
-using int_t = short;
-/// Custom unsigned integer (unsigned short int or unsigned int)
-using uint_t = unsigned short;
-#else
-using float_t = double;
-using int_t = int;
-using uint_t = unsigned;
-#endif
-}
-
-/// KS: noexcept can help with performance but is terrible for debugging, this is meant to help easy way of of turning it on or off. In near future move this to struct or other central class.
-//#define SafeException
-#ifndef SafeException
-#define _noexcept_ noexcept
-#else
-#define _noexcept_
-#endif
-
-/// KS: Using restrict limits the effects of pointer aliasing, aiding optimizations. While reading I found that there might be some compilers which don't have __restrict__. As always we use _restrict_ to more easily turn off restrict in the code
-#ifndef DEBUG
-#define _restrict_ __restrict__
-#else
-#define _restrict_
-#endif
-
-/// Number of overflow bins in TH2Poly,
-#define _TH2PolyOverflowBins_ 9
-
-constexpr static const double _BAD_DOUBLE_ = -999.99;
-constexpr static const int _BAD_INT_ = -999;
-
-constexpr static const double _DEFAULT_RETURN_VAL_ = -999999.123456;
-
-// Some commonly used variables to which we set pointers to
-constexpr static const double Unity = 1.;
-constexpr static const double Zero = 0.;
-constexpr static const float Unity_F = 1.;
-constexpr static const float Zero_F = 0.;
-constexpr static const int Unity_Int = 1;
-
 // C++ includes
-#include <sstream>
-#include <fstream> 
-#include <iostream>
-#include <vector>
-#include <iomanip>
 #include <set>
 #include <list>
 #include <unordered_map>
 
-#ifdef MULTITHREAD
-#include "omp.h"
-#endif
-
 // MaCh3 includes
 #include "manager/MaCh3Exception.h"
 #include "manager/MaCh3Logger.h"
-
-/// @brief KS: Avoiding warning checking for headers
-/// @details Many external files don't strictly adhere to rigorous C++ standards.
-/// Inline functions in such headers may cause errors when compiled with strict MaCh3 compiler flags.
-/// @warning Use this for any external header file to avoid warnings.
-#define _MaCh3_Safe_Include_Start_ \
-_Pragma("GCC diagnostic push") \
-_Pragma("GCC diagnostic ignored \"-Wuseless-cast\"") \
-_Pragma("GCC diagnostic ignored \"-Wfloat-conversion\"") \
-_Pragma("GCC diagnostic ignored \"-Wold-style-cast\"") \
-_Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"") \
-_Pragma("GCC diagnostic ignored \"-Wconversion\"")
-
-/// @brief KS: Restore warning checking after including external headers
-#define _MaCh3_Safe_Include_End_ \
-_Pragma("GCC diagnostic pop")
+#include "manager/Core.h"
 
 _MaCh3_Safe_Include_Start_ //{
 // ROOT include
@@ -93,7 +21,6 @@ _MaCh3_Safe_Include_Start_ //{
 // NuOscillator includes
 #include "Constants/OscillatorConstants.h"
 _MaCh3_Safe_Include_End_ //}
-
 
 /// @file Structs.h
 /// @author Asher Kaboth


### PR DESCRIPTION
# Pull request description
There was a case where yaml loaded toml file and didn't throw error
https://t2k-experiment.slack.com/archives/C017YRE5C93/p1738261416753299

Also make new header file Core.h. Current Struct.h was too wide. For example Current Struct.h relied on spdlog and MaCh3Exception, and it was tricky to not make both reliant on Struct.h

Now Core.h is the first include. It has no external package only cpp (also OMP but this is fine)

## Changes or fixes
- More yaml protection
- New Core header
- New fucntion in MCMC Processor to reduce copy pasting of margin decalration
- raw pointers -> std::vector

## Examples
