### PR TITLE
feat: get sample name fix

### DIFF
--- a/python/samplePDF.cpp
+++ b/python/samplePDF.cpp
@@ -13,6 +13,16 @@ public:
     using samplePDFBase::samplePDFBase;
 
     /* Trampoline (need one for each virtual function) */
+    std::string GetSampleName(int iSample) const override {
+        PYBIND11_OVERRIDE_PURE(
+            std::string,          /* Return type */
+            samplePDFBase, /* Parent class */
+            GetSampleName, /* Name of function in C++ (must match Python name) */
+            iSample         /* Argument(s) */
+        );
+    }
+
+    /* Trampoline (need one for each virtual function) */
     void reweight() override {
         PYBIND11_OVERRIDE_PURE(
             void,          /* Return type */

--- a/samplePDF/samplePDFBase.cpp
+++ b/samplePDF/samplePDFBase.cpp
@@ -251,19 +251,6 @@ double samplePDFBase::getTestStatLLH(const double data, const double mc, const d
 }
 
 // ***************************************************************************
-//KS: Sample getter
-std::string samplePDFBase::GetSampleName(int Sample) {
-// ***************************************************************************
-  if(Sample > nSamples)
-  {
-    MACH3LOG_ERROR("You are asking for sample {}. I only have {}", Sample, nSamples);
-   throw MaCh3Exception(__FILE__ , __LINE__ );
-  }
-
-  return SampleName[Sample];
-}
-
-// ***************************************************************************
 // CW: Silence cout and cerr. Last is risky but psyche persists on spamming both
 void samplePDFBase::QuietPlease() {
 // ***************************************************************************

--- a/samplePDF/samplePDFBase.h
+++ b/samplePDF/samplePDFBase.h
@@ -31,7 +31,7 @@ class samplePDFBase
 
   virtual inline M3::int_t GetNsamples(){ return nSamples; };
   virtual inline std::string GetTitle()const {return "samplePDF";};
-  virtual std::string GetSampleName(int Sample) = 0;
+  virtual std::string GetSampleName(int Sample) const = 0;
   virtual inline double getSampleLikelihood(const int isample){(void) isample; return GetLikelihood();};
 
   /// @brief Return pointer to MaCh3 modes

--- a/samplePDF/samplePDFBase.h
+++ b/samplePDF/samplePDFBase.h
@@ -31,7 +31,7 @@ class samplePDFBase
 
   virtual inline M3::int_t GetNsamples(){ return nSamples; };
   virtual inline std::string GetTitle()const {return "samplePDF";};
-  virtual std::string GetSampleName(int Sample);
+  virtual std::string GetSampleName(int Sample) = 0;
   virtual inline double getSampleLikelihood(const int isample){(void) isample; return GetLikelihood();};
 
   /// @brief Return pointer to MaCh3 modes
@@ -104,8 +104,6 @@ protected:
   M3::int_t nSamples;
   /// KS: number of dimension for this sample
   int nDims;
-  /// Name of Sample
-  std::vector<std::string> SampleName;
 
   /// Holds information about used Generator and MaCh3 modes
   MaCh3Modes* Modes;

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -1389,8 +1389,12 @@ void samplePDFFDBase::SetupNuOscillator() {
   OscParams = OscCov->GetOscParsFromSampleName(SampleName);
 }
 
-std::string samplePDFFDBase::GetSampleName(int iSample) {
+std::string samplePDFFDBase::GetSampleName(int iSample) const {
+  //ETA - this is just to suppress a warning for an unused variable
   (void)iSample;
+
+  //ETA - extra safety to make sure SampleName is actually set
+  // probably unnecessary due to the requirement for it to be in the yaml config
   if(SampleName.length() == 0){
     MACH3LOG_ERROR("No sample name provided");
     MACH3LOG_ERROR("Please provide a SampleName in your configuration file: {}", SampleManager->GetFileName());

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -28,7 +28,7 @@ public:
   virtual ~samplePDFFDBase();
 
   int GetNDim(){return nDimensions;} //DB Function to differentiate 1D or 2D binning
-  std::string GetSampleName(int iSample = 0) override;
+  std::string GetSampleName(int iSample = 0) const override;
   std::string GetTitle() const {return SampleTitle;}
 
   std::string GetXBinVarName() {return XVarStr;}

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -28,7 +28,7 @@ public:
   virtual ~samplePDFFDBase();
 
   int GetNDim(){return nDimensions;} //DB Function to differentiate 1D or 2D binning
-  std::string GetName() const {return SampleName;}
+  std::string GetSampleName(int iSample = 0) override;
   std::string GetTitle() const {return SampleTitle;}
 
   std::string GetXBinVarName() {return XVarStr;}


### PR DESCRIPTION
# Pull request description
Fixing a clashing treatment of SampleNames in samplePDFFDBase and samplePDFBase. Removed SampleNames std::vector from samplePDFBase and made GetSampleNames to be pure virtual. All base classes are currently over-riding this function anyway.

## Changes or fixes
- Removing std::vector<std::string> SampleNames from samplePDFBase
- Making GetSampleNames(int iSample) pure virtual so you have to specify how to get the sample name.
- Changing GetName to GetSampleName(int iSample=0) in samplePDFFDBase which isn't ideal as iSample is not used in this function.

## Examples
