### PR TITLE
feat: Universal, path-independent setup

### DIFF
--- a/cmake/Templates/setup.MaCh3.sh.in
+++ b/cmake/Templates/setup.MaCh3.sh.in
@@ -7,7 +7,7 @@ function add_to_PATH () {
   for d; do
 
     d=$(cd -- "$d" && { pwd -P || pwd; }) 2>/dev/null  # canonicalize symbolic links
-    if [ -z "$d" ]; then continue; fi  # skip nonexistent directory
+    if [[ -z "$d" ]]; then continue; fi  # skip nonexistent directory
 
     if [[ "$d" == "/usr/bin" ]] || [[ "$d" == "/usr/bin64" ]] || [[ "$d" == "/usr/local/bin" ]] || [[ "$d" == "/usr/local/bin64" ]]; then
       case ":$PATH:" in
@@ -31,7 +31,7 @@ function add_to_LD_LIBRARY_PATH () {
   for d; do
 
     d=$(cd -- "$d" && { pwd -P || pwd; }) 2>/dev/null  # canonicalize symbolic links
-    if [ -z "$d" ]; then continue; fi  # skip nonexistent directory
+    if [[ -z "$d" ]]; then continue; fi  # skip nonexistent directory
 
     if [[ "$d" == "/usr/lib" ]] || [[ "$d" == "/usr/lib64" ]] || [[ "$d" == "/usr/local/lib" ]] || [[ "$d" == "/usr/local/lib64" ]]; then
       case ":$LD_LIBRARY_PATH:" in
@@ -57,9 +57,9 @@ function add_to_PYTHONPATH () {
   for d; do
 
     d=$(cd -- "$d" && { pwd -P || pwd; }) 2>/dev/null  # canonicalize symbolic links
-    if [ -z "$d" ]; then continue; fi  # skip nonexistent directory
+    if [[ -z "$d" ]]; then continue; fi  # skip nonexistent directory
 
-    if [ "$d" == "/usr/bin" ] || [ "$d" == "/usr/bin64" ] || [ "$d" == "/usr/local/bin" ] || [ "$d" == "/usr/local/bin64" ]; then
+    if [[ "$d" == "/usr/bin" ]] || [[ "$d" == "/usr/bin64" ]] || [[ "$d" == "/usr/local/bin" ]] || [[ "$d" == "/usr/local/bin64" ]]; then
       case ":$PYTHONPATH:" in
         *":$d:"*) :;;
         *) export PYTHONPATH=$PYTHONPATH:$d;;
@@ -74,22 +74,31 @@ function add_to_PYTHONPATH () {
 }
 fi
 
-#if it was sourced as . setup.sh then you can't scrub off the end... assume that
-#we are in the correct directory.
-if ! echo "${BASH_SOURCE}" | grep "/" --silent; then
-  SETUPDIR=$(readlink -f ${PWD}/..)
-else
-  SETUPDIR=$(readlink -f ${BASH_SOURCE%/*}/..)
-fi
+# TN: this is one of the most stable implementation of getting the
+# path to the script being called (and hence the path to the $MaCh3_ROOT/bin)
+# I have seen so far. This can be called from anywhere and with
+# both source or ., with relative or absolute paths.
+pushd . > '/dev/null';
+SCRIPT_PATH="${BASH_SOURCE[0]:-$0}";
 
-export MaCh3_ROOT=${SETUPDIR}
+while [[ -h "$SCRIPT_PATH" ]];
+do
+    cd "$( dirname -- "$SCRIPT_PATH"; )";
+    SCRIPT_PATH="$( readlink -f -- "$SCRIPT_PATH"; )";
+done
+
+cd "$( dirname -- "$SCRIPT_PATH"; )" > '/dev/null';
+SCRIPT_PATH="$( pwd; )";
+popd  > '/dev/null';
+
+export MaCh3_ROOT=${SCRIPT_PATH}/..
 export MaCh3_VERSION=@MaCh3_VERSION@
 
 add_to_PATH ${MaCh3_ROOT}/bin
 add_to_LD_LIBRARY_PATH ${MaCh3_ROOT}/lib
 add_to_LD_LIBRARY_PATH ${MaCh3_ROOT}/lib64
 
-if [ -f "${MaCh3_ROOT}/bin/setup.NuOscillator.sh" ]; then
+if [[ -f "${MaCh3_ROOT}/bin/setup.NuOscillator.sh" ]]; then
   echo "Sourcing NuOscillator"
   source "${MaCh3_ROOT}/bin/setup.NuOscillator.sh"
 fi


### PR DESCRIPTION
# Pull request description

1. Use [[ ]] instead of [ ] as the latter has bash specific evaluation, different in modern bash-like shells. See the diffs of [[ , [, (, ((, e.g. [here](https://unix.stackexchange.com/questions/306111/what-is-the-difference-between-the-bash-operators-vs-vs-vs). Alternatively, if [ ] is to be used, the conditions shall be recast to work properly, there are proper POSIX [ ] equivalents for any [[ ]].

2. Allowing a universal (shell-inclusive) and path-independent setup of MaCh3 based on the location of the setup.MaCh3.sh script.

## Changes or fixes

Switch for an implementation piece that would allow for locating the script and defyning the MaCh3_ROOT path, irrespective of where the setup script is called from, with equivalent output in a number of different shell types.

## Examples

Including examples from a script ```script.sh```:
```
pushd . > '/dev/null';
SCRIPT_PATH="${BASH_SOURCE[0]:-$0}";

while [[ -h "$SCRIPT_PATH" ]];
do
    cd "$( dirname -- "$SCRIPT_PATH"; )";
    SCRIPT_PATH="$( readlink -f -- "$SCRIPT_PATH"; )";
done

cd "$( dirname -- "$SCRIPT_PATH"; )" > '/dev/null';
SCRIPT_PATH="$( pwd; )";
popd  > '/dev/null';

echo "SCRIPT_PATH=$SCRIPT_PATH"
```
Located in ```/home/user/MaCh3/build/bin/script.sh```, called from ```/home/user/```. Invoked as:  
- ```/home/user/MaCh3/build/bin/script.sh```
- ```./MaCh3/build/bin/script.sh```  
Or whenever appropriate in the respective shell:
- ```. /home/user/MaCh3/build/bin/script.sh```
- ```. ~/MaCh3/build/bin/script.sh```
- ```source ./MaCh3/build/bin/script.sh```
- ```source /home/user/MaCh3/build/bin/script.sh```
- ```source ~/MaCh3/build/bin/script.sh```

The above give: ```SCRIPT_PATH=/home/user/MaCh3/build/bin``` in the following shells:
- **sh, bash** 5.2.37
- **zsh** 5.9
- **ksh** A 2020.0.0 (does not include pushd and popd, so it transfers to the script directory)
- **csh, tcsh** 6.24.15
- **dash** 0.5.12

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
