### PR TITLE
feat: Faster Spline Loading

### DIFF
--- a/splines/splineFDBase.cpp
+++ b/splines/splineFDBase.cpp
@@ -865,7 +865,7 @@ void splineFDBase::FillSampleArray(std::string SampleName, std::vector<std::stri
     TSpline3_red* Spline = nullptr;
     TString Syst, Mode;
     int nKnots, SystNum, ModeNum, Var1Bin, Var2Bin, Var3Bin = M3::_BAD_INT_;
-    double x,y, Eval = M3::_BAD_DOUBLE_;
+    double x,y = M3::_BAD_DOUBLE_;
     bool isFlat = true;
 
     std::set<std::string> SplineFileNames;
@@ -889,8 +889,8 @@ void splineFDBase::FillSampleArray(std::string SampleName, std::vector<std::stri
       std::string FullSplineName = std::string(Key->GetName());
 
       if (SplineFileNames.count(FullSplineName) > 0) {
-	MACH3LOG_CRITICAL("Skipping spline - Found a spline whose name has already been encountered before: {}", FullSplineName); 
-	continue;
+        MACH3LOG_CRITICAL("Skipping spline - Found a spline whose name has already been encountered before: {}", FullSplineName);
+        continue;
       }
       SplineFileNames.insert(FullSplineName);
 
@@ -931,10 +931,10 @@ void splineFDBase::FillSampleArray(std::string SampleName, std::vector<std::stri
       }
 
       if (ModeNum == -1) {
-	//DB - If you have splines in the root file that you don't want to use (e.g. removing a mode from a syst), this will cause a throw
-	//     Therefore include as debug warning and continue instead
+      //DB - If you have splines in the root file that you don't want to use (e.g. removing a mode from a syst), this will cause a throw
+      //     Therefore include as debug warning and continue instead
         MACH3LOG_DEBUG("Couldn't find mode for {} in {}. Problem Spline is : {} ", Mode, Syst, FullSplineName);
-	continue;
+        continue;
       }
 
       mySpline = Key->ReadObject<TSpline3>();
@@ -946,9 +946,7 @@ void splineFDBase::FillSampleArray(std::string SampleName, std::vector<std::stri
         isFlat = true;
         for (int iKnot = 0; iKnot < nKnots; iKnot++) {
           mySpline->GetKnot(iKnot, x, y);
-
-          Eval = mySpline->Eval(x);
-          if (Eval < 0.99999 || Eval > 1.00001)
+          if (y < 0.99999 || y > 1.00001)
           {
             isFlat = false;
             break;


### PR DESCRIPTION
# Pull request description
On knot spline eval and Y value should be the same. We can skip spline eval part (this include alos find spline segment).
This make spline loading 5-10% faster.

## Changes or fixes


## Examples
before:
```
[splineFDBase.cpp][info] Number of combinations of Sample, OscChan, Syst and Mode which have entirely flat response: 2694051 / 2760858
[splineFDBase.cpp][info] Total number of splines loaded: 2760858
[splineFDBase.cpp][info] Total number of non-flat splines loaded: 66807
[splineFDBase.cpp][info] Now transferring splines to a monolith if size 2760858
[samplePDFFDBase.cpp][info] --------------------------------
[samplePDFFDBase.cpp][info] Setup Far Detector splines
[splineFDBase.cpp][info] Cleaning up spline memory
[samplePDFFDBase.cpp][info] It took 415.0200 s 
```

after
```
[splineFDBase.cpp][info] Number of combinations of Sample, OscChan, Syst and Mode which have entirely flat response: 2694051 / 2760858
[splineFDBase.cpp][info] Total number of splines loaded: 2760858
[splineFDBase.cpp][info] Total number of non-flat splines loaded: 66807
[splineFDBase.cpp][info] Now transferring splines to a monolith if size 2760858
[samplePDFFDBase.cpp][info] --------------------------------
[samplePDFFDBase.cpp][info] Setup Far Detector splines
[splineFDBase.cpp][info] Cleaning up spline memory
[samplePDFFDBase.cpp][info] It took 399.3021 s
```
