### PR TITLE
bugfix: delete -> delete [] for isflatarray

### DIFF
--- a/splines/splineFDBase.cpp
+++ b/splines/splineFDBase.cpp
@@ -58,7 +58,7 @@ void splineFDBase::cleanUpMemory() {
   }
   splinevec_Monolith.clear();
   splinevec_Monolith.shrink_to_fit();
-  if(isflatarray != nullptr) delete isflatarray;
+  if(isflatarray) delete [] isflatarray;
 }
 
 //****************************************


### PR DESCRIPTION
# Pull request description
isflatarray is an array, use `delete []` rather than `delete`

## Changes or fixes


## Examples
