### PR TITLE
breaking: det id fix

### DIFF
--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -1210,14 +1210,14 @@ void covarianceBase::SaveUpdatedMatrixConfig() {
 }
 
 // ********************************************
-bool covarianceBase::AppliesToDetID(const int SystIndex, const std::string& DetID) const {
+bool covarianceBase::AppliesToSampleName(const int SystIndex, const std::string& SampleName) const {
 // ********************************************
   // Empty means apply to all
   if (_fDetID[SystIndex].size() == 0) return true;
 
   // Make a copy and to lower case to not be case sensitive
-  std::string DetIDCopy = DetID;
-  std::transform(DetIDCopy.begin(), DetIDCopy.end(), DetIDCopy.begin(), ::tolower);
+  std::string SampleNameCopy = SampleName;
+  std::transform(SampleNameCopy.begin(), SampleNameCopy.end(), SampleNameCopy.begin(), ::tolower);
   bool Applies = false;
 
   for (size_t i = 0; i < _fDetID[SystIndex].size(); i++) {
@@ -1229,7 +1229,7 @@ bool covarianceBase::AppliesToDetID(const int SystIndex, const std::string& DetI
     std::string regexPattern = "^" + std::regex_replace(pattern, std::regex("\\*"), ".*") + "$";
     try {
       std::regex regex(regexPattern);
-      if (std::regex_match(DetIDCopy, regex)) {
+      if (std::regex_match(SampleNameCopy, regex)) {
         Applies = true;
         break;
       }

--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -195,7 +195,7 @@ void covarianceBase::init(const std::vector<std::string>& YAMLFile) {
     _fGenerated[i] = Get<double>(param["Systematic"]["ParameterValues"]["Generated"], __FILE__ , __LINE__);
     _fIndivStepScale[i] = Get<double>(param["Systematic"]["StepScale"]["MCMC"], __FILE__ , __LINE__);
     _fError[i] = Get<double>(param["Systematic"]["Error"], __FILE__ , __LINE__);
-    _fSampleID[i] = GetFromManager<std::vector<std::string>>(param["Systematic"]["SampleID"], {}, __FILE__, __LINE__);
+    _fSampleNames[i] = GetFromManager<std::vector<std::string>>(param["Systematic"]["SampleID"], {}, __FILE__, __LINE__);
     if(_fError[i] <= 0) {
       MACH3LOG_ERROR("Error for param {}({}) is negative and equal to {}", _fFancyNames[i], i, _fError[i]);
       throw MaCh3Exception(__FILE__ , __LINE__ );
@@ -323,7 +323,7 @@ void covarianceBase::ReserveMemory(const int SizeVec) {
   _fUpBound = std::vector<double>(SizeVec);
   _fFlatPrior = std::vector<bool>(SizeVec);
   _fIndivStepScale = std::vector<double>(SizeVec);
-  _fSampleID = std::vector<std::vector<std::string>>(_fNumPar);
+  _fSampleNames = std::vector<std::vector<std::string>>(_fNumPar);
 
   corr_throw = new double[SizeVec]();
   // set random parameter vector (for correlated steps)
@@ -1210,19 +1210,19 @@ void covarianceBase::SaveUpdatedMatrixConfig() {
 }
 
 // ********************************************
-bool covarianceBase::AppliesToSampleID(const int SystIndex, const std::string& SampleName) const {
+bool covarianceBase::AppliesToSample(const int SystIndex, const std::string& SampleName) const {
 // ********************************************
   // Empty means apply to all
-  if (_fSampleID[SystIndex].size() == 0) return true;
+  if (_fSampleNames[SystIndex].size() == 0) return true;
 
   // Make a copy and to lower case to not be case sensitive
   std::string SampleNameCopy = SampleName;
   std::transform(SampleNameCopy.begin(), SampleNameCopy.end(), SampleNameCopy.begin(), ::tolower);
   bool Applies = false;
 
-  for (size_t i = 0; i < _fSampleID[SystIndex].size(); i++) {
+  for (size_t i = 0; i < _fSampleNames[SystIndex].size(); i++) {
     // Convert to low case to not be case sensitive
-    std::string pattern = _fSampleID[SystIndex][i];
+    std::string pattern = _fSampleNames[SystIndex][i];
     std::transform(pattern.begin(), pattern.end(), pattern.begin(), ::tolower);
 
     // Replace '*' in the pattern with '.*' for regex matching

--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -1210,7 +1210,7 @@ void covarianceBase::SaveUpdatedMatrixConfig() {
 }
 
 // ********************************************
-bool covarianceBase::AppliesToSampleName(const int SystIndex, const std::string& SampleName) const {
+bool covarianceBase::AppliesToSampleID(const int SystIndex, const std::string& SampleName) const {
 // ********************************************
   // Empty means apply to all
   if (_fSampleID[SystIndex].size() == 0) return true;

--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -195,7 +195,7 @@ void covarianceBase::init(const std::vector<std::string>& YAMLFile) {
     _fGenerated[i] = Get<double>(param["Systematic"]["ParameterValues"]["Generated"], __FILE__ , __LINE__);
     _fIndivStepScale[i] = Get<double>(param["Systematic"]["StepScale"]["MCMC"], __FILE__ , __LINE__);
     _fError[i] = Get<double>(param["Systematic"]["Error"], __FILE__ , __LINE__);
-    _fSampleNames[i] = GetFromManager<std::vector<std::string>>(param["Systematic"]["SampleID"], {}, __FILE__, __LINE__);
+    _fSampleNames[i] = GetFromManager<std::vector<std::string>>(param["Systematic"]["SampleNames"], {}, __FILE__, __LINE__);
     if(_fError[i] <= 0) {
       MACH3LOG_ERROR("Error for param {}({}) is negative and equal to {}", _fFancyNames[i], i, _fError[i]);
       throw MaCh3Exception(__FILE__ , __LINE__ );

--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -195,7 +195,7 @@ void covarianceBase::init(const std::vector<std::string>& YAMLFile) {
     _fGenerated[i] = Get<double>(param["Systematic"]["ParameterValues"]["Generated"], __FILE__ , __LINE__);
     _fIndivStepScale[i] = Get<double>(param["Systematic"]["StepScale"]["MCMC"], __FILE__ , __LINE__);
     _fError[i] = Get<double>(param["Systematic"]["Error"], __FILE__ , __LINE__);
-    _fDetID[i] = GetFromManager<std::vector<std::string>>(param["Systematic"]["DetID"], {}, __FILE__, __LINE__);
+    _fSampleID[i] = GetFromManager<std::vector<std::string>>(param["Systematic"]["SampleID"], {}, __FILE__, __LINE__);
     if(_fError[i] <= 0) {
       MACH3LOG_ERROR("Error for param {}({}) is negative and equal to {}", _fFancyNames[i], i, _fError[i]);
       throw MaCh3Exception(__FILE__ , __LINE__ );
@@ -323,7 +323,7 @@ void covarianceBase::ReserveMemory(const int SizeVec) {
   _fUpBound = std::vector<double>(SizeVec);
   _fFlatPrior = std::vector<bool>(SizeVec);
   _fIndivStepScale = std::vector<double>(SizeVec);
-  _fDetID = std::vector<std::vector<std::string>>(_fNumPar);
+  _fSampleID = std::vector<std::vector<std::string>>(_fNumPar);
 
   corr_throw = new double[SizeVec]();
   // set random parameter vector (for correlated steps)
@@ -1213,16 +1213,16 @@ void covarianceBase::SaveUpdatedMatrixConfig() {
 bool covarianceBase::AppliesToSampleName(const int SystIndex, const std::string& SampleName) const {
 // ********************************************
   // Empty means apply to all
-  if (_fDetID[SystIndex].size() == 0) return true;
+  if (_fSampleID[SystIndex].size() == 0) return true;
 
   // Make a copy and to lower case to not be case sensitive
   std::string SampleNameCopy = SampleName;
   std::transform(SampleNameCopy.begin(), SampleNameCopy.end(), SampleNameCopy.begin(), ::tolower);
   bool Applies = false;
 
-  for (size_t i = 0; i < _fDetID[SystIndex].size(); i++) {
+  for (size_t i = 0; i < _fSampleID[SystIndex].size(); i++) {
     // Convert to low case to not be case sensitive
-    std::string pattern = _fDetID[SystIndex][i];
+    std::string pattern = _fSampleID[SystIndex][i];
     std::transform(pattern.begin(), pattern.end(), pattern.begin(), ::tolower);
 
     // Replace '*' in the pattern with '.*' for regex matching

--- a/covariance/covarianceBase.h
+++ b/covariance/covarianceBase.h
@@ -417,10 +417,10 @@ protected:
   /// @cite haario2001adaptive
   void updateAdaptiveCovariance();
 
-  /// @brief Check if parameter is affecting given det ID
+  /// @brief Check if parameter is affecting given sample name
   /// @param SystIndex number of parameter
   /// @param DetID The Detector ID used to filter parameters.
-  bool AppliesToDetID(const int SystIndex, const std::string& DetID) const;
+  bool AppliesToSampleName(const int SystIndex, const std::string& SampleName) const;
 
   /// The input root file we read in
   const std::string inputFile;

--- a/covariance/covarianceBase.h
+++ b/covariance/covarianceBase.h
@@ -420,7 +420,7 @@ protected:
   /// @brief Check if parameter is affecting given sample name
   /// @param SystIndex number of parameter
   /// @param SampleName The Sample name used to filter parameters.
-  bool AppliesToSampleID(const int SystIndex, const std::string& SampleName) const;
+  bool AppliesToSample(const int SystIndex, const std::string& SampleName) const;
 
   /// The input root file we read in
   const std::string inputFile;
@@ -474,7 +474,7 @@ protected:
   /// Whether to apply flat prior or not
   std::vector<bool> _fFlatPrior;
   /// Tells to which samples object param should be applied
-  std::vector<std::vector<std::string>> _fSampleID;
+  std::vector<std::vector<std::string>> _fSampleNames;
 
   /// perform PCA or not
   bool pca;

--- a/covariance/covarianceBase.h
+++ b/covariance/covarianceBase.h
@@ -419,8 +419,8 @@ protected:
 
   /// @brief Check if parameter is affecting given sample name
   /// @param SystIndex number of parameter
-  /// @param DetID The Detector ID used to filter parameters.
-  bool AppliesToSampleName(const int SystIndex, const std::string& SampleName) const;
+  /// @param SampleName The Sample name used to filter parameters.
+  bool AppliesToSampleID(const int SystIndex, const std::string& SampleName) const;
 
   /// The input root file we read in
   const std::string inputFile;
@@ -474,7 +474,7 @@ protected:
   /// Whether to apply flat prior or not
   std::vector<bool> _fFlatPrior;
   /// Tells to which samples object param should be applied
-  std::vector<std::vector<std::string>> _fDetID;
+  std::vector<std::vector<std::string>> _fSampleID;
 
   /// perform PCA or not
   bool pca;

--- a/covariance/covarianceOsc.cpp
+++ b/covariance/covarianceOsc.cpp
@@ -102,11 +102,11 @@ void covarianceOsc::Print() {
 
 // ********************************************
 // DB Grab the Normalisation parameters for the relevant DetID
-std::vector<const double*> covarianceOsc::GetOscParsFromDetID(const std::string& DetID) {
+std::vector<const double*> covarianceOsc::GetOscParsFromSampleName(const std::string& SampleName) {
 // ********************************************
   std::vector<const double*> returnVec;
   for (int i = 0; i < _fNumPar; ++i) {
-    if (AppliesToDetID(i, DetID)) {
+    if (AppliesToSampleName(i, SampleName)) {
       returnVec.push_back(retPointer(i));
     }
   }

--- a/covariance/covarianceOsc.cpp
+++ b/covariance/covarianceOsc.cpp
@@ -83,30 +83,30 @@ void covarianceOsc::Print() {
 
   MACH3LOG_INFO("=================================================================================================================================");
   MACH3LOG_INFO("{:<5} {:2} {:<25} {:2} {:<10} {:2} {:<15} {:2} {:<15} {:2} {:<10} {:2} {:<10}",
-                "#", "|", "Name", "|", "Prior", "|", "IndivStepScale", "|", "Error", "|", "FlatPrior", "|", "SampleID");
+                "#", "|", "Name", "|", "Prior", "|", "IndivStepScale", "|", "Error", "|", "FlatPrior", "|", "SampleNames");
   MACH3LOG_INFO("---------------------------------------------------------------------------------------------------------------------------------");
   for (int i = 0; i < _fNumPar; i++) {
-    std::string SampleIdString = "";
-    for (const auto& SampleID : _fSampleID[i]) {
-      if (!SampleIdString.empty()) {
-        SampleIdString += ", ";
+    std::string SampleNameString = "";
+    for (const auto& SampleName : _fSampleNames[i]) {
+      if (!SampleNameString.empty()) {
+        SampleNameString += ", ";
       }
-      SampleIdString += SampleID;
+      SampleNameString += SampleName;
     }
 
     MACH3LOG_INFO("{:<5} {:2} {:<25} {:2} {:<10.4f} {:2} {:<15.2f} {:2} {:<15.4f} {:2} {:<10} {:2} {:<10}",
-                  i, "|", _fNames[i].c_str(), "|", _fPreFitValue[i], "|", _fIndivStepScale[i], "|", _fError[i], "|", _fFlatPrior[i], "|", SampleIdString);
+                  i, "|", _fNames[i].c_str(), "|", _fPreFitValue[i], "|", _fIndivStepScale[i], "|", _fError[i], "|", _fFlatPrior[i], "|", SampleNameString);
   }
   MACH3LOG_INFO("=================================================================================================================================");
 }
 
 // ********************************************
-// DB Grab the Normalisation parameters for the relevant DetID
+// DB Grab the Normalisation parameters for the relevant sample name
 std::vector<const double*> covarianceOsc::GetOscParsFromSampleName(const std::string& SampleName) {
 // ********************************************
   std::vector<const double*> returnVec;
   for (int i = 0; i < _fNumPar; ++i) {
-    if (AppliesToSampleID(i, SampleName)) {
+    if (AppliesToSample(i, SampleName)) {
       returnVec.push_back(retPointer(i));
     }
   }

--- a/covariance/covarianceOsc.cpp
+++ b/covariance/covarianceOsc.cpp
@@ -106,7 +106,7 @@ std::vector<const double*> covarianceOsc::GetOscParsFromSampleName(const std::st
 // ********************************************
   std::vector<const double*> returnVec;
   for (int i = 0; i < _fNumPar; ++i) {
-    if (AppliesToSampleName(i, SampleName)) {
+    if (AppliesToSampleID(i, SampleName)) {
       returnVec.push_back(retPointer(i));
     }
   }

--- a/covariance/covarianceOsc.cpp
+++ b/covariance/covarianceOsc.cpp
@@ -83,19 +83,19 @@ void covarianceOsc::Print() {
 
   MACH3LOG_INFO("=================================================================================================================================");
   MACH3LOG_INFO("{:<5} {:2} {:<25} {:2} {:<10} {:2} {:<15} {:2} {:<15} {:2} {:<10} {:2} {:<10}",
-                "#", "|", "Name", "|", "Prior", "|", "IndivStepScale", "|", "Error", "|", "FlatPrior", "|", "DetID");
+                "#", "|", "Name", "|", "Prior", "|", "IndivStepScale", "|", "Error", "|", "FlatPrior", "|", "SampleID");
   MACH3LOG_INFO("---------------------------------------------------------------------------------------------------------------------------------");
   for (int i = 0; i < _fNumPar; i++) {
-    std::string detIdString = "";
-    for (const auto& detID : _fDetID[i]) {
-      if (!detIdString.empty()) {
-        detIdString += ", ";
+    std::string SampleIdString = "";
+    for (const auto& SampleID : _fSampleID[i]) {
+      if (!SampleIdString.empty()) {
+        SampleIdString += ", ";
       }
-      detIdString += detID;
+      SampleIdString += SampleID;
     }
 
     MACH3LOG_INFO("{:<5} {:2} {:<25} {:2} {:<10.4f} {:2} {:<15.2f} {:2} {:<15.4f} {:2} {:<10} {:2} {:<10}",
-                  i, "|", _fNames[i].c_str(), "|", _fPreFitValue[i], "|", _fIndivStepScale[i], "|", _fError[i], "|", _fFlatPrior[i], "|", detIdString);
+                  i, "|", _fNames[i].c_str(), "|", _fPreFitValue[i], "|", _fIndivStepScale[i], "|", _fError[i], "|", _fFlatPrior[i], "|", SampleIdString);
   }
   MACH3LOG_INFO("=================================================================================================================================");
 }

--- a/covariance/covarianceOsc.h
+++ b/covariance/covarianceOsc.h
@@ -18,7 +18,7 @@ class covarianceOsc : public covarianceBase
   /// @brief Sets whether to flip delta M23.
   void setFlipDeltaM23(bool flip){flipdelM = flip;}
   /// @brief Get pointers to Osc params from detId
-  std::vector<const double*> GetOscParsFromDetID(const std::string& DetID);
+  std::vector<const double*> GetOscParsFromSampleName(const std::string& SampleName);
   /// @brief KS: Print all useful information's after initialization
   void Print();
 

--- a/covariance/covarianceOsc.h
+++ b/covariance/covarianceOsc.h
@@ -17,7 +17,7 @@ class covarianceOsc : public covarianceBase
   void proposeStep() override;
   /// @brief Sets whether to flip delta M23.
   void setFlipDeltaM23(bool flip){flipdelM = flip;}
-  /// @brief Get pointers to Osc params from detId
+  /// @brief Get pointers to Osc params from Sample name
   std::vector<const double*> GetOscParsFromSampleName(const std::string& SampleName);
   /// @brief KS: Print all useful information's after initialization
   void Print();

--- a/covariance/covarianceXsec.cpp
+++ b/covariance/covarianceXsec.cpp
@@ -109,7 +109,7 @@ const std::vector<std::string> covarianceXsec::GetSplineParsNamesFromSampleName(
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kSpline]) {
     auto &SplineIndex = pair.first;
     auto &SystIndex = pair.second;
-    if (AppliesToSampleName(SystIndex, SampleName)) { //If parameter applies to required Sample
+    if (AppliesToSampleID(SystIndex, SampleName)) { //If parameter applies to required Sample
       returnVec.push_back(_fSplineNames.at(SplineIndex));
     }
 
@@ -125,7 +125,7 @@ const std::vector<SplineInterpolation> covarianceXsec::GetSplineInterpolationFro
     auto &SplineIndex = pair.first;
     auto &SystIndex = pair.second;
 
-    if (AppliesToSampleName(SystIndex, SampleName)) { //If parameter applies to required SampleID
+    if (AppliesToSampleID(SystIndex, SampleName)) { //If parameter applies to required SampleID
       returnVec.push_back(SplineParams.at(SplineIndex)._SplineInterpolationType);
     }
   }
@@ -142,7 +142,7 @@ const std::vector< std::vector<int> > covarianceXsec::GetSplineModeVecFromSample
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kSpline]) {
     auto &SplineIndex = pair.first;
     auto &SystIndex = pair.second;
-    if (AppliesToSampleName(SystIndex, SampleName)) { //If parameter applies to required SampleID
+    if (AppliesToSampleID(SystIndex, SampleName)) { //If parameter applies to required SampleID
       returnVec.push_back(SplineParams.at(SplineIndex)._fSplineModes);
     }
   }
@@ -215,7 +215,7 @@ const std::vector<int> covarianceXsec::GetGlobalSystIndexFromSampleName(const st
   std::vector<int> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[Type]) {
     auto &SystIndex = pair.second;
-    if (AppliesToSampleName(SystIndex, SampleName)) { //If parameter applies to required SampleID
+    if (AppliesToSampleID(SystIndex, SampleName)) { //If parameter applies to required SampleID
       returnVec.push_back(SystIndex);
     }
   }
@@ -231,7 +231,7 @@ const std::vector<int> covarianceXsec::GetSystIndexFromSampleName(const std::str
   for (auto &pair : _fSystToGlobalSystIndexMap[Type]) {
     auto &SplineIndex = pair.first;
     auto &systIndex = pair.second;
-    if (AppliesToSampleName(systIndex, SampleName)) { //If parameter applies to required SampleID
+    if (AppliesToSampleID(systIndex, SampleName)) { //If parameter applies to required SampleID
       returnVec.push_back(SplineIndex);
     }
   }
@@ -270,7 +270,7 @@ const std::vector<XsecNorms4> covarianceXsec::GetNormParsFromSampleName(const st
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kNorm]) {
     auto &NormIndex = pair.first;
     auto &GlobalIndex = pair.second;
-    if (AppliesToSampleName(GlobalIndex, SampleName)) {
+    if (AppliesToSampleID(GlobalIndex, SampleName)) {
       returnVec.push_back(NormParams[NormIndex]);
     }
   }
@@ -318,7 +318,7 @@ template <typename FilterFunc, typename ActionFunc>
 void covarianceXsec::IterateOverParams(const std::string& SampleName, FilterFunc filter, ActionFunc action) {
 // ********************************************
   for (int i = 0; i < _fNumPar; ++i) {
-    if ((AppliesToSampleName(i, SampleName)) && filter(i)) { // Common filter logic
+    if ((AppliesToSampleID(i, SampleName)) && filter(i)) { // Common filter logic
       action(i); // Specific action for each function
     }
   }

--- a/covariance/covarianceXsec.cpp
+++ b/covariance/covarianceXsec.cpp
@@ -59,7 +59,7 @@ void covarianceXsec::InitXsecFromConfig() {
       }
 
       //Insert the mapping from the spline index i.e. the length of _fSplineNames etc
-      //to the Systematic index i.e. the counter for things like _fDetID and _fDetID
+      //to the Systematic index i.e. the counter for things like _fSampleID
       _fSystToGlobalSystIndexMap[SystType::kSpline].insert(std::make_pair(ParamCounter[SystType::kSpline], i));
       ParamCounter[SystType::kSpline]++;
     } else if(param["Systematic"]["Type"].as<std::string>() == SystType_ToString(SystType::kNorm)) {
@@ -125,7 +125,7 @@ const std::vector<SplineInterpolation> covarianceXsec::GetSplineInterpolationFro
     auto &SplineIndex = pair.first;
     auto &SystIndex = pair.second;
 
-    if (AppliesToSampleName(SystIndex, SampleName)) { //If parameter applies to required DetID
+    if (AppliesToSampleName(SystIndex, SampleName)) { //If parameter applies to required SampleID
       returnVec.push_back(SplineParams.at(SplineIndex)._SplineInterpolationType);
     }
   }
@@ -142,7 +142,7 @@ const std::vector< std::vector<int> > covarianceXsec::GetSplineModeVecFromSample
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kSpline]) {
     auto &SplineIndex = pair.first;
     auto &SystIndex = pair.second;
-    if (AppliesToSampleName(SystIndex, SampleName)) { //If parameter applies to required DetID
+    if (AppliesToSampleName(SystIndex, SampleName)) { //If parameter applies to required SampleID
       returnVec.push_back(SplineParams.at(SplineIndex)._fSplineModes);
     }
   }
@@ -215,7 +215,7 @@ const std::vector<int> covarianceXsec::GetGlobalSystIndexFromSampleName(const st
   std::vector<int> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[Type]) {
     auto &SystIndex = pair.second;
-    if (AppliesToSampleName(SystIndex, SampleName)) { //If parameter applies to required DetID
+    if (AppliesToSampleName(SystIndex, SampleName)) { //If parameter applies to required SampleID
       returnVec.push_back(SystIndex);
     }
   }
@@ -231,7 +231,7 @@ const std::vector<int> covarianceXsec::GetSystIndexFromSampleName(const std::str
   for (auto &pair : _fSystToGlobalSystIndexMap[Type]) {
     auto &SplineIndex = pair.first;
     auto &systIndex = pair.second;
-    if (AppliesToSampleName(systIndex, SampleName)) { //If parameter applies to required DetID
+    if (AppliesToSampleName(systIndex, SampleName)) { //If parameter applies to required SampleID
       returnVec.push_back(SplineIndex);
     }
   }
@@ -380,18 +380,18 @@ void covarianceXsec::Print() {
 void covarianceXsec::PrintGlobablInfo() {
 // ********************************************
   MACH3LOG_INFO("============================================================================================================================================================");
-  MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10}", "#", "|", "Name", "|", "Gen.", "|", "Prior", "|", "Error", "|", "Lower", "|", "Upper", "|", "StepScale", "|", "DetID", "|", "Type");
+  MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10}", "#", "|", "Name", "|", "Gen.", "|", "Prior", "|", "Error", "|", "Lower", "|", "Upper", "|", "StepScale", "|", "SampleID", "|", "Type");
   MACH3LOG_INFO("------------------------------------------------------------------------------------------------------------------------------------------------------------");
   for (int i = 0; i < GetNumParams(); i++) {
     std::string ErrString = fmt::format("{:.2f}", _fError[i]);
-    std::string detIdString = "";
-    for (const auto& detID : _fDetID[i]) {
-      if (!detIdString.empty()) {
-        detIdString += ", ";
+    std::string SampleIdString = "";
+    for (const auto& SampleID : _fSampleID[i]) {
+      if (!SampleIdString.empty()) {
+        SampleIdString += ", ";
       }
-      detIdString += detID;
+      SampleIdString += SampleID;
     }
-    MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10}", i, "|", GetParFancyName(i), "|", _fGenerated[i], "|", _fPreFitValue[i], "|", "+/- " + ErrString, "|", _fLowBound[i], "|", _fUpBound[i], "|", _fIndivStepScale[i], "|", detIdString, "|", SystType_ToString(_fParamType[i]));
+    MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10}", i, "|", GetParFancyName(i), "|", _fGenerated[i], "|", _fPreFitValue[i], "|", "+/- " + ErrString, "|", _fLowBound[i], "|", _fUpBound[i], "|", _fIndivStepScale[i], "|", SampleIdString, "|", SystType_ToString(_fParamType[i]));
   }
   MACH3LOG_INFO("============================================================================================================================================================");
 }

--- a/covariance/covarianceXsec.cpp
+++ b/covariance/covarianceXsec.cpp
@@ -102,14 +102,14 @@ covarianceXsec::~covarianceXsec() {
 }
 
 // ********************************************
-// DB Grab the Spline Names for the relevant DetID
-const std::vector<std::string> covarianceXsec::GetSplineParsNamesFromDetID(const std::string& DetID) {
+// DB Grab the Spline Names for the relevant SampleName
+const std::vector<std::string> covarianceXsec::GetSplineParsNamesFromSampleName(const std::string& SampleName) {
 // ********************************************
   std::vector<std::string> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kSpline]) {
     auto &SplineIndex = pair.first;
     auto &SystIndex = pair.second;
-    if (AppliesToDetID(SystIndex, DetID)) { //If parameter applies to required DetID
+    if (AppliesToSampleName(SystIndex, SampleName)) { //If parameter applies to required Sample
       returnVec.push_back(_fSplineNames.at(SplineIndex));
     }
 
@@ -118,14 +118,14 @@ const std::vector<std::string> covarianceXsec::GetSplineParsNamesFromDetID(const
 }
 
 // ********************************************
-const std::vector<SplineInterpolation> covarianceXsec::GetSplineInterpolationFromDetID(const std::string& DetID) {
+const std::vector<SplineInterpolation> covarianceXsec::GetSplineInterpolationFromSampleName(const std::string& SampleName) {
 // ********************************************
   std::vector<SplineInterpolation> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kSpline]) {
     auto &SplineIndex = pair.first;
     auto &SystIndex = pair.second;
 
-    if (AppliesToDetID(SystIndex, DetID)) { //If parameter applies to required DetID
+    if (AppliesToSampleName(SystIndex, SampleName)) { //If parameter applies to required DetID
       returnVec.push_back(SplineParams.at(SplineIndex)._SplineInterpolationType);
     }
   }
@@ -133,8 +133,8 @@ const std::vector<SplineInterpolation> covarianceXsec::GetSplineInterpolationFro
 }
 
 // ********************************************
-// DB Grab the Spline Modes for the relevant DetID
-const std::vector< std::vector<int> > covarianceXsec::GetSplineModeVecFromDetID(const std::string& DetID) {
+// DB Grab the Spline Modes for the relevant SampleName
+const std::vector< std::vector<int> > covarianceXsec::GetSplineModeVecFromSampleName(const std::string& SampleName) {
 // ********************************************
   std::vector< std::vector<int> > returnVec;
   //Need a counter or something to correctly get the index in _fSplineModes since it's not of length nPars
@@ -142,7 +142,7 @@ const std::vector< std::vector<int> > covarianceXsec::GetSplineModeVecFromDetID(
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kSpline]) {
     auto &SplineIndex = pair.first;
     auto &SystIndex = pair.second;
-    if (AppliesToDetID(SystIndex, DetID)) { //If parameter applies to required DetID
+    if (AppliesToSampleName(SystIndex, SampleName)) { //If parameter applies to required DetID
       returnVec.push_back(SplineParams.at(SplineIndex)._fSplineModes);
     }
   }
@@ -208,14 +208,14 @@ XsecNorms4 covarianceXsec::GetXsecNorm(const YAML::Node& param, const int Index)
 }
 
 // ********************************************
-// Grab the global syst index for the relevant DetID
+// Grab the global syst index for the relevant SampleName
 // i.e. get a vector of size nSplines where each entry is filled with the global syst number
-const std::vector<int> covarianceXsec::GetGlobalSystIndexFromDetID(const std::string& DetID, const SystType Type) {
+const std::vector<int> covarianceXsec::GetGlobalSystIndexFromSampleName(const std::string& SampleName, const SystType Type) {
 // ********************************************
   std::vector<int> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[Type]) {
     auto &SystIndex = pair.second;
-    if (AppliesToDetID(SystIndex, DetID)) { //If parameter applies to required DetID
+    if (AppliesToSampleName(SystIndex, SampleName)) { //If parameter applies to required DetID
       returnVec.push_back(SystIndex);
     }
   }
@@ -223,15 +223,15 @@ const std::vector<int> covarianceXsec::GetGlobalSystIndexFromDetID(const std::st
 }
 
 // ********************************************
-// Grab the global syst index for the relevant DetID
+// Grab the global syst index for the relevant SampleName
 // i.e. get a vector of size nSplines where each entry is filled with the global syst number
-const std::vector<int> covarianceXsec::GetSystIndexFromDetID(const std::string& DetID,  const SystType Type) {
+const std::vector<int> covarianceXsec::GetSystIndexFromSampleName(const std::string& SampleName,  const SystType Type) {
 // ********************************************
   std::vector<int> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[Type]) {
     auto &SplineIndex = pair.first;
     auto &systIndex = pair.second;
-    if (AppliesToDetID(systIndex, DetID)) { //If parameter applies to required DetID
+    if (AppliesToSampleName(systIndex, SampleName)) { //If parameter applies to required DetID
       returnVec.push_back(SplineIndex);
     }
   }
@@ -263,14 +263,14 @@ XsecSplines1 covarianceXsec::GetXsecSpline(const YAML::Node& param) {
 }
 
 // ********************************************
-// DB Grab the Normalisation parameters for the relevant DetID
-const std::vector<XsecNorms4> covarianceXsec::GetNormParsFromDetID(const std::string& DetID) {
+// DB Grab the Normalisation parameters for the relevant SampleName
+const std::vector<XsecNorms4> covarianceXsec::GetNormParsFromSampleName(const std::string& SampleName) {
 // ********************************************
   std::vector<XsecNorms4> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kNorm]) {
     auto &NormIndex = pair.first;
     auto &GlobalIndex = pair.second;
-    if (AppliesToDetID(GlobalIndex, DetID)) {
+    if (AppliesToSampleName(GlobalIndex, SampleName)) {
       returnVec.push_back(NormParams[NormIndex]);
     }
   }
@@ -278,11 +278,11 @@ const std::vector<XsecNorms4> covarianceXsec::GetNormParsFromDetID(const std::st
 }
 
 // ********************************************
-// DB Grab the number of parameters for the relevant DetID
-int covarianceXsec::GetNumParamsFromDetID(const std::string& DetID, const SystType Type) {
+// DB Grab the number of parameters for the relevant SampleName
+int covarianceXsec::GetNumParamsFromSampleName(const std::string& SampleName, const SystType Type) {
 // ********************************************
   int returnVal = 0;
-  IterateOverParams(DetID,
+  IterateOverParams(SampleName,
     [&](int i) { return GetParamType(i) == Type; }, // Filter condition
     [&](int) { returnVal += 1; } // Action to perform if filter passes
   );
@@ -290,11 +290,11 @@ int covarianceXsec::GetNumParamsFromDetID(const std::string& DetID, const SystTy
 }
 
 // ********************************************
-// DB Grab the parameter names for the relevant DetID
-const std::vector<std::string> covarianceXsec::GetParsNamesFromDetID(const std::string& DetID, const SystType Type) {
+// DB Grab the parameter names for the relevant SampleName
+const std::vector<std::string> covarianceXsec::GetParsNamesFromSampleName(const std::string& SampleName, const SystType Type) {
 // ********************************************
   std::vector<std::string> returnVec;
-  IterateOverParams(DetID,
+  IterateOverParams(SampleName,
     [&](int i) { return GetParamType(i) == Type; }, // Filter condition
     [&](int i) { returnVec.push_back(GetParFancyName(i)); } // Action to perform if filter passes
   );
@@ -302,11 +302,11 @@ const std::vector<std::string> covarianceXsec::GetParsNamesFromDetID(const std::
 }
 
 // ********************************************
-// DB DB Grab the parameter indices for the relevant DetID
-const std::vector<int> covarianceXsec::GetParsIndexFromDetID(const std::string& DetID, const SystType Type) {
+// DB DB Grab the parameter indices for the relevant SampleName
+const std::vector<int> covarianceXsec::GetParsIndexFromSampleName(const std::string& SampleName, const SystType Type) {
 // ********************************************
   std::vector<int> returnVec;
-  IterateOverParams(DetID,
+  IterateOverParams(SampleName,
     [&](int i) { return GetParamType(i) == Type; }, // Filter condition
     [&](int i) { returnVec.push_back(i); } // Action to perform if filter passes
   );
@@ -315,10 +315,10 @@ const std::vector<int> covarianceXsec::GetParsIndexFromDetID(const std::string& 
 
 // ********************************************
 template <typename FilterFunc, typename ActionFunc>
-void covarianceXsec::IterateOverParams(const std::string& DetID, FilterFunc filter, ActionFunc action) {
+void covarianceXsec::IterateOverParams(const std::string& SampleName, FilterFunc filter, ActionFunc action) {
 // ********************************************
   for (int i = 0; i < _fNumPar; ++i) {
-    if ((AppliesToDetID(i, DetID)) && filter(i)) { // Common filter logic
+    if ((AppliesToSampleName(i, SampleName)) && filter(i)) { // Common filter logic
       action(i); // Specific action for each function
     }
   }

--- a/covariance/covarianceXsec.cpp
+++ b/covariance/covarianceXsec.cpp
@@ -109,7 +109,7 @@ const std::vector<std::string> covarianceXsec::GetSplineParsNamesFromSampleName(
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kSpline]) {
     auto &SplineIndex = pair.first;
     auto &SystIndex = pair.second;
-    if (AppliesToSampleID(SystIndex, SampleName)) { //If parameter applies to required Sample
+    if (AppliesToSample(SystIndex, SampleName)) { //If parameter applies to required Sample
       returnVec.push_back(_fSplineNames.at(SplineIndex));
     }
 
@@ -125,7 +125,7 @@ const std::vector<SplineInterpolation> covarianceXsec::GetSplineInterpolationFro
     auto &SplineIndex = pair.first;
     auto &SystIndex = pair.second;
 
-    if (AppliesToSampleID(SystIndex, SampleName)) { //If parameter applies to required SampleID
+    if (AppliesToSample(SystIndex, SampleName)) { //If parameter applies to required SampleID
       returnVec.push_back(SplineParams.at(SplineIndex)._SplineInterpolationType);
     }
   }
@@ -142,7 +142,7 @@ const std::vector< std::vector<int> > covarianceXsec::GetSplineModeVecFromSample
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kSpline]) {
     auto &SplineIndex = pair.first;
     auto &SystIndex = pair.second;
-    if (AppliesToSampleID(SystIndex, SampleName)) { //If parameter applies to required SampleID
+    if (AppliesToSample(SystIndex, SampleName)) { //If parameter applies to required SampleID
       returnVec.push_back(SplineParams.at(SplineIndex)._fSplineModes);
     }
   }
@@ -215,7 +215,7 @@ const std::vector<int> covarianceXsec::GetGlobalSystIndexFromSampleName(const st
   std::vector<int> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[Type]) {
     auto &SystIndex = pair.second;
-    if (AppliesToSampleID(SystIndex, SampleName)) { //If parameter applies to required SampleID
+    if (AppliesToSample(SystIndex, SampleName)) { //If parameter applies to required SampleID
       returnVec.push_back(SystIndex);
     }
   }
@@ -231,7 +231,7 @@ const std::vector<int> covarianceXsec::GetSystIndexFromSampleName(const std::str
   for (auto &pair : _fSystToGlobalSystIndexMap[Type]) {
     auto &SplineIndex = pair.first;
     auto &systIndex = pair.second;
-    if (AppliesToSampleID(systIndex, SampleName)) { //If parameter applies to required SampleID
+    if (AppliesToSample(systIndex, SampleName)) { //If parameter applies to required SampleID
       returnVec.push_back(SplineIndex);
     }
   }
@@ -270,7 +270,7 @@ const std::vector<XsecNorms4> covarianceXsec::GetNormParsFromSampleName(const st
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kNorm]) {
     auto &NormIndex = pair.first;
     auto &GlobalIndex = pair.second;
-    if (AppliesToSampleID(GlobalIndex, SampleName)) {
+    if (AppliesToSample(GlobalIndex, SampleName)) {
       returnVec.push_back(NormParams[NormIndex]);
     }
   }
@@ -318,7 +318,7 @@ template <typename FilterFunc, typename ActionFunc>
 void covarianceXsec::IterateOverParams(const std::string& SampleName, FilterFunc filter, ActionFunc action) {
 // ********************************************
   for (int i = 0; i < _fNumPar; ++i) {
-    if ((AppliesToSampleID(i, SampleName)) && filter(i)) { // Common filter logic
+    if ((AppliesToSample(i, SampleName)) && filter(i)) { // Common filter logic
       action(i); // Specific action for each function
     }
   }
@@ -380,18 +380,18 @@ void covarianceXsec::Print() {
 void covarianceXsec::PrintGlobablInfo() {
 // ********************************************
   MACH3LOG_INFO("============================================================================================================================================================");
-  MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10}", "#", "|", "Name", "|", "Gen.", "|", "Prior", "|", "Error", "|", "Lower", "|", "Upper", "|", "StepScale", "|", "SampleID", "|", "Type");
+  MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10}", "#", "|", "Name", "|", "Gen.", "|", "Prior", "|", "Error", "|", "Lower", "|", "Upper", "|", "StepScale", "|", "SampleNames", "|", "Type");
   MACH3LOG_INFO("------------------------------------------------------------------------------------------------------------------------------------------------------------");
   for (int i = 0; i < GetNumParams(); i++) {
     std::string ErrString = fmt::format("{:.2f}", _fError[i]);
-    std::string SampleIdString = "";
-    for (const auto& SampleID : _fSampleID[i]) {
-      if (!SampleIdString.empty()) {
-        SampleIdString += ", ";
+    std::string SampleNameString = "";
+    for (const auto& SampleName : _fSampleNames[i]) {
+      if (!SampleNameString.empty()) {
+        SampleNameString += ", ";
       }
-      SampleIdString += SampleID;
+      SampleNameString += SampleName;
     }
-    MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10}", i, "|", GetParFancyName(i), "|", _fGenerated[i], "|", _fPreFitValue[i], "|", "+/- " + ErrString, "|", _fLowBound[i], "|", _fUpBound[i], "|", _fIndivStepScale[i], "|", SampleIdString, "|", SystType_ToString(_fParamType[i]));
+    MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10}", i, "|", GetParFancyName(i), "|", _fGenerated[i], "|", _fPreFitValue[i], "|", "+/- " + ErrString, "|", _fLowBound[i], "|", _fUpBound[i], "|", _fIndivStepScale[i], "|", SampleNameString, "|", SystType_ToString(_fParamType[i]));
   }
   MACH3LOG_INFO("============================================================================================================================================================");
 }

--- a/covariance/covarianceXsec.h
+++ b/covariance/covarianceXsec.h
@@ -22,7 +22,7 @@ class covarianceXsec : public covarianceBase {
     ~covarianceXsec();
 
     // General Getter functions not split by detector
-    /// @brief ETA - just return the int of the DetID, this can be removed to do a string comp at some point.
+    /// @brief ETA - just return the int of the SampleName, this can be removed to do a string comp at some point.
     /// @param i parameter index
     inline std::vector<std::string> GetParDetID(const int i) const { return _fDetID[i];};
     /// @brief ETA - just return a string of "spline", "norm" or "functional"
@@ -35,14 +35,14 @@ class covarianceXsec : public covarianceBase {
     /// @brief Get interpolation type for a given parameter
     /// @param i spline parameter index, not confuse with global index
     inline SplineInterpolation GetParSplineInterpolation(const int i) {return SplineParams.at(i)._SplineInterpolationType;}
-    /// @brief Get the interpolation types for splines affecting a particular DetID
-    const std::vector<SplineInterpolation> GetSplineInterpolationFromDetID(const std::string& DetID);
+    /// @brief Get the interpolation types for splines affecting a particular SampleName
+    const std::vector<SplineInterpolation> GetSplineInterpolationFromSampleName(const std::string& SampleName);
     /// @brief Get the name of the spline associated with the spline at index i
     /// @param i spline parameter index, not to be confused with global index
     std::string GetParSplineName(const int i) {return _fSplineNames[i];}
 
-    /// @brief DB Get spline parameters depending on given DetID
-    const std::vector<int> GetGlobalSystIndexFromDetID(const std::string& DetID, const SystType Type);
+    /// @brief DB Get spline parameters depending on given SampleName
+    const std::vector<int> GetGlobalSystIndexFromSampleName(const std::string& SampleName, const SystType Type);
     /// @brief EM: value at which we cap spline knot weight
     /// @param i spline parameter index, not confuse with global index
     inline double GetParSplineKnotUpperBound(const int i) {return SplineParams.at(i)._SplineKnotUpBound;}
@@ -50,28 +50,28 @@ class covarianceXsec : public covarianceBase {
     /// @param i spline parameter index, not confuse with global index
     inline double GetParSplineKnotLowerBound(const int i) {return SplineParams.at(i)._SplineKnotLowBound;}
 
-    /// @brief DB Grab the number of parameters for the relevant DetID
+    /// @brief DB Grab the number of parameters for the relevant SampleName
     /// @param Type Type of syst, for example kNorm, kSpline etc
-    int GetNumParamsFromDetID(const std::string& DetID, const SystType Type);
-    /// @brief DB Grab the parameter names for the relevant DetID
+    int GetNumParamsFromSampleName(const std::string& SampleName, const SystType Type);
+    /// @brief DB Grab the parameter names for the relevant SampleName
     /// @param Type Type of syst, for example kNorm, kSpline etc
-    const std::vector<std::string> GetParsNamesFromDetID(const std::string& DetID, const SystType Type);
-    /// @brief DB Grab the parameter indices for the relevant DetID
+    const std::vector<std::string> GetParsNamesFromSampleName(const std::string& SampleName, const SystType Type);
+    /// @brief DB Grab the parameter indices for the relevant SampleName
     /// @param Type Type of syst, for example kNorm, kSpline etc
-    const std::vector<int> GetParsIndexFromDetID(const std::string& DetID, const SystType Type);
+    const std::vector<int> GetParsIndexFromSampleName(const std::string& SampleName, const SystType Type);
 
-    /// @brief DB Get spline parameters depending on given DetID
-    const std::vector<std::string> GetSplineParsNamesFromDetID(const std::string& DetID);
-    /// @brief DB Get spline parameters depending on given DetID
-    const std::vector<std::string> GetSplineFileParsNamesFromDetID(const std::string& DetID);
+    /// @brief DB Get spline parameters depending on given SampleName
+    const std::vector<std::string> GetSplineParsNamesFromSampleName(const std::string& SampleName);
+    /// @brief DB Get spline parameters depending on given SampleName
+    const std::vector<std::string> GetSplineFileParsNamesFromSampleName(const std::string& SampleName);
 
-    /// @brief DB Grab the Spline Modes for the relevant DetID
-    const std::vector< std::vector<int> > GetSplineModeVecFromDetID(const std::string& DetID);
+    /// @brief DB Grab the Spline Modes for the relevant SampleName
+    const std::vector< std::vector<int> > GetSplineModeVecFromSampleName(const std::string& SampleName);
     /// @brief Grab the index of the syst relative to global numbering.
     /// @param Type Type of syst, for example kNorm, kSpline etc
-    const std::vector<int> GetSystIndexFromDetID(const std::string& DetID, const SystType Type);
-    /// @brief DB Get norm/func parameters depending on given DetID
-    const std::vector<XsecNorms4> GetNormParsFromDetID(const std::string& DetID);
+    const std::vector<int> GetSystIndexFromSampleName(const std::string& SampleName, const SystType Type);
+    /// @brief DB Get norm/func parameters depending on given SampleName
+    const std::vector<XsecNorms4> GetNormParsFromSampleName(const std::string& SampleName);
 
     /// @brief KS: For most covariances prior and fparInit (prior) are the same, however for Xsec those can be different
     std::vector<double> getNominalArray() override
@@ -116,7 +116,7 @@ class covarianceXsec : public covarianceBase {
     /// @brief Iterates over parameters and applies a filter and action function.
     ///
     /// This template function provides a way to iterate over parameters associated
-    /// with a specific Detector ID (DetID). It applies a filter function to determine
+    /// with a specific Detector ID (SampleName). It applies a filter function to determine
     /// which parameters to process and an action function to define what to do
     /// with the selected parameters.
     ///
@@ -124,9 +124,9 @@ class covarianceXsec : public covarianceBase {
     /// which parameters to include.
     /// @tparam ActionFunc The type of the action function applied to each selected
     /// parameter.
-    /// @param DetID The Detector ID used to filter parameters.
+    /// @param SampleName The Detector ID used to filter parameters.
     template <typename FilterFunc, typename ActionFunc>
-    void IterateOverParams(const std::string& DetID, FilterFunc filter, ActionFunc action);
+    void IterateOverParams(const std::string& SampleName, FilterFunc filter, ActionFunc action);
 
     /// @brief Initializes the systematic parameters from the configuration file.
     /// This function loads parameters like normalizations and splines from the provided YAML file.

--- a/covariance/covarianceXsec.h
+++ b/covariance/covarianceXsec.h
@@ -24,7 +24,7 @@ class covarianceXsec : public covarianceBase {
     // General Getter functions not split by detector
     /// @brief ETA - just return the int of the SampleName, this can be removed to do a string comp at some point.
     /// @param i parameter index
-    inline std::vector<std::string> GetParDetID(const int i) const { return _fDetID[i];};
+    inline std::vector<std::string> GetParSampleID(const int i) const { return _fSampleID[i];};
     /// @brief ETA - just return a string of "spline", "norm" or "functional"
     /// @param i parameter index
     inline std::string GetParamTypeString(const int i) const { return SystType_ToString(_fParamType[i]); }
@@ -116,7 +116,7 @@ class covarianceXsec : public covarianceBase {
     /// @brief Iterates over parameters and applies a filter and action function.
     ///
     /// This template function provides a way to iterate over parameters associated
-    /// with a specific Detector ID (SampleName). It applies a filter function to determine
+    /// with a specific Sample ID (SampleName). It applies a filter function to determine
     /// which parameters to process and an action function to define what to do
     /// with the selected parameters.
     ///
@@ -124,7 +124,7 @@ class covarianceXsec : public covarianceBase {
     /// which parameters to include.
     /// @tparam ActionFunc The type of the action function applied to each selected
     /// parameter.
-    /// @param SampleName The Detector ID used to filter parameters.
+    /// @param SampleName The Sample ID used to filter parameters.
     template <typename FilterFunc, typename ActionFunc>
     void IterateOverParams(const std::string& SampleName, FilterFunc filter, ActionFunc action);
 

--- a/covariance/covarianceXsec.h
+++ b/covariance/covarianceXsec.h
@@ -24,7 +24,7 @@ class covarianceXsec : public covarianceBase {
     // General Getter functions not split by detector
     /// @brief ETA - just return the int of the SampleName, this can be removed to do a string comp at some point.
     /// @param i parameter index
-    inline std::vector<std::string> GetParSampleID(const int i) const { return _fSampleID[i];};
+    inline std::vector<std::string> GetParSampleID(const int i) const { return _fSampleNames[i];};
     /// @brief ETA - just return a string of "spline", "norm" or "functional"
     /// @param i parameter index
     inline std::string GetParamTypeString(const int i) const { return SystType_ToString(_fParamType[i]); }

--- a/mcmc/FitterBase.cpp
+++ b/mcmc/FitterBase.cpp
@@ -232,6 +232,14 @@ void FitterBase::SaveOutput() {
 // Add samplePDF object to the Markov Chain
 void FitterBase::addSamplePDF(samplePDFBase * const sample) {
 // *************************
+  //Check if the sample has a unique name
+  for (const auto &s : samples) {
+    if (s->GetTitle() == sample->GetTitle()) {
+      MACH3LOG_ERROR("SamplePDF with name '{}' already exists!", sample->GetTitle());
+      throw MaCh3Exception(__FILE__ , __LINE__ );
+    }
+  }
+
   TotalNSamples += sample->GetNsamples();
   MACH3LOG_INFO("Adding {} object, with {} samples", sample->GetTitle(), sample->GetNsamples());
   samples.push_back(sample);

--- a/mcmc/FitterBase.cpp
+++ b/mcmc/FitterBase.cpp
@@ -136,7 +136,7 @@ void FitterBase::SaveSettings() {
     MACH3LOG_INFO("{}: Cov name: {}, it has {} params", i, systematics[i]->getName(), systematics[i]->GetNumParams());
   MACH3LOG_INFO("Number of SamplePDFs: {}", samples.size());
   for(unsigned int i = 0; i < samples.size(); ++i)
-    MACH3LOG_INFO("{}: SamplePDF name: {}, it has {} samples",i , samples[i]->GetName(), samples[i]->GetNsamples());
+    MACH3LOG_INFO("{}: SamplePDF name: {}, it has {} samples",i , samples[i]->GetTitle(), samples[i]->GetNsamples());
 
   SettingsSaved = true;
 }
@@ -233,7 +233,7 @@ void FitterBase::SaveOutput() {
 void FitterBase::addSamplePDF(samplePDFBase * const sample) {
 // *************************
   TotalNSamples += sample->GetNsamples();
-  MACH3LOG_INFO("Adding {} object, with {} samples", sample->GetName(), sample->GetNsamples());
+  MACH3LOG_INFO("Adding {} object, with {} samples", sample->GetTitle(), sample->GetNsamples());
   samples.push_back(sample);
 }
 
@@ -404,7 +404,7 @@ void FitterBase::DragRace(const int NLaps) {
       samples[ivs]->reweight();
     }
     clockRace.Stop();
-    MACH3LOG_INFO("It took {:.4f} s to reweights {} times sample: {}", clockRace.RealTime(), NLaps, samples[ivs]->GetName());
+    MACH3LOG_INFO("It took {:.4f} s to reweights {} times sample: {}", clockRace.RealTime(), NLaps, samples[ivs]->GetTitle());
     MACH3LOG_INFO("On average {:.6f}", clockRace.RealTime()/NLaps);
   }
 
@@ -416,7 +416,7 @@ void FitterBase::DragRace(const int NLaps) {
       samples[ivs]->GetLikelihood();
     }
     clockRace.Stop();
-    MACH3LOG_INFO("It took {:.4f} s to calculate  GetLikelihood {} times sample:  {}", clockRace.RealTime(), NLaps, samples[ivs]->GetName());
+    MACH3LOG_INFO("It took {:.4f} s to calculate  GetLikelihood {} times sample:  {}", clockRace.RealTime(), NLaps, samples[ivs]->GetTitle());
     MACH3LOG_INFO("On average {:.6f}", clockRace.RealTime()/NLaps);
   }
   // Get vector of proposed steps. If we want to run LLH scan or something else after we need to revert changes after proposing steps multiple times
@@ -485,7 +485,7 @@ void FitterBase::RunLLHScan() {
   std::vector<TDirectory *> SampleClass_LLH(samples.size());
   for(unsigned int ivs = 0; ivs < samples.size(); ++ivs )
   {
-    std::string NameTemp = samples[ivs]->GetName();
+    std::string NameTemp = samples[ivs]->GetTitle();
     SampleClass_LLH[ivs] = outputFile->mkdir(NameTemp.c_str());
   }
 
@@ -613,7 +613,7 @@ void FitterBase::RunLLHScan() {
       std::vector<double> nSamLLH(samples.size());
       for(unsigned int ivs = 0; ivs < samples.size(); ++ivs )
       {
-        std::string NameTemp = samples[ivs]->GetName();
+        std::string NameTemp = samples[ivs]->GetTitle();
         hScanSample[ivs] = new TH1D((name+"_"+NameTemp).c_str(), (name+"_" + NameTemp).c_str(), n_points, lower, upper);
         hScanSample[ivs]->SetTitle(("2LLH_" + NameTemp + ", " + name + ";" + name + "; -2(ln L_{" + NameTemp +"})").c_str());
         nSamLLH[ivs] = 0.;

--- a/mcmc/MaCh3Factory.h
+++ b/mcmc/MaCh3Factory.h
@@ -136,7 +136,7 @@ std::vector<SampleType*> MaCh3SamplePDFFactory(const std::vector<std::string>& S
     Sample->reweight();
 
     // Obtain sample name and create a TString version for histogram naming
-    std::string name = Sample->GetName();
+    std::string name = Sample->GetTitle();
     TString NameTString = TString(name.c_str());
 
     // Clone the 1D histogram with a modified name

--- a/samplePDF/samplePDFBase.h
+++ b/samplePDF/samplePDFBase.h
@@ -30,7 +30,7 @@ class samplePDFBase
   virtual ~samplePDFBase();
 
   virtual inline M3::int_t GetNsamples(){ return nSamples; };
-  virtual inline std::string GetName()const {return "samplePDF";};
+  virtual inline std::string GetTitle()const {return "samplePDF";};
   virtual std::string GetSampleName(int Sample);
   virtual inline double getSampleLikelihood(const int isample){(void) isample; return GetLikelihood();};
 

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -1400,10 +1400,10 @@ void samplePDFFDBase::fillSplineBins() {
       std::vector< std::vector<int> > EventSplines;
       switch(nDimensions){
         case 1:
-          EventSplines = SplineHandler->GetEventSplines(GetTitle(), i, int(*(MCSamples[i].mode[j])), *(MCSamples[i].rw_etru[j]), *(MCSamples[i].x_var[j]), 0.);
+          EventSplines = SplineHandler->GetEventSplines(GetName(), i, int(*(MCSamples[i].mode[j])), *(MCSamples[i].rw_etru[j]), *(MCSamples[i].x_var[j]), 0.);
           break;
         case 2:
-          EventSplines = SplineHandler->GetEventSplines(GetTitle(), i, int(*(MCSamples[i].mode[j])), *(MCSamples[i].rw_etru[j]), *(MCSamples[i].x_var[j]), *(MCSamples[i].y_var[j]));
+          EventSplines = SplineHandler->GetEventSplines(GetName(), i, int(*(MCSamples[i].mode[j])), *(MCSamples[i].rw_etru[j]), *(MCSamples[i].x_var[j]), *(MCSamples[i].y_var[j]));
           break;
         default:
           MACH3LOG_ERROR("Error in assigning spline bins because nDimensions = {}", nDimensions);

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -726,7 +726,7 @@ M3::float_t samplePDFFDBase::CalcWeightNorm(const int iSample, const int iEvent)
 }
 
 void samplePDFFDBase::SetupNormParameters() {  
-  xsec_norms = XsecCov->GetNormParsFromDetID(SampleName);
+  xsec_norms = XsecCov->GetNormParsFromSampleName(SampleName);
 
   if(!XsecCov){
     MACH3LOG_ERROR("XsecCov is not setup!");
@@ -1397,7 +1397,7 @@ void samplePDFFDBase::SetupNuOscillator() {
   }// end loop over channels
   delete OscillFactory;
 
-  OscParams = OscCov->GetOscParsFromDetID(SampleName);
+  OscParams = OscCov->GetOscParsFromSampleName(SampleName);
 }
 
 M3::float_t samplePDFFDBase::GetEventWeight(const int iSample, const int iEntry) const {

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -1524,7 +1524,7 @@ void samplePDFFDBase::InitialiseSplineObject() {
     SplineVarNames.push_back(YVarStr);
   }
   
-  SplineHandler->AddSample(SampleTitle, SampleName, spline_filepaths, SplineVarNames);
+  SplineHandler->AddSample(SampleName, spline_filepaths, SplineVarNames);
   SplineHandler->CountNumberOfLoadedSplines(false, 1);
   SplineHandler->TransferToMonolith();
 

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -28,6 +28,7 @@ public:
   virtual ~samplePDFFDBase();
 
   int GetNDim(){return nDimensions;} //DB Function to differentiate 1D or 2D binning
+  std::string GetName() const {return SampleName;}
   std::string GetTitle() const {return SampleTitle;}
 
   std::string GetXBinVarName() {return XVarStr;}

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -29,7 +29,6 @@ public:
 
   int GetNDim(){return nDimensions;} //DB Function to differentiate 1D or 2D binning
   std::string GetTitle() const {return SampleTitle;}
-  //std::string GetTitle() const {return SampleDetID;}
 
   std::string GetXBinVarName() {return XVarStr;}
   std::string GetYBinVarName() {return YVarStr;}

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -28,7 +28,8 @@ public:
   virtual ~samplePDFFDBase();
 
   int GetNDim(){return nDimensions;} //DB Function to differentiate 1D or 2D binning
-  std::string GetName() const {return samplename;}
+  std::string GetTitle() const {return SampleTitle;}
+  //std::string GetTitle() const {return SampleDetID;}
 
   std::string GetXBinVarName() {return XVarStr;}
   std::string GetYBinVarName() {return YVarStr;}
@@ -237,12 +238,12 @@ public:
   /// @brief Keep track of the dimensions of the sample binning
   int nDimensions = M3::_BAD_INT_;
   /// @brief A unique ID for each sample based on powers of two for quick binary operator comparisons 
-  std::string SampleDetID;
+  std::string SampleName;
   /// holds "TrueNeutrinoEnergy" and the strings used for the sample binning.
   std::vector<std::string> SplineBinnedVars;
 
   /// @brief the name of this sample e.g."muon-like"
-  std::string samplename;
+  std::string SampleTitle;
 
   /// @brief Information to store for normalisation pars
   std::vector<XsecNorms4> xsec_norms;

--- a/splines/splineFDBase.cpp
+++ b/splines/splineFDBase.cpp
@@ -50,7 +50,6 @@ void splineFDBase::cleanUpMemory() {
   CleanVector(SplineInterpolationTypes);
   CleanVector(nOscChans);
   CleanVector(nSplineParams);
-  CleanVector(DetIDs);
   CleanVector(DimensionLabels);
   CleanVector(SampleNames);
   CleanVector(Dimensions);
@@ -61,7 +60,6 @@ void splineFDBase::cleanUpMemory() {
 
 //****************************************
 void splineFDBase::AddSample(const std::string& SampleName,
-                             const std::string& DetID,
                              const std::vector<std::string>& OscChanFileNames,
                              const std::vector<std::string>& SplineVarNames)
 //Adds samples to the large array
@@ -70,25 +68,24 @@ void splineFDBase::AddSample(const std::string& SampleName,
   SampleNames.push_back(SampleName);
   Dimensions.push_back(int(SplineVarNames.size()));
   DimensionLabels.push_back(SplineVarNames);
-  DetIDs.push_back(DetID);
 
-  int nSplineParam = xsec->GetNumParamsFromSampleName(DetID, SystType::kSpline);
+  int nSplineParam = xsec->GetNumParamsFromSampleName(SampleName, SystType::kSpline);
   nSplineParams.push_back(nSplineParam);
 
   //This holds the global index of the spline i.e. 0 -> _fNumPar
-  std::vector<int> GlobalSystIndex_Sample = xsec->GetGlobalSystIndexFromSampleName(DetID, SystType::kSpline);
+  std::vector<int> GlobalSystIndex_Sample = xsec->GetGlobalSystIndexFromSampleName(SampleName, SystType::kSpline);
   //Keep track of this for all the samples
   GlobalSystIndex.push_back(GlobalSystIndex_Sample);
 
-  std::vector<SplineInterpolation> SplineInterpolation_Sample = xsec->GetSplineInterpolationFromSampleName(DetID);
+  std::vector<SplineInterpolation> SplineInterpolation_Sample = xsec->GetSplineInterpolationFromSampleName(SampleName);
   // Keep track of this for all samples
   SplineInterpolationTypes.push_back(SplineInterpolation_Sample);
 
-  std::vector<std::string> SplineFileParPrefixNames_Sample = xsec->GetSplineParsNamesFromSampleName(DetID);
+  std::vector<std::string> SplineFileParPrefixNames_Sample = xsec->GetSplineParsNamesFromSampleName(SampleName);
   SplineFileParPrefixNames.push_back(SplineFileParPrefixNames_Sample);
 
   MACH3LOG_INFO("Create SplineModeVecs_Sample");
-  std::vector<std::vector<int>> SplineModeVecs_Sample = StripDuplicatedModes(xsec->GetSplineModeVecFromSampleName(DetID));
+  std::vector<std::vector<int>> SplineModeVecs_Sample = StripDuplicatedModes(xsec->GetSplineModeVecFromSampleName(SampleName));
   MACH3LOG_INFO("SplineModeVecs_Sample is of size {}", SplineModeVecs_Sample.size());
   SplineModeVecs.push_back(SplineModeVecs_Sample);
 
@@ -669,7 +666,6 @@ void splineFDBase::PrintSampleDetails(const std::string& SampleName) const
 
   MACH3LOG_INFO("Details about sample: {:<20}", SampleNames[iSample]);
   MACH3LOG_INFO("\t Dimension: {:<35}", Dimensions[iSample]);
-  MACH3LOG_INFO("\t DetID: {:<35}", DetIDs[iSample]);
   MACH3LOG_INFO("\t nSplineParam: {:<35}", nSplineParams[iSample]);
   MACH3LOG_INFO("\t nOscChan: {:<35}", nOscChans[iSample]);
 }

--- a/splines/splineFDBase.cpp
+++ b/splines/splineFDBase.cpp
@@ -72,23 +72,23 @@ void splineFDBase::AddSample(const std::string& SampleName,
   DimensionLabels.push_back(SplineVarNames);
   DetIDs.push_back(DetID);
 
-  int nSplineParam = xsec->GetNumParamsFromDetID(DetID, SystType::kSpline);
+  int nSplineParam = xsec->GetNumParamsFromSampleName(DetID, SystType::kSpline);
   nSplineParams.push_back(nSplineParam);
 
   //This holds the global index of the spline i.e. 0 -> _fNumPar
-  std::vector<int> GlobalSystIndex_Sample = xsec->GetGlobalSystIndexFromDetID(DetID, SystType::kSpline);
+  std::vector<int> GlobalSystIndex_Sample = xsec->GetGlobalSystIndexFromSampleName(DetID, SystType::kSpline);
   //Keep track of this for all the samples
   GlobalSystIndex.push_back(GlobalSystIndex_Sample);
 
-  std::vector<SplineInterpolation> SplineInterpolation_Sample = xsec->GetSplineInterpolationFromDetID(DetID);
+  std::vector<SplineInterpolation> SplineInterpolation_Sample = xsec->GetSplineInterpolationFromSampleName(DetID);
   // Keep track of this for all samples
   SplineInterpolationTypes.push_back(SplineInterpolation_Sample);
 
-  std::vector<std::string> SplineFileParPrefixNames_Sample = xsec->GetSplineParsNamesFromDetID(DetID);
+  std::vector<std::string> SplineFileParPrefixNames_Sample = xsec->GetSplineParsNamesFromSampleName(DetID);
   SplineFileParPrefixNames.push_back(SplineFileParPrefixNames_Sample);
 
   MACH3LOG_INFO("Create SplineModeVecs_Sample");
-  std::vector<std::vector<int>> SplineModeVecs_Sample = StripDuplicatedModes(xsec->GetSplineModeVecFromDetID(DetID));
+  std::vector<std::vector<int>> SplineModeVecs_Sample = StripDuplicatedModes(xsec->GetSplineModeVecFromSampleName(DetID));
   MACH3LOG_INFO("SplineModeVecs_Sample is of size {}", SplineModeVecs_Sample.size());
   SplineModeVecs.push_back(SplineModeVecs_Sample);
 

--- a/splines/splineFDBase.h
+++ b/splines/splineFDBase.h
@@ -30,7 +30,6 @@ class splineFDBase : public SplineBase {
 
     /// @brief add oscillation channel to spline monolith
     void AddSample(const std::string& SampleName,
-                   const std::string& DetID,
                    const std::vector<std::string>& OscChanFileNames,
                    const std::vector<std::string>& SplineVarNames);
     /// @brief flatten multidimensional spline array into proper monolith
@@ -61,7 +60,7 @@ class splineFDBase : public SplineBase {
     void PrepForReweight();
     void getSplineCoeff_SepMany(int splineindex, M3::float_t *& xArray, M3::float_t *&manyArray);
     void PrintBinning(TAxis* Axis) const;
-    /// @brief Print info like DetID number of spline params etc.
+    /// @brief Print info like Sample ID of spline params etc.
     void PrintSampleDetails(const std::string& SampleName) const;
     void PrintArrayDetails(const std::string& SampleName) const;
 
@@ -84,7 +83,6 @@ class splineFDBase : public SplineBase {
     std::vector<std::string> SampleNames;
     std::vector<int> Dimensions;
     std::vector<std::vector<std::string>> DimensionLabels;
-    std::vector<std::string> DetIDs;
     std::vector<int> nSplineParams;
     std::vector<int> nOscChans;
 
@@ -99,7 +97,7 @@ class splineFDBase : public SplineBase {
     /// systematics which affect that sample.
     std::vector< std::vector<int> > GlobalSystIndex;
     /// @brief spline interpolation types for each sample. These vectors are from
-    /// a call to GetSplineInterpolationFromDetID()
+    /// a call to GetSplineInterpolationFromSampleID()
     std::vector< std::vector<SplineInterpolation> > SplineInterpolationTypes;
 
     /// name of each spline parameter


### PR DESCRIPTION
# Pull request description
Instead of reading in a separate field "DetID" from a sample config instead the "SampleName" is used and a separate field of "SampleTitle" has been added so that it can be used for plotting names.

This addresses this issue: https://github.com/mach3-software/MaCh3/issues/373

## Changes or fixes
Renaming of covariance class functions where I felt it was appropriate to use SampleName rather than DetId.
samplename is now SampleTitle and samplePDFFDBase::GetName is samplePDFFDBase::GetTitle
SampleDetID is now SampleName.
DetID in parameter yaml is now SampleID
Additional check in FitterBase on whether the SamplePDF object has a unique name.

## Examples
CovarianceXsec::AppliesToDetID -> CovarianceXsec::AppliesToSampleName
