### PR TITLE
feat: functional parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build*/
 install/
 Doc/html
 Doc/latex
+.cache/
 
 # Ignore emacs/vim stuff
 *#* 

--- a/covariance/covarianceXsec.cpp
+++ b/covariance/covarianceXsec.cpp
@@ -34,6 +34,7 @@ void covarianceXsec::InitXsecFromConfig() {
   //KS: We know at most how params we expect so reserve memory for max possible params. Later we will shrink to size to not waste memory. Reserving means slightly faster loading and possible less memory fragmentation.
   NormParams.reserve(_fNumPar);
   SplineParams.reserve(_fNumPar);
+  FuncParams.reserve(_fNumPar);
 
   int i = 0;
   unsigned int ParamCounter[SystType::kSystTypes] = {0};
@@ -69,6 +70,7 @@ void covarianceXsec::InitXsecFromConfig() {
       ParamCounter[SystType::kNorm]++;
     } else if(param["Systematic"]["Type"].as<std::string>() == SystType_ToString(SystType::kFunc)){
       _fParamType[i] = SystType::kFunc;
+      FuncParams.push_back(GetFuncPars(param["Systematic"], i));
       _fSystToGlobalSystIndexMap[SystType::kFunc].insert(std::make_pair(ParamCounter[SystType::kFunc], i));
       ParamCounter[SystType::kFunc]++;
     } else{
@@ -93,6 +95,7 @@ void covarianceXsec::InitXsecFromConfig() {
   //KS We resized them above to all params to fight memory fragmentation, now let's resize to fit only allocated memory to save RAM
   NormParams.shrink_to_fit();
   SplineParams.shrink_to_fit();
+  FuncParams.shrink_to_fit();
 }
 
 // ********************************************
@@ -260,6 +263,60 @@ XsecSplines1 covarianceXsec::GetXsecSpline(const YAML::Node& param) {
   Spline._fSplineModes = GetFromManager(param["SplineInformation"]["Mode"], std::vector<int>(), __FILE__ , __LINE__);
 
   return Spline;
+}
+
+// ********************************************
+// Get Func params
+FuncPars covarianceXsec::GetFuncPars(const YAML::Node& param, const int Index) {
+// ********************************************
+  FuncPars func;
+  func.name = GetParFancyName(Index);
+  func.pdgs = GetFromManager<std::vector<int>>(param["NeutrinoFlavour"], std::vector<int>(), __FILE__ , __LINE__);
+  func.targets = GetFromManager<std::vector<int>>(param["TargetNuclei"], std::vector<int>(), __FILE__ , __LINE__);
+  func.modes = GetFromManager<std::vector<int>>(param["Mode"], std::vector<int>(), __FILE__ , __LINE__);
+  func.preoscpdgs = GetFromManager<std::vector<int>>(param["NeutrinoFlavourUnosc"], std::vector<int>(), __FILE__ , __LINE__);
+
+  // HH - Copied from GetXsecNorm
+  int NumKinematicCuts = 0;
+  if(param["KinematicCuts"]){
+
+    NumKinematicCuts = int(param["KinematicCuts"].size());
+
+    std::vector<std::string> TempKinematicStrings;
+    std::vector<std::vector<double>> TempKinematicBounds;
+    //First element of TempKinematicBounds is always -999, and size is then 3
+    for(int KinVar_i = 0 ; KinVar_i < NumKinematicCuts ; ++KinVar_i){
+      //ETA: This is a bit messy, Kinematic cuts is a list of maps
+      for (YAML::const_iterator it = param["KinematicCuts"][KinVar_i].begin();it!=param["KinematicCuts"][KinVar_i].end();++it) {
+        TempKinematicStrings.push_back(it->first.as<std::string>());
+        TempKinematicBounds.push_back(it->second.as<std::vector<double>>());
+      }
+      if(TempKinematicStrings.size() == 0) {
+        MACH3LOG_ERROR("Recived a KinematicCuts node but couldn't read the contents (it's a list of single-element dictionaries (python) = map of pairs (C++))");
+        MACH3LOG_ERROR("For Param {}", func.name);
+        throw MaCh3Exception(__FILE__, __LINE__);
+      }
+    }//KinVar_i
+    func.KinematicVarStr = TempKinematicStrings;
+    func.Selection = TempKinematicBounds;
+  }
+  func.index = Index;
+  return func;
+}
+
+// ********************************************
+// HH: Grab the Functional parameters for the relevant DetID
+const std::vector<FuncPars> covarianceXsec::GetFuncParsFromDetID(const std::string& DetID) {
+  // ********************************************
+  std::vector<FuncPars> returnVec;
+  for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kFunc]) {
+    auto &FuncIndex = pair.first;
+    auto &GlobalIndex = pair.second;
+    if (AppliesToDetID(GlobalIndex, DetID)) {
+      returnVec.push_back(FuncParams[FuncIndex]);
+    }
+  }
+  return returnVec;
 }
 
 // ********************************************

--- a/covariance/covarianceXsec.cpp
+++ b/covariance/covarianceXsec.cpp
@@ -301,6 +301,7 @@ FuncPars covarianceXsec::GetFuncPars(const YAML::Node& param, const int Index) {
     func.Selection = TempKinematicBounds;
   }
   func.index = Index;
+  func.valuePtr = retPointer(Index);
   return func;
 }
 

--- a/covariance/covarianceXsec.h
+++ b/covariance/covarianceXsec.h
@@ -72,6 +72,8 @@ class covarianceXsec : public covarianceBase {
     const std::vector<int> GetSystIndexFromDetID(const std::string& DetID, const SystType Type);
     /// @brief DB Get norm/func parameters depending on given DetID
     const std::vector<XsecNorms4> GetNormParsFromDetID(const std::string& DetID);
+    /// @brief HH Get functional parameters for the relevant DetID
+    const std::vector<FuncPars> GetFuncParsFromDetID(const std::string& DetID);
 
     /// @brief KS: For most covariances prior and fparInit (prior) are the same, however for Xsec those can be different
     std::vector<double> getNominalArray() override
@@ -139,6 +141,10 @@ class covarianceXsec : public covarianceBase {
     /// @param param Yaml node describing param
     /// @param Index Global parameter index
     inline XsecNorms4 GetXsecNorm(const YAML::Node& param, const int Index);
+    /// @brief Get Func params
+    /// @param param Yaml node describing param
+    /// @param Index Global parameter index
+    inline FuncPars GetFuncPars(const YAML::Node& param, const int Index);
     /// @brief Get Spline params
     /// @param param Yaml node describing param
     inline XsecSplines1 GetXsecSpline(const YAML::Node& param);
@@ -160,4 +166,7 @@ class covarianceXsec : public covarianceBase {
 
     /// Vector containing info for normalisation systematics
     std::vector<XsecNorms4> NormParams;
+
+    /// Vector containing info for functional systematics
+    std::vector<FuncPars> FuncParams;
 };

--- a/python/samplePDF.cpp
+++ b/python/samplePDF.cpp
@@ -198,6 +198,15 @@ public:
                            /* Argument(s) */
         );
     }
+
+    void RegisterFunctionalParameters() override {
+        PYBIND11_OVERRIDE_PURE_NAME(
+            void,
+            samplePDFFDBase,
+            "register_functional_parameters",
+            RegisterFunctionalParameters
+        );
+    }
 };
 
 void initSamplePDF(py::module &m){

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -186,6 +186,9 @@ struct FuncPars {
 
   /// Parameter value pointer
   const double* valuePtr;
+
+  /// Function pointer
+  FuncParFuncType* funcPtr;
 };
 
 /// Make an enum of the spline interpolation type

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -151,6 +151,9 @@ struct FuncPars {
   /// Parameter number of this functional in current systematic model
   int index;
 
+  /// Parameter value pointer
+  const double* valuePtr;
+
 };
 
 

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -117,6 +117,43 @@ constexpr unsigned int str2int(const char* str, int h = 0) {
   return !str[h] ? 5381 : (str2int(str, h+1) * 33) ^ str[h];
 }
 
+// HH - a shorthand type for funcpar functions
+using FuncParFuncType = std::function<void (const double*, std::size_t, std::size_t)>;
+// *******************
+/// @brief HH - Functional parameters
+/// Carrier for whether you want to apply a systematic to an event or not
+struct FuncPars {
+// *******************
+  /// Name of parameters
+  std::string name;
+  /// Mode which parameter applies to
+  std::vector<int> modes;
+  /// Horn currents which parameter applies to
+  std::vector<int> horncurrents;
+  /// PDG which parameter applies to
+  std::vector<int> pdgs;
+  /// Preosc PDG which parameter applies to
+  std::vector<int> preoscpdgs;
+  /// Targets which parameter applies to
+  std::vector<int> targets;
+  /// Does this parameter have kinematic bounds
+  bool hasKinBounds;
+  /// Generic vector contain enum relating to a kinematic variable
+  /// and lower and upper bounds. This can then be passed to IsEventSelected
+  std::vector< std::vector<double> > Selection;
+
+  /// Generic vector containing the string of kinematic type
+  /// This then needs to be converted to a kinematic type enum
+  /// within a samplePDF daughter class
+  /// The bounds for each kinematic variable are given in Selection
+  std::vector< std::string > KinematicVarStr;
+
+  /// Parameter number of this functional in current systematic model
+  int index;
+
+};
+
+
 // *******************
 /// @brief ETA - Normalisations for cross-section parameters
 /// Carrier for whether you want to apply a systematic to an event or not

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -117,6 +117,39 @@ constexpr unsigned int str2int(const char* str, int h = 0) {
   return !str[h] ? 5381 : (str2int(str, h+1) * 33) ^ str[h];
 }
 
+// *******************
+/// @brief ETA - Normalisations for cross-section parameters
+/// Carrier for whether you want to apply a systematic to an event or not
+struct XsecNorms4 {
+// *******************
+  /// Name of parameters
+  std::string name;
+  /// Mode which parameter applies to
+  std::vector<int> modes;
+  /// Horn currents which parameter applies to
+  std::vector<int> horncurrents;
+  /// PDG which parameter applies to
+  std::vector<int> pdgs;
+  /// Preosc PDG which parameter applies to
+  std::vector<int> preoscpdgs;
+  /// Targets which parameter applies to
+  std::vector<int> targets;
+  /// Does this parameter have kinematic bounds
+  bool hasKinBounds;
+  /// Generic vector contain enum relating to a kinematic variable
+  /// and lower and upper bounds. This can then be passed to IsEventSelected
+  std::vector< std::vector<double> > Selection;
+
+  /// Generic vector containing the string of kinematic type
+  /// This then needs to be converted to a kinematic type enum
+  /// within a samplePDF daughter class
+  /// The bounds for each kinematic variable are given in Selection
+  std::vector< std::string > KinematicVarStr;
+
+  /// Parameter number of this normalisation in current systematic model
+  int index;
+};
+
 // HH - a shorthand type for funcpar functions
 using FuncParFuncType = std::function<void (const double*, std::size_t, std::size_t)>;
 // *******************
@@ -154,40 +187,6 @@ struct FuncPars {
   /// Parameter value pointer
   const double* valuePtr;
 
-};
-
-
-// *******************
-/// @brief ETA - Normalisations for cross-section parameters
-/// Carrier for whether you want to apply a systematic to an event or not
-struct XsecNorms4 {
-// *******************
-  /// Name of parameters
-  std::string name;
-  /// Mode which parameter applies to
-  std::vector<int> modes;
-  /// Horn currents which parameter applies to
-  std::vector<int> horncurrents;
-  /// PDG which parameter applies to
-  std::vector<int> pdgs;
-  /// Preosc PDG which parameter applies to
-  std::vector<int> preoscpdgs;
-  /// Targets which parameter applies to
-  std::vector<int> targets;
-  /// Does this parameter have kinematic bounds
-  bool hasKinBounds;
-  /// Generic vector contain enum relating to a kinematic variable
-  /// and lower and upper bounds. This can then be passed to IsEventSelected
-  std::vector< std::vector<double> > Selection;
-
-  /// Generic vector containing the string of kinematic type
-  /// This then needs to be converted to a kinematic type enum
-  /// within a samplePDF daughter class
-  /// The bounds for each kinematic variable are given in Selection
-  std::vector< std::string > KinematicVarStr;
-
-  /// Parameter number of this normalisation in current systematic model
-  int index;
 };
 
 /// Make an enum of the spline interpolation type

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -186,7 +186,6 @@ struct FuncPars {
 
   /// Parameter value pointer
   const double* valuePtr;
-
 };
 
 /// Make an enum of the spline interpolation type

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -387,8 +387,7 @@ void samplePDFFDBase::fillArray() {
   size_t nXBins = int(XBinEdges.size()-1);
   //size_t nYBins = int(YBinEdges.size()-1);
 
-  // HH todo: remove prepfunctionalparameters after checking with ETA
-  // PrepFunctionalParameters();
+  PrepFunctionalParameters();
   if(SplineHandler){
     SplineHandler->Evaluate();
   }
@@ -488,7 +487,7 @@ void samplePDFFDBase::fillArray_MP()  {
   size_t nXBins = int(XBinEdges.size()-1);
   size_t nYBins = int(YBinEdges.size()-1);
 
-  // PrepFunctionalParameters();
+  PrepFunctionalParameters();
   //==================================================
   //Calc Weights and fill Array
   if(SplineHandler){
@@ -716,6 +715,7 @@ void samplePDFFDBase::SetupFunctionalParameters() {
 
 void samplePDFFDBase::applyShifts(int iSample, int iEvent) {
   // Given a sample and event, apply the shifts to the event based on the vector of functional parameter enums
+  // HH: .at() can be replaced with [] for speed if necessary
   for (std::vector<int>::iterator it = funcParsGrid.at(iSample).at(iEvent).begin(); it != funcParsGrid.at(iSample).at(iEvent).end(); ++it) {
     // Check if func exists
     // HH: Commented this out because this if statemnt will get checked very often so very slow. 
@@ -723,7 +723,7 @@ void samplePDFFDBase::applyShifts(int iSample, int iEvent) {
     //   MACH3LOG_ERROR("Functional parameter {} not found in map", *it);
     //   throw MaCh3Exception(__FILE__, __LINE__);
     // }
-    funcParsFuncMap[*it](XsecCov->retPointer(funcParsMap[*it]->index), iSample, iEvent);
+    funcParsFuncMap[*it](funcParsMap[*it]->valuePtr, iSample, iEvent);
   }
 }
 // =================================

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -150,13 +150,16 @@ public:
   // ----- Functional Parameters -----
   /// @brief ETA - a function to setup and pass values to functional parameters where you need to pass a value to some custom reweight calc or engine
   virtual void SetupFunctionalParameters();
+  /// @brief HH - a helper function for RegisterFunctionalParameter
+  void RegisterIndividualFuncPar(std::string fpName, int fpEnum, FuncParFuncType fpFunc);
   /// @brief HH - a experiment-specific function where the maps to actual functions are set up
   virtual void RegisterFunctionalParameters() = 0;
   /// @brief Update the functional parameter values to the latest propsed values. Needs to be called before every new reweight so is called in fillArray 
-  // HH: I don't think this function will be needed
   virtual void PrepFunctionalParameters(){};
   /// @brief ETA - generic function applying shifts
   virtual void applyShifts(int iSample, int iEvent);
+  /// @brief HH - reset the shifted values to the original values
+  virtual void resetShifts(int iSample, int iEvent){(void) iSample; (void) iEvent;};
   /// @brief HH - a vector that stores all the FuncPars struct
   std::vector<FuncPars> funcParsVec;
   /// @brief HH - a map that relates the name of the functional parameter to funcpar enum
@@ -167,9 +170,9 @@ public:
   std::unordered_map<int, FuncParFuncType> funcParsFuncMap;
   /// @brief HH - a grid of vectors of enums for each sample and event
   std::vector<std::vector<std::vector<int>>> funcParsGrid;
+  /// @brief HH - a vector of string names for each functional parameter
+  std::vector<std::string> funcParsNamesVec = {};
   // --------------------------------
-
-
   /// @brief DB Function which determines if an event is selected, where Selection double looks like {{ND280KinematicTypes Var1, douuble LowBound}
   bool IsEventSelected(const int iSample, const int iEvent);
 

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -154,7 +154,7 @@ public:
   virtual void RegisterFunctionalParameters() = 0;
   /// @brief Update the functional parameter values to the latest propsed values. Needs to be called before every new reweight so is called in fillArray 
   // HH: I don't think this function will be needed
-  // virtual void PrepFunctionalParameters(){};
+  virtual void PrepFunctionalParameters(){};
   /// @brief ETA - generic function applying shifts
   virtual void applyShifts(int iSample, int iEvent);
   /// @brief HH - a vector that stores all the FuncPars struct

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -147,12 +147,29 @@ public:
   std::vector<double> SampleYBins;
   //===============================================================================
 
+  // ----- Functional Parameters -----
   /// @brief ETA - a function to setup and pass values to functional parameters where you need to pass a value to some custom reweight calc or engine
-  virtual void SetupFunctionalParameters(){};
+  virtual void SetupFunctionalParameters();
+  /// @brief HH - a experiment-specific function where the maps to actual functions are set up
+  virtual void RegisterFunctionalParameters() = 0;
   /// @brief Update the functional parameter values to the latest propsed values. Needs to be called before every new reweight so is called in fillArray 
-  virtual void PrepFunctionalParameters(){};
+  // HH: I don't think this function will be needed
+  // virtual void PrepFunctionalParameters(){};
   /// @brief ETA - generic function applying shifts
-  virtual void applyShifts(int iSample, int iEvent){(void) iSample; (void) iEvent;};
+  virtual void applyShifts(int iSample, int iEvent);
+  /// @brief HH - a vector that stores all the FuncPars struct
+  std::vector<FuncPars> funcParsVec;
+  /// @brief HH - a map that relates the name of the functional parameter to funcpar enum
+  std::unordered_map<std::string, int> funcParsNamesMap;
+  /// @brief HH - a map that relates the funcpar enum to pointer of FuncPars struct
+  std::unordered_map<int, FuncPars*> funcParsMap;
+  /// @brief HH - a map that relates the funcpar enum to pointer of the actual function
+  std::unordered_map<int, FuncParFuncType> funcParsFuncMap;
+  /// @brief HH - a grid of vectors of enums for each sample and event
+  std::vector<std::vector<std::vector<int>>> funcParsGrid;
+  // --------------------------------
+
+
   /// @brief DB Function which determines if an event is selected, where Selection double looks like {{ND280KinematicTypes Var1, douuble LowBound}
   bool IsEventSelected(const int iSample, const int iEvent);
 

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -152,7 +152,7 @@ public:
   /// @brief ETA - a function to setup and pass values to functional parameters where you need to pass a value to some custom reweight calc or engine
   virtual void SetupFunctionalParameters();
   /// @brief HH - a helper function for RegisterFunctionalParameter
-  void RegisterIndividualFuncPar(std::string fpName, int fpEnum, FuncParFuncType fpFunc);
+  void RegisterIndividualFuncPar(const std::string& fpName, int fpEnum, FuncParFuncType fpFunc);
   /// @brief HH - a experiment-specific function where the maps to actual functions are set up
   virtual void RegisterFunctionalParameters() = 0;
   /// @brief Update the functional parameter values to the latest propsed values. Needs to be called before every new reweight so is called in fillArray 

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -165,7 +165,8 @@ public:
   /// @brief HH - a map that relates the name of the functional parameter to funcpar enum
   std::unordered_map<std::string, int> funcParsNamesMap;
   /// @brief HH - a map that relates the funcpar enum to pointer of FuncPars struct
-  std::unordered_map<int, FuncPars*> funcParsMap;
+  // HH - Changed to a vector of pointers since it's faster than unordered_map and we are using ints as keys
+  std::vector<FuncPars*> funcParsMap;
   /// @brief HH - a map that relates the funcpar enum to pointer of the actual function
   std::unordered_map<int, FuncParFuncType> funcParsFuncMap;
   /// @brief HH - a grid of vectors of enums for each sample and event


### PR DESCRIPTION
# Pull request description
Added an implementation of functional parameter that's hopefully faster and more flexible. 

## Changes or fixes
 - Added a new struct `FuncPars` in Structs.h, similar to spline and norm. 
   - This struct will take a valuePtr and a funcPtr. The former is set by `covarianceXsec::GetFuncPars` and the latter is set by `samplePDFFDBase::SetupFunctionalParameters`. 
 - In samplePDFFDBase, added `applyShift`, `SetupFunctionalParameters`, `RegisterIndividualFuncPar`.
   -  `RegisterFunctionalParameters` and `resetShift` are virtual so they need to be implemented in inherited classes. 

## Examples
A demo can be found in the [MaCh3 tutorial](https://github.com/mach3-software/MaCh3Tutorial/tree/hhua/demo/FunctionalParams) by running:
```
build/bin/KinemDistributionTutorial ./TutorialConfigs/FitterConfig.yaml
```