### PR TITLE
feat: Set Burn-In from YAML file

### DIFF
--- a/Diagnostics/ProcessMCMC.cpp
+++ b/Diagnostics/ProcessMCMC.cpp
@@ -97,6 +97,17 @@ void ProcessMCMC(const std::string& inputFile)
   Processor->SetPost2DPlotThreshold(GetFromManager<double>(Settings["Post2DPlotThreshold"], 0.2));
 
   Processor->Initialise();
+
+  if(Settings["BurnInSteps"])
+  {
+    Processor->SetStepCut(Settings["BurnInSteps"].as<int>());
+  }
+  else
+  {
+    MACH3LOG_WARN("BurnInSteps not set, defaulting to 20%");
+    Processor->SetStepCut(static_cast<int>(Processor->GetnSteps()/5));
+  }
+
   if(Settings["Thinning"])
   {
     if(Settings["Thinning"][0].as<bool>()){

--- a/mcmc/MCMCProcessor.cpp
+++ b/mcmc/MCMCProcessor.cpp
@@ -2046,9 +2046,7 @@ void MCMCProcessor::ScanInput() {
   PrintInfo();
 
   nSteps = Chain->GetMaximum("step");
-  // Set the step cut to be 20%
-  int cut = nSteps/5;
-  SetStepCut(cut);
+  SetStepCut(0);
 }
 
 // ****************************


### PR DESCRIPTION
# Pull request description

Initialize burn in cut to 0, and set it from YAML file in `ProcessMCMC`, instead of hardcoding it to 1/5.

