### PR TITLE
bugfix: LLHScanSkipVector yaml node group inside sigma variation function

### DIFF
--- a/mcmc/FitterBase.cpp
+++ b/mcmc/FitterBase.cpp
@@ -1061,9 +1061,9 @@ void FitterBase::RunSigmaVar() {
   bool PlotLLHperBin = false;
 
   std::vector<std::string> SkipVector;
-  if(fitMan->raw()["General"]["LLHScanSkipVector"])
+  if(fitMan->raw()["LLHScan"]["LLHScanSkipVector"])
   {
-    SkipVector = fitMan->raw()["General"]["LLHScanSkipVector"].as<std::vector<std::string>>();
+    SkipVector = fitMan->raw()["LLHScan"]["LLHScanSkipVector"].as<std::vector<std::string>>();
     MACH3LOG_INFO("Found skip vector with {} entries", SkipVector.size());
   }
 


### PR DESCRIPTION
# Pull request description
This is just a small update to https://github.com/mach3-software/MaCh3/pull/346 where the LLHScanSkipVector was being searched under General node in the Sigma Variation function.

## Changes or fixes


## Examples
