### PR TITLE
Bugfix: chain restart fix

### DIFF
--- a/mcmc/FitterBase.cpp
+++ b/mcmc/FitterBase.cpp
@@ -218,7 +218,7 @@ void FitterBase::SaveOutput() {
   outputFile->cd();
   outTree->Write();
 
-  MACH3LOG_INFO("{} steps took {:.2f} seconds to complete. ({:.2f}s / step).", step, clock->RealTime(), clock->RealTime() / step);
+  MACH3LOG_INFO("{} steps took {:.2f} seconds to complete. ({:.2f}s / step).", step - stepStart, clock->RealTime(), clock->RealTime() / static_cast<double>(step - stepStart));
   MACH3LOG_INFO("{} steps were accepted.", accCount);
   #ifdef DEBUG
   if (debug)

--- a/mcmc/FitterBase.cpp
+++ b/mcmc/FitterBase.cpp
@@ -20,6 +20,7 @@ FitterBase::FitterBase(manager * const man) : fitMan(man) {
   // Counter of the accepted # of steps
   accCount = 0;
   step = 0;
+  stepStart = 0;
 
   clock = std::make_unique<TStopwatch>();
   stepClock = std::make_unique<TStopwatch>();
@@ -307,12 +308,15 @@ void FitterBase::StartFromPreviousFit(const std::string& FitName) {
         MACH3LOG_ERROR("Yaml configs in previous chain and current one are different", FitName);
         throw MaCh3Exception(__FILE__ , __LINE__ );
       }
-    }
-    if(ConfigCov == nullptr) delete ConfigCov;
 
-    std::vector<double> branch_vals(systematics[s]->GetNumParams());
+      delete ConfigCov;
+    }
+
+    CovarianceFolder->Close();
+    delete CovarianceFolder;
+
+    std::vector<double> branch_vals(systematics[s]->GetNumParams(), _BAD_DOUBLE_);
     for (int i = 0; i < systematics[s]->GetNumParams(); ++i) {
-      branch_vals[i] = _BAD_DOUBLE_;
       posts->SetBranchAddress(systematics[s]->GetParName(i).c_str(), &branch_vals[i]);
     }
     posts->GetEntry(posts->GetEntries()-1);
@@ -331,11 +335,14 @@ void FitterBase::StartFromPreviousFit(const std::string& FitName) {
     MACH3LOG_INFO("Printing new starting values for: {}", systematics[s]->getName());
     systematics[s]->printNominalCurrProp();
 
-    CovarianceFolder->Close();
-    delete CovarianceFolder;
+    // Resetting branch adressed to nullptr as we don't want to write into a delected vector out of scope...
+    for (int i = 0; i < systematics[s]->GetNumParams(); ++i) {
+      posts->SetBranchAddress(systematics[s]->GetParName(i).c_str(), nullptr);
+    }
   }
   logLCurr = log_val;
 
+  delete posts;
   infile->Close();
   delete infile;
 

--- a/mcmc/FitterBase.h
+++ b/mcmc/FitterBase.h
@@ -93,6 +93,8 @@ class FitterBase {
   double accProb;
   /// counts accepted steps
   int accCount;
+  /// step start if restarting
+  int stepStart;
 
   /// store the llh breakdowns
   std::vector<double> sample_llh;

--- a/mcmc/mcmc.cpp
+++ b/mcmc/mcmc.cpp
@@ -223,12 +223,12 @@ void mcmc::StartFromPreviousFit(const std::string& FitName) {
   // For MCMC we also need to set stepStart
   TFile *infile = new TFile(FitName.c_str(), "READ");
   TTree *posts = infile->Get<TTree>("posteriors");
-  int step_val = 0;
+  int step_val = -1;
 
   posts->SetBranchAddress("step",&step_val);
   posts->GetEntry(posts->GetEntries()-1);
 
-  stepStart = step_val;
+  stepStart = step_val + 1;
   infile->Close();
   delete infile;
 }

--- a/mcmc/mcmc.h
+++ b/mcmc/mcmc.h
@@ -47,8 +47,5 @@ class mcmc : public FitterBase {
   bool anneal;
   /// simulated annealing temperature
   double AnnealTemp;
-
-  /// starting value of a chain, usually 0, unless starting from previous chain
-  int stepStart;
 };
 


### PR DESCRIPTION
# Pull request description
A few tweaks to have the chain restart working

## Changes or fixes
- Moved stepStart to `FitterBase` to be able to quote the right time per step
- Fixed some inverted nullptr condition
- Fixing some write to deleted memory space by resetting the branches after the previous systematics have been read.
