### PR TITLE
bugfix: Improve Thread Sanity

### DIFF
--- a/manager/Monitor.cpp
+++ b/manager/Monitor.cpp
@@ -120,6 +120,9 @@ void GetCPUInfo() {
 // ************************
 void NThreadsSanity() {
 // ************************
+  //KS: If OMP_NUM_THREADS is exported, assume user did this on purpose
+  if (std::getenv("OMP_NUM_THREADS") != nullptr) return;
+
   const int nThreads = M3::GetNThreads();
   constexpr int MaxAllowedThreads = 16;
   constexpr int RecommendedThreads = 8;


### PR DESCRIPTION
# Pull request description
Previously there was no way to run wiht more 16 threads other than commenting out line.
Simplest way to still have error (which I think is usefull for less expirenced users) but give ability to play with for more expireinced is to make check based on OMP_NUM_THREADS enviorment

## Changes or fixes


## Examples
