### PR TITLE
feat: Turn on MO switching by default

### DIFF
--- a/covariance/covarianceOsc.cpp
+++ b/covariance/covarianceOsc.cpp
@@ -30,7 +30,7 @@ covarianceOsc::covarianceOsc(const std::vector<std::string>& YAMLFile, std::stri
   CheckInitialisation("sin2th_23", kSinTheta23);
 
   /// @todo KS: Technically if we would like to use PCA we have to initialise parts here...
-  flipdelM = false;
+  flipdelM = true;
 
   randomize();
   Print();


### PR DESCRIPTION
# Pull request description

As discussed in `#mach3_crossexperiment` on Slack, turn MO switching on by default, leaving the ability to switch it off with `setFlipDeltaM23` is desired.

(Fixed version of #377 to avoid CI problem)