### PR TITLE
feat: SampleName[Sample] might not be initialized

### DIFF
--- a/samplePDF/samplePDFBase.cpp
+++ b/samplePDF/samplePDFBase.cpp
@@ -256,13 +256,13 @@ std::string samplePDFBase::GetSampleName(int Sample) {
 // ***************************************************************************
   if(Sample > nSamples)
   {
-    MACH3LOG_ERROR("You are asking for sample {} of the samplePDF {}. It has only {} samples!", Sample, GetName(), nSamples);
+    MACH3LOG_ERROR("You are asking for sample {} of the samplePDF {}. It has only {} samples!", Sample, GetTitle(), nSamples);
     throw MaCh3Exception(__FILE__ , __LINE__ );
   }
 
   if(SampleName.size() <= Sample)
   {
-    MACH3LOG_ERROR("The name for sample {} of the samplePDF {} was not initialized! Check whether you have set all the sample names correctly first!", Sample, GetName());
+    MACH3LOG_ERROR("The name for sample {} of the samplePDF {} was not initialized! Check whether you have set all the sample names correctly first!", Sample, GetTitle());
     throw MaCh3Exception(__FILE__, __LINE__);
   }
 

--- a/samplePDF/samplePDFBase.cpp
+++ b/samplePDF/samplePDFBase.cpp
@@ -260,6 +260,16 @@ std::string samplePDFBase::GetSampleName(int Sample) {
    throw MaCh3Exception(__FILE__ , __LINE__ );
   }
 
+  if(SampleName.size() <= Sample)
+  {
+    unsigned int origsize = SampleName.size();
+    MACH3LOG_WARN("The name for sample {} was not initialized. I will set it to \"{}_NoNameSample_{}\".", Sample, GetName(), Sample);
+    SampleName.resize(Sample+1);
+    for (unsigned int i = origsize; i <= Sample; ++i) {
+     SampleName[i] = GetName()+"_NoNameSample_"+std::to_string(i); 
+    }
+  }
+
   return SampleName[Sample];
 }
 

--- a/samplePDF/samplePDFBase.cpp
+++ b/samplePDF/samplePDFBase.cpp
@@ -263,9 +263,10 @@ std::string samplePDFBase::GetSampleName(int Sample) {
   if(SampleName.size() <= Sample)
   {
     unsigned int origsize = SampleName.size();
-    MACH3LOG_WARN("The name for sample {} was not initialized. I will set it to \"{}_NoNameSample_{}\".", Sample, GetName(), Sample);
     SampleName.resize(Sample+1);
+    
     for (unsigned int i = origsize; i <= Sample; ++i) {
+     MACH3LOG_WARN("The name for sample {} was not initialized. I will set it to \"{}_NoNameSample_{}\".", i, GetName(), i);
      SampleName[i] = GetName()+"_NoNameSample_"+std::to_string(i); 
     }
   }

--- a/samplePDF/samplePDFBase.cpp
+++ b/samplePDF/samplePDFBase.cpp
@@ -256,19 +256,14 @@ std::string samplePDFBase::GetSampleName(int Sample) {
 // ***************************************************************************
   if(Sample > nSamples)
   {
-    MACH3LOG_ERROR("You are asking for sample {}. I only have {}", Sample, nSamples);
-   throw MaCh3Exception(__FILE__ , __LINE__ );
+    MACH3LOG_ERROR("You are asking for sample {} of the samplePDF {}. It has only {} samples!", Sample, GetName(), nSamples);
+    throw MaCh3Exception(__FILE__ , __LINE__ );
   }
 
   if(SampleName.size() <= Sample)
   {
-    unsigned int origsize = SampleName.size();
-    SampleName.resize(Sample+1);
-    
-    for (unsigned int i = origsize; i <= Sample; ++i) {
-     MACH3LOG_WARN("The name for sample {} was not initialized. I will set it to \"{}_NoNameSample_{}\".", i, GetName(), i);
-     SampleName[i] = GetName()+"_NoNameSample_"+std::to_string(i); 
-    }
+    MACH3LOG_ERROR("The name for sample {} of the samplePDF {} was not initialized! Check whether you have set all the sample names correctly first!", i, GetName());
+    throw MaCh3Exception(__FILE__, __LINE__);
   }
 
   return SampleName[Sample];

--- a/samplePDF/samplePDFBase.cpp
+++ b/samplePDF/samplePDFBase.cpp
@@ -260,7 +260,7 @@ std::string samplePDFBase::GetSampleName(int Sample) {
     throw MaCh3Exception(__FILE__ , __LINE__ );
   }
 
-  if(SampleName.size() <= Sample)
+  if(int(SampleName.size()) <= Sample)
   {
     MACH3LOG_ERROR("The name for sample {} of the samplePDF {} was not initialized! Check whether you have set all the sample names correctly first!", Sample, GetTitle());
     throw MaCh3Exception(__FILE__, __LINE__);

--- a/samplePDF/samplePDFBase.cpp
+++ b/samplePDF/samplePDFBase.cpp
@@ -262,7 +262,7 @@ std::string samplePDFBase::GetSampleName(int Sample) {
 
   if(SampleName.size() <= Sample)
   {
-    MACH3LOG_ERROR("The name for sample {} of the samplePDF {} was not initialized! Check whether you have set all the sample names correctly first!", i, GetName());
+    MACH3LOG_ERROR("The name for sample {} of the samplePDF {} was not initialized! Check whether you have set all the sample names correctly first!", Sample, GetName());
     throw MaCh3Exception(__FILE__, __LINE__);
   }
 


### PR DESCRIPTION
# Pull request description
There is an inherent problem here, since the `SampleName[Sample]` might not be initialized, there is no default SampleName[] in the samplePDF constructor. This leads to runtime errors when trying to do tricks and  non-standard gymnastics with the samplePDF objects.

## Changes or fixes
What I propose here is to check whether the `SampleName` vector actually has `Sample` index at all. If not (the name was not initialized), assign some default names to the samples (from where it ends up to whatever was called). Might be later reassigned to some other name, no problem with that.

Of course I am open to other solutions, like initializing the names somewhere else, but I am not really sure at what point the number of samples in the samplePDF is settled for good. Let me know.

Also, for much better user experience, we should make sure there are no samples with identical names (rename those), as any root data saving will overwrite the samples with the same name.

## Examples
This came to me when I set `LLHScanBySample: true` but used only FD samplePDFs. It went down with an error, because the names of FD samplePDFs osc channel samples were never really initialized.

Also this might be an extra issue of `FitterBase.cxx`, as `RunLLHScan` will iterate over samples of FD samplePDFs (osc channel samples) with `LLHScanBySample: true`, which I guess was meant only to run over ND samples.