### PR TITLE
feat: Yaml Merging

### DIFF
--- a/manager/manager.cpp
+++ b/manager/manager.cpp
@@ -7,17 +7,34 @@ _MaCh3_Safe_Include_End_ //}
 
 // *************************
 manager::manager(std::string const &filename)
-    : config(M3OpenConfig(filename)) {
+: config(M3OpenConfig(filename)) {
 // *************************
   FileName = filename;
+
+  Initialise();
+}
+
+// *************************
+manager::manager(const YAML::Node ConfigNode) {
+// *************************
+  config = ConfigNode;
+  FileName = "unknown";
+
+  Initialise();
+}
+
+// *************************
+void manager::Initialise() {
+// *************************
   SetMaCh3LoggerFormat();
   MaCh3Utils::MaCh3Welcome();
 
-  MACH3LOG_INFO("Setting config to be: {}", filename);
+  MACH3LOG_INFO("Setting config to be: {}", FileName);
 
   MACH3LOG_INFO("Config is now: ");
   MaCh3Utils::PrintConfig(config);
 }
+
 
 // *************************
 // Empty destructor, for now...

--- a/manager/manager.h
+++ b/manager/manager.h
@@ -19,6 +19,11 @@ public:
   /// @brief Constructs a manager object with the specified file name.
   /// @param filename The name of the configuration file.
   explicit manager(std::string const &filename);
+  /// @brief Constructs a manager object with the specified YAML
+  /// @note This is primarily used when initializing from a previous chain, allowing the creation of a manager instance based embedded YAML in that chain.
+  /// @param ConfigNode Actual YAML config
+  manager(const YAML::Node ConfigNode);
+
   /// @brief Destroys the manager object.
   virtual ~manager();
 
@@ -49,6 +54,9 @@ public:
   }
 
 private:
+  /// @brief Common inialiser for both constructors
+  void Initialise();
+
   /// The YAML node containing the configuration data.
   YAML::Node config;
   /// The name of the configuration file.


### PR DESCRIPTION
# Pull request description
Give ability to merge yaml configs, in near future I want to have ability of overwriting configs.
For example you have base T2K config, and ATM config with additional settings. You could pass both and MaCh3 would simply add/overwrite settings. For valdiations see: https://github.com/mach3-software/MaCh3Tutorial/pull/110

Also add new constuctor for manager to make easier to start from previous chain (changes will have to be done on exe level)

## Changes or fixes


## Examples
