### PR TITLE
tidy: Proper descturctors for spline related classes

### DIFF
--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -755,7 +755,7 @@ void covarianceBase::printNominalCurrProp() const {
 // fParEvalLikelihood stores if we want to evaluate the likelihood for the given parameter
 //                    true = evaluate likelihood (so run with a prior)
 //                    false = don't evaluate likelihood (so run without a prior)
-double covarianceBase::CalcLikelihood() _noexcept_ {
+double covarianceBase::CalcLikelihood() const _noexcept_ {
 // ********************************************
   double logL = 0.0;
   #ifdef MULTITHREAD
@@ -777,7 +777,7 @@ double covarianceBase::CalcLikelihood() _noexcept_ {
 }
 
 // ********************************************
-int covarianceBase::CheckBounds() const {
+int covarianceBase::CheckBounds() const _noexcept_ {
 // ********************************************
   int NOutside = 0;
   #ifdef MULTITHREAD

--- a/covariance/covarianceBase.h
+++ b/covariance/covarianceBase.h
@@ -7,9 +7,6 @@
 #include "covariance/AdaptiveMCMCHandler.h"
 #include "covariance/PCAHandler.h"
 
-/// Large Likelihood is used it parameter go out of physical boundary, this indicates in MCMC that such step should eb removed
-constexpr static const double _LARGE_LOGL_ = 1234567890.0;
-
 /// @brief Base class responsible for handling of systematic error parameters. Capable of using PCA or using adaptive throw matrix
 /// @see For more details, visit the [Wiki](https://github.com/mach3-software/MaCh3/wiki/02.-Implementation-of-Systematic).
 /// @author Dan Barrow
@@ -123,9 +120,9 @@ class covarianceBase {
   void RandomConfiguration();
   
   /// @brief Check if parameters were proposed outside physical boundary
-  int CheckBounds() const;
+  int CheckBounds() const _noexcept_;
   /// @brief Calc penalty term based on inverted covariance matrix
-  double CalcLikelihood() _noexcept_;
+  double CalcLikelihood() const _noexcept_;
   /// @brief Return CalcLikelihood if some params were thrown out of boundary return _LARGE_LOGL_
   virtual double GetLikelihood();
 

--- a/manager/Core.h
+++ b/manager/Core.h
@@ -33,8 +33,7 @@ namespace M3 {
 }
 
 /// KS: noexcept can help with performance but is terrible for debugging, this is meant to help easy way of of turning it on or off. In near future move this to struct or other central class.
-//#define SafeException
-#ifndef SafeException
+#ifndef DEBUG
 #define _noexcept_ noexcept
 #else
 #define _noexcept_
@@ -52,15 +51,17 @@ namespace M3 {
 
 constexpr static const double _BAD_DOUBLE_ = -999.99;
 constexpr static const int _BAD_INT_ = -999;
-
 constexpr static const double _DEFAULT_RETURN_VAL_ = -999999.123456;
 
-// Some commonly used variables to which we set pointers to
+/// Some commonly used variables to which we set pointers to
 constexpr static const double Unity = 1.;
 constexpr static const double Zero = 0.;
 constexpr static const float Unity_F = 1.;
 constexpr static const float Zero_F = 0.;
 constexpr static const int Unity_Int = 1;
+
+/// Large Likelihood is used it parameter go out of physical boundary, this indicates in MCMC that such step should be removed
+constexpr static const double _LARGE_LOGL_ = 1234567890.0;
 
 // C++ includes
 #include <sstream>

--- a/splines/SplineBase.cpp
+++ b/splines/SplineBase.cpp
@@ -7,14 +7,12 @@
 SplineBase::SplineBase() {
 // *****************************************
 
-
 }
 
 
 // *****************************************
 SplineBase::~SplineBase() {
 // *****************************************
-
 
 }
 
@@ -24,7 +22,6 @@ SplineBase::~SplineBase() {
 // This should maximize our cache hits!
 void SplineBase::getTF1Coeff(TF1_red* &spl, int &nPoints, float *& coeffs) {
 // *****************************************
-
   // Initialise all arrays to 1.0
   for (int i = 0; i < _nTF1Coeff_; ++i) {
     coeffs[i] = 0.0;

--- a/splines/SplineBase.h
+++ b/splines/SplineBase.h
@@ -37,7 +37,6 @@ class SplineBase {
     virtual inline std::string GetName()const {return "SplineBase";};
 
   protected:
-
     /// @brief CW:Code used in step by step reweighting, Find Spline Segment for each param
     virtual void FindSplineSegment() = 0;
     /// @brief CPU based code which eval weight for each spline

--- a/splines/SplineMonolith.cpp
+++ b/splines/SplineMonolith.cpp
@@ -362,23 +362,11 @@ void SMonolith::MoveToGPU() {
           NTF1_valid);
 
   // Delete all the coefficient arrays from the CPU once they are on the GPU
-  cpu_spline_handler->coeff_x.clear();
-  cpu_spline_handler->coeff_x.shrink_to_fit();
-  cpu_spline_handler->coeff_many.clear();
-  cpu_spline_handler->coeff_many.shrink_to_fit();
-  cpu_spline_handler->paramNo_arr.clear();
-  cpu_spline_handler->paramNo_arr.shrink_to_fit();
-  cpu_spline_handler->nKnots_arr.clear();
-  cpu_spline_handler->nKnots_arr.shrink_to_fit();
-  cpu_coeff_TF1_many.clear();
-  cpu_coeff_TF1_many.shrink_to_fit();
-  cpu_paramNo_TF1_arr.clear();
-  cpu_paramNo_TF1_arr.shrink_to_fit();
+  CleanVector(cpu_coeff_TF1_many);
+  CleanVector(cpu_paramNo_TF1_arr)
   #ifndef Weight_On_SplineBySpline_Basis
-  cpu_nParamPerEvent.clear();
-  cpu_nParamPerEvent.shrink_to_fit();
-  cpu_nParamPerEvent_tf1.clear();
-  cpu_nParamPerEvent_tf1.shrink_to_fit();
+  CleanVector(cpu_nParamPerEvent);
+  CleanVector(cpu_nParamPerEvent_tf1)
   #endif
   delete cpu_spline_handler;
   cpu_spline_handler = nullptr;
@@ -458,7 +446,7 @@ void SMonolith::ScanMasterSpline(std::vector<std::vector<TResponseFunction_red*>
           nSplines_SingleEvent++;
 
           // Fill the SplineInfoArray entries with information on each splinified parameter
-          if (SplineInfoArray[ParamNumber].xPts == NULL)
+          if (SplineInfoArray[ParamNumber].xPts == nullptr)
           {
             // Fill the number of points
             SplineInfoArray[ParamNumber].nPts = CurrSpline->GetNp();
@@ -501,7 +489,7 @@ void SMonolith::ScanMasterSpline(std::vector<std::vector<TResponseFunction_red*>
 
     const M3::int_t nPoints = SplineInfoArray[i].nPts;
     const M3::float_t* xArray = SplineInfoArray[i].xPts;
-    if (nPoints == -999 || xArray == NULL) {
+    if (nPoints == -999 || xArray == nullptr) {
       Counter++;
       if(Counter < 5) {
         MACH3LOG_WARN("SplineInfoArray[{}] isn't set yet", i);
@@ -515,7 +503,7 @@ void SMonolith::ScanMasterSpline(std::vector<std::vector<TResponseFunction_red*>
 
 // *****************************************
 // Load SplineFile
-SMonolith::SMonolith(std::string FileName)
+SMonolith::SMonolith(const std::string& FileName)
           : SplineBase() {
 // *****************************************
   Initialise();
@@ -810,8 +798,7 @@ void SMonolith::PrepareSplineFile() {
 // Destructor
 // Cleans up the allocated GPU memory
 SMonolith::~SMonolith() {
-  // *****************************************
-
+// *****************************************
   #ifdef CUDA
   gpu_spline_handler->CleanupGPU_SplineMonolith(
         #ifndef Weight_On_SplineBySpline_Basis
@@ -832,31 +819,6 @@ SMonolith::~SMonolith() {
   if(cpu_weights != nullptr) delete[] cpu_weights;
   if(cpu_weights_spline_var != nullptr) delete[] cpu_weights_spline_var;
   if(cpu_weights_tf1_var != nullptr) delete[] cpu_weights_tf1_var;
-
-  //KS: Those might be deleted or not depending on GPU/CPU TSpline3/TF1 DEBUG or not hence we check if not NULL
-  if(cpu_spline_handler != nullptr)
-  {
-    cpu_spline_handler->coeff_x.clear();
-    cpu_spline_handler->coeff_x.shrink_to_fit();
-    cpu_spline_handler->coeff_many.clear();
-    cpu_spline_handler->coeff_many.shrink_to_fit();
-    cpu_spline_handler->paramNo_arr.clear();
-    cpu_spline_handler->paramNo_arr.shrink_to_fit();
-    cpu_spline_handler->nKnots_arr.clear();
-    cpu_spline_handler->nKnots_arr.shrink_to_fit();
-  }
-  cpu_coeff_TF1_many.clear();
-  cpu_coeff_TF1_many.shrink_to_fit();
-  cpu_paramNo_TF1_arr.clear();
-  cpu_paramNo_TF1_arr.shrink_to_fit();
-  #ifndef Weight_On_SplineBySpline_Basis
-  cpu_nParamPerEvent.clear();
-  cpu_nParamPerEvent.shrink_to_fit();
-  cpu_nParamPerEvent_tf1.clear();
-  cpu_nParamPerEvent_tf1.shrink_to_fit();
-  #endif
-  cpu_nPoints_arr.clear();
-  cpu_nPoints_arr.shrink_to_fit();
 
   if(cpu_spline_handler != nullptr) delete cpu_spline_handler;
 }
@@ -910,7 +872,6 @@ void SMonolith::getSplineCoeff_SepMany(TSpline3_red* &spl, int &nPoints, float *
   }
 }
 
-
 #ifdef CUDA
 // *****************************************
 // Tell the GPU to evaluate the weights
@@ -920,7 +881,6 @@ void SMonolith::getSplineCoeff_SepMany(TSpline3_red* &spl, int &nPoints, float *
 // This avoids doing lots of binary searches on the GPU
 void SMonolith::Evaluate() {
 // *****************************************
-
   // There's a parameter mapping that goes from spline parameter to a global parameter index
   // Find the spline segments
   FindSplineSegment();
@@ -946,7 +906,6 @@ void SMonolith::Evaluate() {
 // *****************************************
 void SMonolith::Evaluate() {
 // *****************************************
-
   // There's a parameter mapping that goes from spline parameter to a global parameter index
   // Find the spline segments
   FindSplineSegment();
@@ -979,7 +938,7 @@ void SMonolith::FindSplineSegment() {
     // EM: if we have a parameter that has no response for any event (i.e. all splines have just one knot), then skip it and avoid a seg fault here
     //     In principle, such parameters shouldn't really be included in the first place, but with new det syst splines this
     //     could happen if say you were just running on one FHC run, then all RHC parameters would be flat and the code below would break.
-    if(xArray == NULL) continue;
+    if(xArray == nullptr) continue;
 
     // The segment we're interested in (klow in ROOT code)
     M3::int_t segment = 0;

--- a/splines/SplineMonolith.cpp
+++ b/splines/SplineMonolith.cpp
@@ -363,10 +363,10 @@ void SMonolith::MoveToGPU() {
 
   // Delete all the coefficient arrays from the CPU once they are on the GPU
   CleanVector(cpu_coeff_TF1_many);
-  CleanVector(cpu_paramNo_TF1_arr)
+  CleanVector(cpu_paramNo_TF1_arr);
   #ifndef Weight_On_SplineBySpline_Basis
   CleanVector(cpu_nParamPerEvent);
-  CleanVector(cpu_nParamPerEvent_tf1)
+  CleanVector(cpu_nParamPerEvent_tf1);
   #endif
   delete cpu_spline_handler;
   cpu_spline_handler = nullptr;

--- a/splines/SplineMonolith.h
+++ b/splines/SplineMonolith.h
@@ -20,7 +20,7 @@ class SMonolith : public SplineBase {
               const bool SaveFlatTree = false);
     /// @brief Constructor where you pass path to preprocessed root FileName
     /// @param FileName path to pre-processed root file containing stripped monolith info
-    SMonolith(std::string FileName);
+    SMonolith(const std::string& FileName);
     /// @brief Destructor for SMonolith class.
     virtual ~SMonolith();
 
@@ -28,7 +28,7 @@ class SMonolith : public SplineBase {
     void Evaluate() override;
 
     /// @brief Get class name
-    inline std::string GetName()const {return "SplineMonolith";};
+    inline std::string GetName() const {return "SplineMonolith";};
 
     /// @brief Get number of spline parameters
     short int GetNParams()const {return nParams;};
@@ -51,7 +51,7 @@ class SMonolith : public SplineBase {
     /// The returned gpu weights, read by the GPU
     float* cpu_weights;
     /// KS: This holds the total CPU weights that gets read in samplePDFND
-    float *cpu_total_weights;
+    float* cpu_total_weights;
 
   private:
     /// @brief KS: Set everything to null etc.

--- a/splines/SplineStructs.h
+++ b/splines/SplineStructs.h
@@ -23,15 +23,15 @@ struct FastSplineInfo {
   /// @brief Constructor
   FastSplineInfo() {
     nPts = -999;
-    xPts = NULL;
+    xPts = nullptr;
     CurrSegment = 0;
-    splineParsPointer = NULL;
+    splineParsPointer = nullptr;
   }
 
   /// @brief Destructor
-  ~FastSplineInfo() {
+  virtual ~FastSplineInfo() {
     // Free dynamically allocated memory
-    if(xPts != NULL) delete[] xPts;
+    if(xPts != nullptr) delete[] xPts;
   }
 
   /// Number of points in spline
@@ -79,7 +79,6 @@ inline void ApplyKnotWeightCap(TGraph* xsecgraph, int splineParsIndex, covarianc
 
     // EM: check if our cap made the spline flat, if so we set to 1 knot to avoid problems later on
     bool isFlat = true;
-
     for(int knotId = 0; knotId < xsecgraph->GetN(); knotId++){
       double x,y;
 
@@ -88,7 +87,6 @@ inline void ApplyKnotWeightCap(TGraph* xsecgraph, int splineParsIndex, covarianc
         MACH3LOG_ERROR("Invalid knot requested: {}", knotId);
         throw MaCh3Exception(__FILE__ , __LINE__ );
       }
-
       if(std::abs(y - 1.0) > 1e-5) isFlat = false;
     }
 
@@ -128,7 +126,7 @@ public:
   }
 
   /// @brief Empty destructor
-  ~TF1_red() {
+  virtual ~TF1_red() {
     if (Par != NULL) {
       delete[] Par;
       Par = NULL;
@@ -548,7 +546,7 @@ public:
   }
 
   /// @brief Empty destructor
-  ~TSpline3_red() {
+  virtual ~TSpline3_red() {
     if(Par != NULL) {
       for (int i = 0; i < nPoints; ++i) {
         if (Par[i] != NULL) {

--- a/splines/splineFDBase.cpp
+++ b/splines/splineFDBase.cpp
@@ -38,8 +38,6 @@ void splineFDBase::cleanUpMemory() {
   CleanVector(UniqueSystNames);
   CleanVector(SplineInterpolationTypes);
 
-
-
   for (auto& Binning2D : SplineBinning) {
     for (auto& Binning1D : Binning2D) {
       for (TAxis* axis : Binning1D) {


### PR DESCRIPTION
# Pull request description
Genrally  destructors should be virtual

## Changes or fixes
- Virtual destructors
- Now NoExpect should work correctly
- stop with manual delting std::vectors

## Examples
