### PR TITLE
breaking: Add Kinematic Cut Struct

### DIFF
--- a/python/samplePDF.cpp
+++ b/python/samplePDF.cpp
@@ -155,7 +155,7 @@ public:
         );
     }
 
-    double ReturnKinematicParameter(double, int, int) override {
+    double ReturnKinematicParameter(int, int, int) override {
         PYBIND11_OVERRIDE_PURE_NAME(
             double,                     /* Return type */
             samplePDFFDBase,            /* Parent class */

--- a/samplePDF/Structs.h
+++ b/samplePDF/Structs.h
@@ -448,79 +448,6 @@ enum NuPDG {
   kNutauBar = -16
 };
 
-// *****************
-/// Enum to track neutrino species for Prob3
-enum ProbNu {
-// *****************
-  kProbNue = 1,
-  kProbNumu = 2,
-  kProbNutau = 3,
-  kProbNueBar = -1,
-  kProbNumuBar = -2,
-  kProbNutauBar = -3
-};
-
-// *****************
-/// @brief ETA - Probs3++ doesn't use the PDG codes for the neutrino type so add in a small converter
-inline int PDGToProbs(NuPDG pdg){
-// *****************
-  int ReturnProbNu = -999;
-
-  switch (pdg){
-    case kNue:
-      ReturnProbNu = kProbNue;
-      break;
-    case kNumu:
-      ReturnProbNu = kProbNumu;
-      break;
-    case kNutau:
-      ReturnProbNu = kProbNutau;
-      break;
-    case kNueBar:
-      ReturnProbNu = kProbNueBar;
-      break;
-    case kNumuBar:
-      ReturnProbNu = kProbNumuBar;
-      break;
-    case kNutauBar:
-      ReturnProbNu = kProbNutauBar;
-      break;
-    default:
-      MACH3LOG_WARN("Unrecognised pdg for the neutrino so can't map this to an int for Prob3++");
-      break;
-  }
-  return ReturnProbNu;
-}
-
-inline int ProbsToPDG(ProbNu NuType){
-  int ReturnNuPDG = -999;
-
-  switch (NuType){
-    case kProbNue:
-      ReturnNuPDG = static_cast<int>(kNue);
-      break;
-    case kProbNumu:
-      ReturnNuPDG = static_cast<int>(kNumu);
-      break;
-    case kProbNutau:
-      ReturnNuPDG = static_cast<int>(kNutau);
-      break;
-    case kProbNueBar:
-      ReturnNuPDG = static_cast<int>(kNueBar);
-      break;
-    case kProbNumuBar:
-      ReturnNuPDG = static_cast<int>(kNumuBar);
-      break;
-    case kProbNutauBar:
-      ReturnNuPDG = static_cast<int>(kNutauBar);
-      break;
-    default:
-      MACH3LOG_WARN("Unrecognised NuType for the neutrino so can't map this to a PDG code");
-      break;
-  }
-  return ReturnNuPDG;
-}
-
 /// Make an enum of the test statistic that we're using
 /// @todo KS: Consider adding BakerCousins based on Baker & Cousins, Nucl.Instrum.Meth.A 221 (1984) 437-442
 enum TestStatistic {
@@ -565,17 +492,25 @@ inline std::string TestStatistic_ToString(TestStatistic i) {
   return name;
 }
 
+// ***************************
+/// @brief KS: Small struct used for applying kinematic cuts
+struct KinematicCut {
+// ***************************
+  /// Index or enum value identifying the kinematic variable to cut on.
+  int ParamToCutOnIt = M3::_BAD_INT_;
+  /// Lower bound on which we apply cut
+  double LowerBound = M3::_BAD_DOUBLE_;
+  /// Upper bound on which we apply cut
+  double UpperBound = M3::_BAD_DOUBLE_;
+};
 
 // ***************************
 // A handy namespace for variables extraction
 namespace MaCh3Utils {
-  // ***************************
+// ***************************
 
-  // ***************************
   /// @brief Return mass for given PDG
-  // *****************************
-  // Get the mass of a particle from the PDG
-  // In GeV, not MeV!
+  /// @note Get the mass of a particle from the PDG In GeV, not MeV!
   inline double GetMassFromPDG(const int PDG) {
     // *****************************
     switch (abs(PDG)) {
@@ -656,7 +591,7 @@ namespace MaCh3Utils {
         NuOscillatorFlavour = NuOscillator::kTau;
         break;
       default:
-        MACH3LOG_ERROR("Unknown Nuetrino PDG {}, cannot convert to NuOscillator type", NuPdg);
+        MACH3LOG_ERROR("Unknown Neutrino PDG {}, cannot convert to NuOscillator type", NuPdg);
         break;
     }
 

--- a/samplePDF/samplePDFFDBase.cpp
+++ b/samplePDF/samplePDFFDBase.cpp
@@ -33,6 +33,7 @@ samplePDFFDBase::samplePDFFDBase(std::string ConfigFileName, covarianceXsec* xse
 
   samplePDFFD_array = nullptr;
   samplePDFFD_data = nullptr;
+  samplePDFFD_array_w2 = nullptr;
   SampleName = "";
   SampleManager = std::unique_ptr<manager>(new manager(ConfigFileName.c_str()));
 
@@ -143,24 +144,17 @@ void samplePDFFDBase::ReadSampleConfig()
     sample_nupdg.push_back(static_cast<NuPDG>(osc_channel["oscnutype"].as<int>()));
   }
 
-  //Now get selection cuts
-  double low_bound = 0;
-  double up_bound = 0;
-  double KinematicParamter = 0;
-
-  std::vector<double> SelectionVec;
   //Now grab the selection cuts from the manager
   for ( auto const &SelectionCuts : SampleManager->raw()["SelectionCuts"]) {
     SelectionStr.push_back(SelectionCuts["KinematicStr"].as<std::string>());
     auto TempBoundsVec = GetBounds(SelectionCuts["Bounds"]);
-    low_bound = TempBoundsVec[0];
-    up_bound = TempBoundsVec[1];
-    KinematicParamter = static_cast<double>(ReturnKinematicParameterFromString(SelectionCuts["KinematicStr"].as<std::string>()));
+    KinematicCut CutObj;
+    CutObj.LowerBound = TempBoundsVec[0];
+    CutObj.UpperBound = TempBoundsVec[1];
+    CutObj.ParamToCutOnIt = ReturnKinematicParameterFromString(SelectionCuts["KinematicStr"].as<std::string>());
     MACH3LOG_INFO("Adding cut on {} with bounds {} to {}", SelectionCuts["KinematicStr"].as<std::string>(), TempBoundsVec[0], TempBoundsVec[1]);
-    SelectionVec = {KinematicParamter, low_bound, up_bound};
-    StoredSelection.push_back(SelectionVec);
+    StoredSelection.push_back(CutObj);
   }
-  NSelections = int(SelectionStr.size());
 
   // EM: initialise the mode weight map
   for( int iMode=0; iMode < Modes->GetNModes(); iMode++ ) {
@@ -336,10 +330,9 @@ void samplePDFFDBase::SetupSampleBinning(){
 // ************************************************
 bool samplePDFFDBase::IsEventSelected(const int iSample, const int iEvent) {
 // ************************************************
-  double Val;
   for (unsigned int iSelection=0;iSelection < Selection.size() ;iSelection++) {  
-    Val = ReturnKinematicParameter(Selection[iSelection][0], iSample, iEvent);
-    if ((Val<Selection[iSelection][1])||(Val>=Selection[iSelection][2])) {
+    const double Val = ReturnKinematicParameter(Selection[iSelection].ParamToCutOnIt, iSample, iEvent);
+    if ((Val < Selection[iSelection].LowerBound) || (Val >= Selection[iSelection].UpperBound)) {
       return false;
     }
   }
@@ -1679,14 +1672,14 @@ void samplePDFFDBase::InitialiseSplineObject() {
   SplineHandler->cleanUpMemory();
 }
 
-TH1* samplePDFFDBase::get1DVarHist(const std::string& ProjectionVar_Str, const std::vector< std::vector<double> >& SelectionVec, int WeightStyle, TAxis* Axis) {
+TH1* samplePDFFDBase::get1DVarHist(const std::string& ProjectionVar_Str, const std::vector< KinematicCut >& SelectionVec, int WeightStyle, TAxis* Axis) {
   //DB Grab the associated enum with the argument string
   int ProjectionVar_Int = ReturnKinematicParameterFromString(ProjectionVar_Str);
 
   //DB Need to overwrite the Selection member variable so that IsEventSelected function operates correctly.
   //   Consequently, store the selection cuts already saved in the sample, overwrite the Selection variable, then reset
-  std::vector< std::vector<double> > tmp_Selection = Selection;
-  std::vector< std::vector<double> > SelectionVecToApply;
+  std::vector< KinematicCut > tmp_Selection = Selection;
+  std::vector< KinematicCut > SelectionVecToApply;
 
   //DB Add all the predefined selections to the selection vector which will be applied
   for (size_t iSelec=0;iSelec<Selection.size();iSelec++) {
@@ -1696,14 +1689,6 @@ TH1* samplePDFFDBase::get1DVarHist(const std::string& ProjectionVar_Str, const s
   //DB Add all requested cuts from the argument to the selection vector which will be applied
   for (size_t iSelec=0;iSelec<SelectionVec.size();iSelec++) {
     SelectionVecToApply.emplace_back(SelectionVec[iSelec]);
-  }
-
-  //DB Check the formatting of all requested cuts, should be [cutPar,lBound,uBound]
-  for (size_t iSelec=0;iSelec<SelectionVecToApply.size();iSelec++) {
-    if (SelectionVecToApply[iSelec].size()!=3) {
-      MACH3LOG_ERROR("Selection Vector[{}] is not formed correctly. Expect size == 3, given: {}",iSelec,SelectionVecToApply[iSelec].size());
-      throw MaCh3Exception(__FILE__, __LINE__);
-    }
   }
 
   //DB Set the member variable to be the cuts to apply
@@ -1739,7 +1724,7 @@ TH1* samplePDFFDBase::get1DVarHist(const std::string& ProjectionVar_Str, const s
 }
 // ************************************************
 TH2* samplePDFFDBase::get2DVarHist(const std::string& ProjectionVar_StrX, const std::string& ProjectionVar_StrY,
-                                   const std::vector< std::vector<double> >& SelectionVec,
+                                   const std::vector< KinematicCut >& SelectionVec,
                                    int WeightStyle, TAxis* AxisX, TAxis* AxisY) {
 // ************************************************
 
@@ -1749,8 +1734,8 @@ TH2* samplePDFFDBase::get2DVarHist(const std::string& ProjectionVar_StrX, const 
 
   //DB Need to overwrite the Selection member variable so that IsEventSelected function operates correctly.
   //   Consequently, store the selection cuts already saved in the sample, overwrite the Selection variable, then reset
-  std::vector< std::vector<double> > tmp_Selection = Selection;
-  std::vector< std::vector<double> > SelectionVecToApply;
+  std::vector< KinematicCut > tmp_Selection = Selection;
+  std::vector< KinematicCut > SelectionVecToApply;
 
   //DB Add all the predefined selections to the selection vector which will be applied
   for (size_t iSelec=0;iSelec<Selection.size();iSelec++) {
@@ -1760,14 +1745,6 @@ TH2* samplePDFFDBase::get2DVarHist(const std::string& ProjectionVar_StrX, const 
   //DB Add all requested cuts from the argument to the selection vector which will be applied
   for (size_t iSelec=0;iSelec<SelectionVec.size();iSelec++) {
     SelectionVecToApply.emplace_back(SelectionVec[iSelec]);
-  }
-
-  //DB Check the formatting of all requested cuts, should be [cutPar,lBound,uBound]
-  for (size_t iSelec=0;iSelec<SelectionVecToApply.size();iSelec++) {
-    if (SelectionVecToApply[iSelec].size()!=3) {
-      MACH3LOG_ERROR("Selection Vector[{}] is not formed correctly. Expect size == 3, given: {}",iSelec,SelectionVecToApply[iSelec].size());
-      throw MaCh3Exception(__FILE__, __LINE__);
-    }
   }
 
   //DB Set the member variable to be the cuts to apply
@@ -1792,7 +1769,7 @@ TH2* samplePDFFDBase::get2DVarHist(const std::string& ProjectionVar_StrX, const 
           Weight = 1.;
         }
         double VarX = ReturnKinematicParameter(ProjectionVar_IntX,iSample,iEvent);
-	double VarY = ReturnKinematicParameter(ProjectionVar_IntY,iSample,iEvent);
+        double VarY = ReturnKinematicParameter(ProjectionVar_IntY,iSample,iEvent);
         _h2DVar->Fill(VarX,VarY,Weight);
       }
     }
@@ -1858,21 +1835,21 @@ TH1* samplePDFFDBase::get1DVarHistByModeAndChannel(const std::string& Projection
     fMode = false;
   }
 
-  std::vector< std::vector<double> > SelectionVec;
+  std::vector< KinematicCut > SelectionVec;
 
   if (fMode) {
-    std::vector<double> SelecMode(3);
-    SelecMode[0] = ReturnKinematicParameterFromString("Mode");
-    SelecMode[1] = kModeToFill;
-    SelecMode[2] = kModeToFill+1;
+    KinematicCut SelecMode;
+    SelecMode.ParamToCutOnIt = ReturnKinematicParameterFromString("Mode");
+    SelecMode.LowerBound = kModeToFill;
+    SelecMode.UpperBound = kModeToFill+1;
     SelectionVec.push_back(SelecMode);
   }
 
   if (fChannel) {
-    std::vector<double> SelecChannel(3);
-    SelecChannel[0] = ReturnKinematicParameterFromString("OscillationChannel");
-    SelecChannel[1] = kChannelToFill;
-    SelecChannel[2] = kChannelToFill+1;
+    KinematicCut SelecChannel;
+    SelecChannel.ParamToCutOnIt = ReturnKinematicParameterFromString("OscillationChannel");
+    SelecChannel.LowerBound = kChannelToFill;
+    SelecChannel.UpperBound = kChannelToFill+1;
     SelectionVec.push_back(SelecChannel);
   }
 
@@ -1907,21 +1884,21 @@ TH2* samplePDFFDBase::get2DVarHistByModeAndChannel(const std::string& Projection
     fMode = false;
   }
 
-  std::vector< std::vector<double> > SelectionVec;
+  std::vector< KinematicCut > SelectionVec;
 
   if (fMode) {
-    std::vector<double> SelecMode(3);
-    SelecMode[0] = ReturnKinematicParameterFromString("Mode");
-    SelecMode[1] = kModeToFill;
-    SelecMode[2] = kModeToFill+1;
+    KinematicCut SelecMode;
+    SelecMode.ParamToCutOnIt = ReturnKinematicParameterFromString("Mode");
+    SelecMode.LowerBound = kModeToFill;
+    SelecMode.UpperBound = kModeToFill+1;
     SelectionVec.push_back(SelecMode);
   }
 
   if (fChannel) {
-    std::vector<double> SelecChannel(3);
-    SelecChannel[0] = ReturnKinematicParameterFromString("OscillationChannel");
-    SelecChannel[1] = kChannelToFill;
-    SelecChannel[2] = kChannelToFill+1;
+    KinematicCut SelecChannel;
+    SelecChannel.ParamToCutOnIt = ReturnKinematicParameterFromString("OscillationChannel");
+    SelecChannel.LowerBound = kChannelToFill;
+    SelecChannel.UpperBound = kChannelToFill+1;
     SelectionVec.push_back(SelecChannel);
   }
 

--- a/samplePDF/samplePDFFDBase.h
+++ b/samplePDF/samplePDFFDBase.h
@@ -77,10 +77,10 @@ public:
     return MCSamples[iSample].flavourName;
   }
 
-  TH1* get1DVarHist(const std::string& ProjectionVar, const std::vector< std::vector<double> >& SelectionVec = std::vector< std::vector<double> >(),
+  TH1* get1DVarHist(const std::string& ProjectionVar, const std::vector< KinematicCut >& SelectionVec = std::vector< KinematicCut >(),
                     int WeightStyle=0, TAxis* Axis=nullptr);
   TH2* get2DVarHist(const std::string& ProjectionVarX, const std::string& ProjectionVarY,
-                    const std::vector< std::vector<double> >& SelectionVec = std::vector< std::vector<double> >(),
+                    const std::vector< KinematicCut >& SelectionVec = std::vector< KinematicCut >(),
                     int WeightStyle=0, TAxis* AxisX=nullptr, TAxis* AxisY=nullptr);
 
   TH1* get1DVarHistByModeAndChannel(const std::string& ProjectionVar_Str, int kModeToFill=-1, int kChannelToFill=-1, int WeightStyle=0, TAxis* Axis=nullptr);
@@ -196,7 +196,7 @@ public:
   virtual void CalcWeightFunc(int iSample, int iEvent){return; (void)iSample; (void)iEvent;};
 
   virtual double ReturnKinematicParameter(std::string KinematicParamter, int iSample, int iEvent) = 0;
-  virtual double ReturnKinematicParameter(double KinematicVariable, int iSample, int iEvent) = 0;
+  virtual double ReturnKinematicParameter(int KinematicVariable, int iSample, int iEvent) = 0;
 
   virtual std::vector<double> ReturnKinematicParameterBinning(std::string KinematicParameter) = 0; //Returns binning for parameter Var
   virtual const double* GetPointerToKinematicParameter(std::string KinematicParamter, int iSample, int iEvent) = 0; 
@@ -263,8 +263,6 @@ public:
   int nDimensions = M3::_BAD_INT_;
   /// @brief A unique ID for each sample based on powers of two for quick binary operator comparisons 
   std::string SampleName;
-  /// holds "TrueNeutrinoEnergy" and the strings used for the sample binning.
-  std::vector<std::string> SplineBinnedVars;
 
   /// @brief the name of this sample e.g."muon-like"
   std::string SampleTitle;
@@ -278,17 +276,15 @@ public:
   //like in XsecNorms but for events in sample. Read in from sample yaml file 
   //What gets used in IsEventSelected, which gets set equal to user input plus 
   //all the vectors in StoreSelection
-  /// @brief the Number of selections in the 
-  int NSelections = M3::_BAD_INT_;
   
   /// @brief What gets pulled from config options, these are constant after loading in
   /// this is of length 3: 0th index is the value, 1st is lower bound, 2nd is upper bound
-  std::vector< std::vector<double> > StoredSelection;
+  std::vector< KinematicCut > StoredSelection;
   /// @brief the strings grabbed from the sample config specifying the selections
   std::vector< std::string > SelectionStr;
   /// @brief a way to store selection cuts which you may push back in the get1DVar functions
   /// most of the time this is just the same as StoredSelection
-  std::vector< std::vector<double> > Selection;
+  std::vector< KinematicCut > Selection;
    //===========================================================================
 
   /// Mapping between string and kinematic enum


### PR DESCRIPTION
# Pull request description
Instead of passing vector of doubles simply use new struct for applying kinematic cuts. I personally didn't like how we were casting  double to enum. Passing int to enum is faster and safer (no need of floating operations).

Marked as breaking as ReturnKinematicParameter now uses `int `not `double`

Merge this before: https://github.com/mach3-software/MaCh3Tutorial/pull/115

## Changes or fixes
- Removed enums related to Prob3++ (NuOsc is handling this)
- NSelections and SplineBinnedVars wasn't used anywhere (checked T2K and DUNE codes as well)

## Examples

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
