### PR TITLE
feat: Add lib64 to LD_LIBRARY_PATH

### DIFF
--- a/cmake/Templates/setup.MaCh3.sh.in
+++ b/cmake/Templates/setup.MaCh3.sh.in
@@ -89,6 +89,8 @@ export CUDAProb3_DIR=@CUDAProb3_SOURCE_DIR@
 
 add_to_PATH ${MaCh3_ROOT}/bin
 add_to_LD_LIBRARY_PATH ${MaCh3_ROOT}/lib
+add_to_LD_LIBRARY_PATH ${MaCh3_ROOT}/lib64
+
 
 if test -d ${MaCh3_ROOT}/pyMaCh3; then
   add_to_PYTHONPATH ${MaCh3_ROOT}


### PR DESCRIPTION
# Pull request description
Some libraries are stored in lib64 so we should add this to our environment. Whilst right now this isn't a breaking issue some future dependencies may use this so best to fix now
