### PR TITLE
feat: Ability to speicfy "empty" bounds

### DIFF
--- a/covariance/covarianceBase.cpp
+++ b/covariance/covarianceBase.cpp
@@ -201,11 +201,7 @@ void covarianceBase::init(const std::vector<std::string>& YAMLFile) {
       throw MaCh3Exception(__FILE__ , __LINE__ );
     }
     //ETA - a bit of a fudge but works
-    auto TempBoundsVec = Get<std::vector<double>>(param["Systematic"]["ParameterBounds"], __FILE__ , __LINE__);
-    if(TempBoundsVec.size() != 2) {
-      MACH3LOG_ERROR("Size of param bounds isn't 2 and is equal to {}", TempBoundsVec.size());
-      throw MaCh3Exception(__FILE__ , __LINE__ );
-    }
+    auto TempBoundsVec = GetBounds(param["Systematic"]["ParameterBounds"]);
     _fLowBound[i] = TempBoundsVec[0];
     _fUpBound[i] = TempBoundsVec[1];
 

--- a/manager/Core.h
+++ b/manager/Core.h
@@ -48,8 +48,8 @@ namespace M3 {
   constexpr static const float Zero_F = 0.;
   constexpr static const int Unity_Int = 1;
 
-  constexpr static const double KinematicLowBound = -1e16;
-  constexpr static const double KinematicUpBound = 1e16;
+  constexpr static const double KinematicLowBound = std::numeric_limits<double>::lowest();
+  constexpr static const double KinematicUpBound = std::numeric_limits<double>::max();
 
   /// Large Likelihood is used it parameter go out of physical boundary, this indicates in MCMC that such step should be removed
   constexpr static const double _LARGE_LOGL_ = 1234567890.0;

--- a/manager/Core.h
+++ b/manager/Core.h
@@ -48,6 +48,9 @@ namespace M3 {
   constexpr static const float Zero_F = 0.;
   constexpr static const int Unity_Int = 1;
 
+  constexpr static const double KinematicLowBound = -1e16;
+  constexpr static const double KinematicUpBound = 1e16;
+
   /// Large Likelihood is used it parameter go out of physical boundary, this indicates in MCMC that such step should be removed
   constexpr static const double _LARGE_LOGL_ = 1234567890.0;
 }

--- a/manager/Core.h
+++ b/manager/Core.h
@@ -12,6 +12,8 @@
 #include <vector>
 #include <iomanip>
 #include <cmath>
+#include <limits>
+
 /// Run low or high memory versions of structs
 /// N.B. for 64 bit systems sizeof(float) == sizeof(double) so not a huge effect
 namespace M3 {

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -147,15 +147,16 @@ void samplePDFFDBase::ReadSampleConfig()
   double low_bound = 0;
   double up_bound = 0;
   double KinematicParamter = 0;
+
   std::vector<double> SelectionVec;
   //Now grab the selection cuts from the manager
   for ( auto const &SelectionCuts : SampleManager->raw()["SelectionCuts"]) {
     SelectionStr.push_back(SelectionCuts["KinematicStr"].as<std::string>());
-    SelectionBounds.push_back(SelectionCuts["Bounds"].as<std::vector<double>>());
-    low_bound = SelectionBounds.back().at(0);
-    up_bound = SelectionBounds.back().at(1);
+    auto TempBoundsVec = GetBounds(SelectionCuts["Bounds"]);
+    low_bound = TempBoundsVec[0];
+    up_bound = TempBoundsVec[1];
     KinematicParamter = static_cast<double>(ReturnKinematicParameterFromString(SelectionCuts["KinematicStr"].as<std::string>()));
-    MACH3LOG_INFO("Adding cut on {} with bounds {} to {}", SelectionCuts["KinematicStr"].as<std::string>(), SelectionBounds.back().at(0), SelectionBounds.back().at(1));
+    MACH3LOG_INFO("Adding cut on {} with bounds {} to {}", SelectionCuts["KinematicStr"].as<std::string>(), TempBoundsVec[0], TempBoundsVec[1]);
     SelectionVec = {KinematicParamter, low_bound, up_bound};
     StoredSelection.push_back(SelectionVec);
   }

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -285,9 +285,7 @@ public:
   /// this is of length 3: 0th index is the value, 1st is lower bound, 2nd is upper bound
   std::vector< std::vector<double> > StoredSelection;
   /// @brief the strings grabbed from the sample config specifying the selections
-  std::vector< std::string > SelectionStr; 
-  /// @brief the bounds for each selection lower and upper
-  std::vector< std::vector<double> > SelectionBounds;
+  std::vector< std::string > SelectionStr;
   /// @brief a way to store selection cuts which you may push back in the get1DVar functions
   /// most of the time this is just the same as StoredSelection
   std::vector< std::vector<double> > Selection;


### PR DESCRIPTION
# Pull request description
This is meant to help having to specify bounds like
```
SelectionCuts:
  - KinematicStr: "RecoLeptonMomentum"
    Bounds: [100., 1000000.]
```
 and instead use ""
 like here:
 SelectionCuts:
  - KinematicStr: "RecoLeptonMomentum"
    Bounds: [100., ""] 


In addition found std::vector< std::vector<double> > SelectionBounds; is not used at all so remvoed it. Did check both T2K and DUNE and neither uses it.

## Changes or fixes


## Examples
test with wrong size
![test](https://github.com/user-attachments/assets/13aee4af-305d-4718-b6cd-87dc063dc20d)

test with wrong string
![test2](https://github.com/user-attachments/assets/e0bfac9c-5c5f-4fc8-954f-71892adf38ad)

test with upper bound
![test3](https://github.com/user-attachments/assets/a3934def-8a77-4121-a0f1-bc5108d02789)

test with both bounds (pointless but why not...)
<img width="658" alt="test4" src="https://github.com/user-attachments/assets/d2f281d6-d916-4a85-bf35-32254f1cc47c" />

Test that everything works as it used to be
![image](https://github.com/user-attachments/assets/878fe11c-ec73-4b5d-be8e-8c0293ebfbec)
