### PR TITLE
feat: Particle-level histograms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(MaCh3GPUCompilerOptions INTERFACE)
 
 find_package(CUDAToolkit QUIET)
 # Check if CUDA was found
-if(CUDAToolkit_FOUND AND NOT(MaCh3_GPU_ENABLED))
+if(CUDAToolkit_FOUND AND MaCh3_GPU_ENABLED)
   cmessage(STATUS "CUDA found. Adding CUDA support.")
   set(MaCh3_GPU_ENABLED ON)
   enable_language(CUDA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 # CMake version check
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
-project(MaCh3 VERSION 1.4.7 LANGUAGES CXX)
+project(MaCh3 VERSION 1.4.8 LANGUAGES CXX)
 set(MaCh3_VERSION ${PROJECT_VERSION})
 
 option(MaCh3_PYTHON_ENABLED "Whether to build MaCh3 python bindings" OFF)

--- a/Doc/Doxyfile
+++ b/Doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "MaCh3"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.4.5
+PROJECT_NUMBER         = 1.4.8
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/cmake/Modules/NuOscillatorSetup.cmake
+++ b/cmake/Modules/NuOscillatorSetup.cmake
@@ -62,7 +62,7 @@ set(CMAKE_CUDA_ARCHITECTURES_STRING ${CMAKE_CUDA_ARCHITECTURES})
 string(REPLACE " " ";" CMAKE_CUDA_ARCHITECTURES_STRING "${CMAKE_CUDA_ARCHITECTURES}")
 
 if(NOT DEFINED MaCh3_NuOscillatorBranch)
-  set(MaCh3_NuOscillatorBranch "v1.2.2")
+  set(MaCh3_NuOscillatorBranch "v1.3.0")
 endif()
 
 #Try adding Oscillator Class

--- a/covariance/covarianceOsc.cpp
+++ b/covariance/covarianceOsc.cpp
@@ -68,9 +68,9 @@ void covarianceOsc::proposeStep() {
 void covarianceOsc::CircularPrior(const int index, const double LowBound, const double UpBound) {
 // *************************************
   if(_fPropVal[index] > UpBound) {
-    _fPropVal[index] = LowBound + std::fmod(_fPropVal[index], UpBound);
+    _fPropVal[index] = LowBound + std::fmod(_fPropVal[index] - UpBound, UpBound - LowBound);
   } else if (_fPropVal[index] < LowBound) {
-    _fPropVal[index] = UpBound + std::fmod(_fPropVal[index], UpBound);
+    _fPropVal[index] = UpBound - std::fmod(LowBound - _fPropVal[index], UpBound - LowBound);
   }
 }
 

--- a/mcmc/FitterBase.cpp
+++ b/mcmc/FitterBase.cpp
@@ -720,7 +720,7 @@ void FitterBase::RunLLHScan() {
           {
             for(int is = 0; is < samples[ivs]->GetNsamples(); ++is)
             {
-              hScanSamSplit[is]->SetBinContent(j+1, 2*sampleSplitllh[is]);
+              hScanSamSplit[SampleIterator]->SetBinContent(j+1, 2*sampleSplitllh[SampleIterator]);
               SampleIterator++;
             }
           }

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -67,6 +67,14 @@ void samplePDFFDBase::ReadSampleConfig()
   NuOscillatorConfigFile = Get<std::string>(SampleManager->raw()["NuOsc"]["NuOscConfigFile"], __FILE__ , __LINE__);
   EqualBinningPerOscChannel = Get<bool>(SampleManager->raw()["NuOsc"]["EqualBinningPerOscChannel"], __FILE__ , __LINE__);
   
+  // TN override the sample setting if not using binned oscillation
+  if (EqualBinningPerOscChannel) {
+    if (YAML::LoadFile(NuOscillatorConfigFile)["General"]["CalculationType"].as<std::string>() != "Binned") {
+      MACH3LOG_WARN("Tried using EqualBinningPerOscChannel while using Unbinned oscillation calculation, changing EqualBinningPerOscChannel to false");
+      EqualBinningPerOscChannel = false;
+    }
+  }
+
   //Default TestStatistic is kPoisson
   //ETA: this can be configured with samplePDFBase::SetTestStatistic()
   if (CheckNodeExists(SampleManager->raw(), "TestStatistic")) {
@@ -1444,9 +1452,9 @@ double samplePDFFDBase::GetLikelihood() {
   #ifdef MULTITHREAD
   #pragma omp parallel for collapse(2) reduction(+:negLogL)
   #endif
-  for (int xBin = 0; xBin < nXBins; ++xBin)
+  for (int yBin = 0; yBin < nYBins; ++yBin)
   {
-    for (int yBin = 0; yBin < nYBins; ++yBin)
+    for (int xBin = 0; xBin < nXBins; ++xBin)
     {
       const double DataVal = samplePDFFD_data[yBin][xBin];
       const double MCPred = samplePDFFD_array[yBin][xBin];

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -79,6 +79,9 @@ public:
   TH1* get1DVarHist(std::string ProjectionVar, std::vector< std::vector<double> > SelectionVec = std::vector< std::vector<double> >(), int WeightStyle=0, TAxis* Axis=nullptr);
   TH2* get2DVarHist(std::string ProjectionVarX, std::string ProjectionVarY, std::vector< std::vector<double> > SelectionVec = std::vector< std::vector<double> >(), int WeightStyle=0, TAxis* AxisX=nullptr, TAxis* AxisY=nullptr);
 
+	virtual TH1* get1DParticleVarHist(std::string ProjectionVarX, std::vector< std::vector<double> > SelectionVec = std::vector< std::vector<double> >(), int WeightStyle=0, TAxis* AxisX=nullptr){(void)ProjectionVarX; (void)SelectionVec; (void)WeightStyle; (void)AxisX; return nullptr;};
+	virtual TH2* get2DParticleVarHist(std::string ProjectionVarX, std::string ProjectionVarY, std::vector< std::vector<double> > SelectionVec = std::vector< std::vector<double> >(), int WeightStyle=0, TAxis* AxisX=nullptr, TAxis* AxisY=nullptr){(void)ProjectionVarX; (void)ProjectionVarY; (void)SelectionVec; (void)WeightStyle; (void)AxisX; (void)AxisY; return nullptr;};
+
   TH1* get1DVarHistByModeAndChannel(std::string ProjectionVar_Str, int kModeToFill=-1, int kChannelToFill=-1, int WeightStyle=0, TAxis* Axis=nullptr);
   TH2* get2DVarHistByModeAndChannel(std::string ProjectionVar_StrX, std::string ProjectionVar_StrY, int kModeToFill=-1, int kChannelToFill=-1, int WeightStyle=0, TAxis* AxisX=nullptr, TAxis* AxisY=nullptr);
 

--- a/splines/splineFDBase.cpp
+++ b/splines/splineFDBase.cpp
@@ -865,7 +865,7 @@ void splineFDBase::FillSampleArray(std::string SampleName, std::vector<std::stri
     TSpline3_red* Spline = nullptr;
     TString Syst, Mode;
     int nKnots, SystNum, ModeNum, Var1Bin, Var2Bin, Var3Bin = M3::_BAD_INT_;
-    double x,y, Eval = M3::_BAD_DOUBLE_;
+    double x,y = M3::_BAD_DOUBLE_;
     bool isFlat = true;
 
     std::set<std::string> SplineFileNames;
@@ -946,9 +946,7 @@ void splineFDBase::FillSampleArray(std::string SampleName, std::vector<std::stri
         isFlat = true;
         for (int iKnot = 0; iKnot < nKnots; iKnot++) {
           mySpline->GetKnot(iKnot, x, y);
-
-          Eval = mySpline->Eval(x);
-          if (Eval < 0.99999 || Eval > 1.00001)
+          if (y < 0.99999 || y > 1.00001)
           {
             isFlat = false;
             break;


### PR DESCRIPTION
# Pull request description
Declared two virtual functions in samplePDFFDBase.h for plotting particle-level 1D and 2D histograms (ie. one histogram entry for each particle). 

## Changes or fixes
The functions added are:
- virtual TH1* get1DParticleVarHist
- virtual TH2* get2DParticleVarHist

## Examples
If it is to be used, the function can be overridden in a derived class, see for example samplePDFDUNEBeamNDGAr.cpp in MaCh3_DUNE in branch jmartin/feature/NDGAr 