### PR TITLE
bugfix: Fix typo to make CUDA work properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(MaCh3GPUCompilerOptions INTERFACE)
 
 find_package(CUDAToolkit QUIET)
 # Check if CUDA was found
-if(CUDAToolkit_FOUND AND NOT(MaCh3_GPU_ENABLED))
+if(CUDAToolkit_FOUND AND MaCh3_GPU_ENABLED)
   cmessage(STATUS "CUDA found. Adding CUDA support.")
   set(MaCh3_GPU_ENABLED ON)
   enable_language(CUDA)


### PR DESCRIPTION
# Pull request description
CMakeLists.txt had a typo that didn't allow CUDA to be included if GPU was enabled. 

## Changes or fixes
Changed line if(CUDAToolkit_FOUND AND NOT(MaCh3_GPU_ENABLED)) to if(CUDAToolkit_FOUND AND MaCh3_GPU_ENABLED).

## Examples
![image](https://github.com/user-attachments/assets/a099a9cb-4ceb-4959-a511-9e6bdb7a1328)
