### PR TITLE
feat: Universal setup: bash, sh, zsh, ksh, dash

### DIFF
--- a/cmake/Templates/setup.MaCh3.sh.in
+++ b/cmake/Templates/setup.MaCh3.sh.in
@@ -1,15 +1,22 @@
+# TN: This shebang is rather useless, since I guess the user needs to "source" the setup,
+# not execute it. Executing it from a different shell than bash would only open bash, run
+# the script and close the bash with no changes in the PATHs of the original shell. That is,
+# nothing gets set up. If the script is sourced, the shebang is skipped and the script is sourced
+# from the original shell (not bash).
+# Anyway, I will keep it here, if there is some use to it I am missing.
 #!/bin/bash
 
 if ! type add_to_PATH &> /dev/null; then
 
 ### Adapted from https://unix.stackexchange.com/questions/4965/keep-duplicates-out-of-path-on-source
-function add_to_PATH () {
+add_to_PATH()
+{
   for d; do
 
-    d=$(cd -- "$d" && { pwd -P || pwd; }) 2>/dev/null  # canonicalize symbolic links
-    if [[ -z "$d" ]]; then continue; fi  # skip nonexistent directory
+    d=$( cd -- $d && { pwd -P || pwd; } ) 2>/dev/null  # canonicalize symbolic links
+    if [[ -z $d ]]; then continue; fi  # skip nonexistent directory
 
-    if [[ "$d" == "/usr/bin" ]] || [[ "$d" == "/usr/bin64" ]] || [[ "$d" == "/usr/local/bin" ]] || [[ "$d" == "/usr/local/bin64" ]]; then
+    if [[ $d == "/usr/bin" || $d == "/usr/bin64" || $d == "/usr/local/bin" || $d == "/usr/local/bin64" ]]; then
       case ":$PATH:" in
         *":$d:"*) :;;
         *) export PATH=$PATH:$d;;
@@ -27,13 +34,14 @@ fi
 
 if ! type add_to_LD_LIBRARY_PATH &> /dev/null; then
 
-function add_to_LD_LIBRARY_PATH () {
+add_to_LD_LIBRARY_PATH()
+{
   for d; do
 
-    d=$(cd -- "$d" && { pwd -P || pwd; }) 2>/dev/null  # canonicalize symbolic links
-    if [[ -z "$d" ]]; then continue; fi  # skip nonexistent directory
+    d=$( cd -- $d && { pwd -P || pwd; } ) 2>/dev/null  # canonicalize symbolic links
+    if [[ -z $d ]]; then continue; fi  # skip nonexistent directory
 
-    if [[ "$d" == "/usr/lib" ]] || [[ "$d" == "/usr/lib64" ]] || [[ "$d" == "/usr/local/lib" ]] || [[ "$d" == "/usr/local/lib64" ]]; then
+    if [[ $d == "/usr/bin" || $d == "/usr/bin64" || $d == "/usr/local/bin" || $d == "/usr/local/bin64" ]]; then
       case ":$LD_LIBRARY_PATH:" in
         *":$d:"*) :;;
         *) export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$d;;
@@ -53,13 +61,14 @@ fi
 if ! type add_to_PYTHONPATH &> /dev/null; then
 
 ### Adapted from ^^
-function add_to_PYTHONPATH () {
+add_to_PYTHONPATH()
+{
   for d; do
 
-    d=$(cd -- "$d" && { pwd -P || pwd; }) 2>/dev/null  # canonicalize symbolic links
-    if [[ -z "$d" ]]; then continue; fi  # skip nonexistent directory
+    d=$( cd -- $d && { pwd -P || pwd; } ) 2>/dev/null  # canonicalize symbolic links
+    if [[ -z $d ]]; then continue; fi  # skip nonexistent directory
 
-    if [[ "$d" == "/usr/bin" ]] || [[ "$d" == "/usr/bin64" ]] || [[ "$d" == "/usr/local/bin" ]] || [[ "$d" == "/usr/local/bin64" ]]; then
+    if [[ $d == "/usr/bin" || $d == "/usr/bin64" || $d == "/usr/local/bin" || $d == "/usr/local/bin64" ]]; then
       case ":$PYTHONPATH:" in
         *":$d:"*) :;;
         *) export PYTHONPATH=$PYTHONPATH:$d;;
@@ -72,6 +81,7 @@ function add_to_PYTHONPATH () {
     fi
   done
 }
+
 fi
 
 # TN: this is one of the most stable implementation of getting the
@@ -92,11 +102,14 @@ SCRIPT_PATH="$( pwd; )";
 popd  > '/dev/null';
 
 export MaCh3_ROOT=${SCRIPT_PATH}/..
-export MaCh3_VERSION=@MaCh3_VERSION@
+export MaCh3_VERSION=1.4.8
 
 add_to_PATH ${MaCh3_ROOT}/bin
 add_to_LD_LIBRARY_PATH ${MaCh3_ROOT}/lib
-add_to_LD_LIBRARY_PATH ${MaCh3_ROOT}/lib64
+
+if test -d ${MaCh3_ROOT}/lib64; then
+  add_to_LD_LIBRARY_PATH ${MaCh3_ROOT}/lib64
+fi
 
 if [[ -f "${MaCh3_ROOT}/bin/setup.NuOscillator.sh" ]]; then
   echo "Sourcing NuOscillator"
@@ -107,4 +120,4 @@ if test -d ${MaCh3_ROOT}/pyMaCh3; then
   add_to_PYTHONPATH ${MaCh3_ROOT}
 fi
 
-unset SETUPDIR
+unset SCRIPT_PATH

--- a/cmake/Templates/setup.MaCh3.sh.in
+++ b/cmake/Templates/setup.MaCh3.sh.in
@@ -102,7 +102,7 @@ SCRIPT_PATH="$( pwd; )";
 popd  > '/dev/null';
 
 export MaCh3_ROOT=${SCRIPT_PATH}/..
-export MaCh3_VERSION=1.4.8
+export MaCh3_VERSION=@MaCh3_VERSION@
 
 add_to_PATH ${MaCh3_ROOT}/bin
 add_to_LD_LIBRARY_PATH ${MaCh3_ROOT}/lib


### PR DESCRIPTION
# Pull request description

Trying to edit the setup functions to be portable and sourceable across different unix shells. I tested this version with bash, sh, zsh, ksh, and dash. This script can be sourced from anywhere, independent on your current $(pwd).

Unfortunately, this is cannot be sourced in csh and tcsh shells. Likely a specific script is needed (though I hope nobody's been using csh).

## Changes or fixes

1) Switching to the enhanced bash c++-like syntax ```[[ ]],  ==,``` etc., which is available in most modern versions of unix shells (unlike combinations of bash extension with POSIX statements) and making it consistent in the setup scripts.
2) ```function function_name () {}``` is also a mixture of several definition practices interpreted correctly in bash only. The edited way is accessible from all bash, zsh, ksh, and dash shells.
3) Keep spaces from within the parentheses ```$( )```.
4) ```lib64``` might not exist, right?

## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
