### PR TITLE
breaking: Better workflow for GPU in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 project(MaCh3 VERSION 1.4.0 LANGUAGES CXX)
 set(MaCh3_VERSION ${PROJECT_VERSION})
 
-#LP - This option name is confusing, but I wont change it now.
-option(USE_CPU "Whether to *only* use the CPU (i.e. no GPU)" OFF)
 option(MaCh3_PYTHON_ENABLED "Whether to build MaCh3 python bindings" OFF)
 option(MaCh3_WERROR_ENABLED "Whether to build MaCh3 with heightened compiler pedancy" ON)
 option(MaCh3_LOW_MEMORY_STRUCTS_ENABLED "This will use float/short string for many structures" OFF)
@@ -16,6 +14,11 @@ option(MaCh3_DEBUG_ENABLED "Enable special debugging mode, with additional print
 option(MaCh3_DependancyGraph "Will produce dependency graph" OFF)
 option(MaCh3_GPU_BENCHMARK "Perform fancy CUDA Benchmarking" OFF)
 option(MaCh3_NATIVE_ENABLED "Enable native CPU optimizations for improved performance during benchmarking)" OFF)
+option(MaCh3_GPU_ENABLED "Use GPU acceleration or not" ON)
+
+#KS: Load cmake function like DefineEnabledRequiredSwitch allowing to write more compact cmake
+LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/Modules)
+include(MaCh3Utils)
 
 add_library(MaCh3CompileDefinitions INTERFACE)
 #Create a seperate target for GPU compiler options
@@ -25,14 +28,14 @@ add_library(MaCh3GPUCompilerOptions INTERFACE)
 
 find_package(CUDAToolkit QUIET)
 # Check if CUDA was found
-if(CUDAToolkit_FOUND AND NOT(USE_CPU))
-  message(STATUS "CUDA found. Adding CUDA support.")
-  set(MaCh3_GPU_ENABLED TRUE)
+if(CUDAToolkit_FOUND AND NOT(MaCh3_GPU_ENABLED))
+  cmessage(STATUS "CUDA found. Adding CUDA support.")
+  set(MaCh3_GPU_ENABLED ON)
   enable_language(CUDA)
   set(CPU_ONLY FALSE)
 else()
-  message(STATUS "CUDA not found. Proceeding without CUDA support.")
-  set(MaCh3_GPU_ENABLED FALSE)
+  cmessage(STATUS "CUDA not found. Proceeding without CUDA support.")
+  set(MaCh3_GPU_ENABLED OFF)
   set(CPU_ONLY TRUE)
 endif()
 
@@ -48,10 +51,6 @@ endif()
 # Use the compilers found in the path
 find_program(CMAKE_C_COMPILER NAMES $ENV{CC} gcc PATHS ENV PATH NO_DEFAULT_PATH)
 find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++ PATHS ENV PATH NO_DEFAULT_PATH)
-
-LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/Modules)
-#KS: Load cmake function like DefineEnabledRequiredSwitch allowing to write more compact cmake
-include(MaCh3Utils)
 
 ################################## Dependencies ################################
 include(MaCh3Dependencies)
@@ -169,10 +168,6 @@ if(MaCh3_MULTITHREAD_ENABLED)
   target_compile_options(MaCh3CompilerOptions INTERFACE -fopenmp)
   target_link_libraries(MaCh3CompilerOptions INTERFACE gomp)
   target_compile_definitions(MaCh3CompileDefinitions INTERFACE MULTITHREAD)
-endif()
-
-if(CPU_ONLY)
-  target_compile_definitions(MaCh3CompileDefinitions INTERFACE CPU_ONLY)
 endif()
 
 if(MaCh3_GPU_ENABLED) 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ cmake ../ -DMaCh3_MULTITHREAD_ENABLED=OFF
 If the system has access to GPU, MaCh3 will enable GPU functionality automatically. If you would like to CPU only despite having access to [CUDA](https://developer.nvidia.com/cuda-toolkit)
 ```bash
 mkdir build; cd build;
-cmake ../ -DUSE_CPU=ON
+cmake ../ -DMaCh3_GPU_ENABLED=OFF
 ```
 MaCh3 supports quite a high range of CUDA architectures if something doesn't work on your GPU let us know. MaCh3 supports only NVIDIA GPUs.
 

--- a/covariance/CMakeLists.txt
+++ b/covariance/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(Covariance PROPERTIES
     EXPORT_NAME Covariance)
 
 
-if(NOT CPU_ONLY)
+if(MaCh3_GPU_ENABLED)
     set_target_properties(Covariance PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
     #KS: In cmake 3.18 this is no longer needed https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html#cmake-cuda-architectures
     set_property(TARGET Covariance PROPERTY CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})

--- a/manager/CMakeLists.txt
+++ b/manager/CMakeLists.txt
@@ -13,14 +13,14 @@ add_library(Manager SHARED
     manager.cpp
     MaCh3Modes.cpp
     Monitor.cpp
-    $<$<NOT:$<BOOL:${CPU_ONLY}>>:gpuUtils.cu>
+    $<$<BOOL:${MaCh3_GPU_ENABLED}>:gpuUtils.cu>
 )
 
 set_target_properties(Manager PROPERTIES
     PUBLIC_HEADER "${HEADERS}"
     EXPORT_NAME Manager)
 
-if(NOT CPU_ONLY)
+if(MaCh3_GPU_ENABLED)
     set_target_properties(Manager PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
     #KS: In cmake 3.18 this is no longer needed https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html#cmake-cuda-architectures
     set_property(TARGET Manager PROPERTY CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES}) 

--- a/mcmc/CMakeLists.txt
+++ b/mcmc/CMakeLists.txt
@@ -23,10 +23,10 @@ add_library(MCMC SHARED
     SampleSummary.cpp
     MaCh3Factory.cpp
     StatisticalUtils.cpp
-    $<$<NOT:$<BOOL:${CPU_ONLY}>>:gpuMCMCProcessorUtils.cu>
+    $<$<BOOL:${MaCh3_GPU_ENABLED}>:gpuMCMCProcessorUtils.cu>
 )
 
-if(NOT CPU_ONLY)
+if(MaCh3_GPU_ENABLED)
     set_target_properties(MCMC PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
     #KS: In cmake 3.18 this is no longer needed https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html#cmake-cuda-architectures
     set_property(TARGET MCMC PROPERTY CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})

--- a/samplePDF/CMakeLists.txt
+++ b/samplePDF/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(SamplePDF PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 
-if(NOT CPU_ONLY)
+if(MaCh3_GPU_ENABLED)
     set_target_properties(SamplePDF PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
     set_property(TARGET SamplePDF PROPERTY CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})
 endif()

--- a/splines/CMakeLists.txt
+++ b/splines/CMakeLists.txt
@@ -16,10 +16,10 @@ add_library(Splines SHARED
     SplineBase.cpp
     splineFDBase.cpp
     SplineMonolith.cpp
-    $<$<NOT:$<BOOL:${CPU_ONLY}>>:gpuSplineUtils.cu>
+    $<$<BOOL:${MaCh3_GPU_ENABLED}>:gpuSplineUtils.cu>
 )
 
-if(NOT CPU_ONLY)
+if(MaCh3_GPU_ENABLED)
     set_target_properties(Splines PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
     #KS: In cmake 3.18 this is no longer needed https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html#cmake-cuda-architectures
     set_property(TARGET Splines PROPERTY CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})


### PR DESCRIPTION
# Pull request description
Flags like USE_CPU or CPU_ONLY was confusing. This is remnant of initial MaCh3 cmake build.

Now if you don't want GPU you turn off gpu or don't have cuda.

All GPU stuff in cmake are controlled by this MaCh3_GPU_ENABLED flag. We no longer need like 2 or three variables to cotnrol GPU...

Marked as breaking as T2K and DUNE still uses old ways of turning off GPU.

## Changes or fixes


## Examples
