### PR TITLE
bugfix: fix the index of sample llh histograms

### DIFF
--- a/mcmc/FitterBase.cpp
+++ b/mcmc/FitterBase.cpp
@@ -728,7 +728,7 @@ void FitterBase::RunLLHScan() {
           {
             for(int is = 0; is < samples[ivs]->GetNsamples(); ++is)
             {
-              hScanSamSplit[is]->SetBinContent(j+1, 2*sampleSplitllh[is]);
+              hScanSamSplit[SampleIterator]->SetBinContent(j+1, 2*sampleSplitllh[SampleIterator]);
               SampleIterator++;
             }
           }


### PR DESCRIPTION
# Pull request description
I believe these histogram and LLH calculation indices are wrongly iterated over. Histograms reserved for LLHs of `samples[0]` (corresponding to the first `samples[0]->GetNsamples()` of `TotalNSamples` histograms) are being overwritten with LLHs from samples of `samples[ivs]`. We need `SampleIterator` index in here.

Also, is there some logic or reason why to iterate over `samples` and `samples[ivs]` (indices `ivs` and `is`) and not simply from 0 to `TotalNSamples` (see also at least one other loop in `RunLLHScan()`, where no `ivs` and `is` are used)? Like this:

```
for(unsigned int is = 0; is < TotalNSamples; ++is )
{
  hScanSamSplit[is]->SetBinContent(j+1, 2*sampleSplitllh[is]);
}
```

## Changes or fixes
Insert `SampleIterator` index instead of `is` , which runs again from 0 for each `samples[ivs]`.

## Examples
