### PR TITLE
bugfix: Fix CircularPrior logic

### DIFF
--- a/covariance/covarianceOsc.cpp
+++ b/covariance/covarianceOsc.cpp
@@ -68,9 +68,9 @@ void covarianceOsc::proposeStep() {
 void covarianceOsc::CircularPrior(const int index, const double LowBound, const double UpBound) {
 // *************************************
   if(_fPropVal[index] > UpBound) {
-    _fPropVal[index] = LowBound + std::fmod(_fPropVal[index], UpBound);
+    _fPropVal[index] = LowBound + std::fmod(_fPropVal[index] - UpBound, UpBound - LowBound);
   } else if (_fPropVal[index] < LowBound) {
-    _fPropVal[index] = UpBound + std::fmod(_fPropVal[index], UpBound);
+    _fPropVal[index] = UpBound - std::fmod(LowBound - _fPropVal[index], UpBound - LowBound);
   }
 }
 


### PR DESCRIPTION
# Pull request description

This fixes a few problems with `CircularPrior()` (used for delta_cp).

First, e.g. with delta_cp, this won't actually be cyclical with period 2pi, but with period pi. For example, we want 2.5pi -> 2.5pi - 2pi = 0.5pi. But currently, this sends 2.5pi -> -pi + 0.5pi = -0.5pi.

Second, the logic is broken and won't generalize to things besides delta_cp. The signs of the `fmod` terms will be the wrong sign if `UpBound` is less than zero, or if `LowBound` is more than zero. Also, if one of the two bounds is zero, you'll get a divide by zero error.
