### PR TITLE
feat: Override EqualBinning setting when not using binnedosc

### DIFF
--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -69,7 +69,10 @@ void samplePDFFDBase::ReadSampleConfig()
 
   // TN override the sample setting if not using binned oscillation
   if (EqualBinningPerOscChannel) {
-    if (YAML::LoadFile(NuOscillatorConfigFile)["General"]["CalculationType"].as<std::string>() != "Binned") EqualBinningPerOscChannel = false;
+    if (YAML::LoadFile(NuOscillatorConfigFile)["General"]["CalculationType"].as<std::string>() != "Binned") {
+      MACH3LOG_WARN("Tried using EqualBinningPerOscChannel while using Unbinned oscillation calculation, changing EqualBinningPerOscChannel to false");
+      EqualBinningPerOscChannel = false;
+    }
   }
   
   //Default TestStatistic is kPoisson

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -66,6 +66,11 @@ void samplePDFFDBase::ReadSampleConfig()
   SampleDetID = Get<std::string>(SampleManager->raw()["DetID"], __FILE__ , __LINE__);
   NuOscillatorConfigFile = Get<std::string>(SampleManager->raw()["NuOsc"]["NuOscConfigFile"], __FILE__ , __LINE__);
   EqualBinningPerOscChannel = Get<bool>(SampleManager->raw()["NuOsc"]["EqualBinningPerOscChannel"], __FILE__ , __LINE__);
+
+  // TN override the sample setting if not using binned oscillation
+  if (EqualBinningPerOscChannel) {
+    if (YAML::LoadFile(NuOscillatorConfigFile)["General"]["CalculationType"].as<std::string>() != "Binned") EqualBinningPerOscChannel = false;
+  }
   
   //Default TestStatistic is kPoisson
   //ETA: this can be configured with samplePDFBase::SetTestStatistic()


### PR DESCRIPTION
# Pull request description
Because of the EqualBinningPerOscChannel handling, binned osc configuration and switching between binned and unbinned oscillation calculation for NuOscillator are unnecessary difficult to be set properly.

EqualBinningPerOscChannel comes from sample configuration (multiple configuration files) and serves as a "sort of an indicator" of binned oscillation weights for samplePDFFDBase  (see `samplePDFFDBase::SetupNuOscillator()`). But, the calculation type is set in NuOscillator. As a result, to effectively switch between different calculation types, one needs to edit multiple configuration files, which is rather bacwardy. I would prefer handling the calculation type from NuOscillator config directly.

Not sure whether this might be called a bug or a user experience feature:)

## Changes or fixes

I suggest checking the NuOscillator config for the calculation type and override the sample configuration. This worked for me as an instant work-around (see changes). In longer-term, I guess, keeping and checking both EqualBinningPerOscChannel and a CalculationType as defined in the NuOscillator config file would be better. Something like:

```
...  
NuOscillatorConfigFile = Get<std::string>(SampleManager->raw()["NuOsc"]["NuOscConfigFile"], __FILE__ , __LINE__);  
EqualBinningPerOscChannel = Get<bool>(SampleManager->raw()["NuOsc"]["EqualBinningPerOscChannel"], __FILE__ , __LINE__);  
NuOscillatorCalcType = YAML::LoadFile(NuOscillatorConfigFile)["General"]["CalculationType"].as<std::string>();  
...
```  

## Examples

When setting NuOscillator config to "Unbinned", samplePDF throws from `samplePDFFDBase::SetupNuOscillator()` with 

`Attempted to use equal binning per oscillation channel, but not binning has been set in the NuOscillator::Oscillator object`

if not all the samples are set to `EqualBinningPerOscChannel = false`.

If avoided from within `samplePDFFDBase::SetupNuOscillator()`, samplePDF will keep handling the oscillation weights as binned, though NuOscillator is set to "Unbinned". This leads to runtime errors.