### PR TITLE
feat: Add cmake option to be able to pass which NuOsc branch to build against

### DIFF
--- a/cmake/Modules/NuOscillatorSetup.cmake
+++ b/cmake/Modules/NuOscillatorSetup.cmake
@@ -63,12 +63,16 @@ set(CMAKE_CUDA_ARCHITECTURES_STRING ${CMAKE_CUDA_ARCHITECTURES})
 #string(REPLACE " " ";" CMAKE_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
 string(REPLACE " " ";" CMAKE_CUDA_ARCHITECTURES_STRING "${CMAKE_CUDA_ARCHITECTURES}")
 
+if(NOT DEFINED MaCh3_NuOscillatorBranch)
+  set(MaCh3_NuOscillatorBranch "v1.2.0")
+endif()
+
 #Try adding Oscillator Class
 CPMAddPackage(
   NAME NuOscillator
     VERSION 1.2.0
     GITHUB_REPOSITORY "dbarrow257/NuOscillator"
-    GIT_TAG "v1.2.0"
+    GIT_TAG ${MaCh3_NuOscillatorBranch}
     GIT_SHALLOW YES
     OPTIONS
     "UseGPU ${DAN_USE_GPU}"


### PR DESCRIPTION
# Pull request description
Allow option to use alternative NuOscillator branches:

```
[barrowd@pplxint12 build]$ cmake .. -DMaCh3_NuOscillatorBranch="feature_NuSQUIDS" -DCUDAProb3_ENABLED=ON
...
-- CPM: Adding package NuOscillator@1.2.0 (feature_NuSQUIDS)
-- [INFO]: NuOscillator Features: 
-- [INFO]:      CUDAProb3: 1
-- [INFO]:      CUDAProb3Linear: 0
-- [INFO]:      Prob3ppLinear: 0
-- [INFO]:      ProbGPULinear: 0
-- [INFO]:      NuFASTLinear:  0
-- [INFO]:      NuSQUIDSLinear: 0
-- [INFO]:      OscProb: 0
-- [INFO]: Required variables being used:
-- [INFO]: 	Not using GPU
-- [INFO]: 	Using Multithreading with nThreads=128
```

```
[barrowd@pplxint12 build]$ cmake .. -DCUDAProb3_ENABLED=ON
...
-- CPM: Adding package NuOscillator@1.2.0 (v1.2.0)
-- [INFO]: NuOscillator Features: 
-- [INFO]:      CUDAProb3: 1
-- [INFO]:      CUDAProb3Linear: 0
-- [INFO]:      Prob3ppLinear: 0
-- [INFO]:      ProbGPULinear: 0
-- [INFO]:      NuFASTLinear:  0
-- [INFO]:      OscProb: 0
-- [INFO]: Required variables being used:
-- [INFO]: 	Not using GPU
-- [INFO]: 	Using Multithreading with nThreads=128
```

## Changes or fixes


## Examples
