### PR TITLE
feat: Allow to override config with another config

### DIFF
--- a/mcmc/MaCh3Factory.cpp
+++ b/mcmc/MaCh3Factory.cpp
@@ -36,6 +36,26 @@ std::unique_ptr<manager> MaCh3ManagerFactory(int argc, char **argv) {
     throw MaCh3Exception(__FILE__, __LINE__);
   }
 
+  // Check if we are using --override mode
+  if (argc >= 4 && std::string(argv[2]) == "--override") {
+    const std::string overrideFile = argv[3];
+    MACH3LOG_INFO("Merging two configs: {} and {}", argv[1], overrideFile);
+
+    if(argc > 4) {
+      MACH3LOG_ERROR("Looks like you are trying to pass multiple arguments and --override");
+      throw MaCh3Exception(__FILE__, __LINE__);
+    }
+    // Load the two YAML files
+    YAML::Node config1 = M3OpenConfig(argv[1]);
+    YAML::Node config2 = M3OpenConfig(overrideFile);
+
+    // Merge them
+    YAML::Node merged = MergeNodes(config1, config2);
+    auto FitManager = std::make_unique<manager>(merged);
+
+    return FitManager;
+  }
+
   // Initialise manger responsible for config handling
   auto FitManager = std::make_unique<manager>(argv[1]);
   
@@ -92,7 +112,7 @@ std::unique_ptr<manager> MaCh3ManagerFactory(int argc, char **argv) {
       FitManager->OverrideSettings(section, key, key2, value);
     } else {
       MACH3LOG_ERROR("Invalid override argument format: {}", arg);
-      MACH3LOG_ERROR("Expected format:Section:Key:Key:Valu, Section:Key:Value or Section:Value");
+      MACH3LOG_ERROR("Expected format:Section:Key:Key:Value, Section:Key:Value or Section:Value");
       throw MaCh3Exception(__FILE__, __LINE__);
     }
   }

--- a/mcmc/MaCh3Factory.cpp
+++ b/mcmc/MaCh3Factory.cpp
@@ -39,10 +39,14 @@ std::unique_ptr<manager> MaCh3ManagerFactory(int argc, char **argv) {
   // Check if we are using --override mode
   if (argc >= 4 && std::string(argv[2]) == "--override") {
     const std::string overrideFile = argv[3];
-    MACH3LOG_INFO("Merging two configs: {} and {}", argv[1], overrideFile);
+      MACH3LOG_INFO("Merging configuration files: base config '{}', override config '{}'. "
+                "Options in '{}' will take precedence over '{}'.",
+                argv[1], overrideFile, overrideFile, argv[1]);
 
     if(argc > 4) {
-      MACH3LOG_ERROR("Looks like you are trying to pass multiple arguments and --override");
+      MACH3LOG_ERROR("Too many arguments provided when using '--override'. "
+                   "Expected only two config files. "
+                   "If using override feature, you cannot provide any additional arguments.");
       throw MaCh3Exception(__FILE__, __LINE__);
     }
     // Load the two YAML files


### PR DESCRIPTION
# Pull request description
This allow to override default config with another config.

## Changes or fixes


## Examples
<img width="974" alt="example" src="https://github.com/user-attachments/assets/3019081d-8586-44e5-8086-087800b05474" />

`./bin/MCMCTutorial TutorialConfigs/FitterConfig.yaml --override TutorialConfigs/Override.yaml
`

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
