### PR TITLE
breaking: Fix Setting initial steps for adaption when starting from previous chain

### DIFF
--- a/mcmc/mcmc.cpp
+++ b/mcmc/mcmc.cpp
@@ -233,6 +233,12 @@ void mcmc::StartFromPreviousFit(const std::string& FitName) {
   posts->GetEntry(posts->GetEntries()-1);
 
   stepStart = step_val + 1;
+  // KS: Also update number of steps if using adaption
+  for(unsigned int i = 0; i < systematics.size(); ++i){
+    if(systematics[i]->getDoAdaption()){
+      systematics[i]->setNumberOfSteps(step_val);
+    }
+  }
   infile->Close();
   delete infile;
 }

--- a/mcmc/mcmc.h
+++ b/mcmc/mcmc.h
@@ -17,9 +17,6 @@ class mcmc : public FitterBase {
 
   /// @brief Set how long chain should be
   inline void setChainLength(unsigned int L) { chainLength = L; };
-
-  /// @brief Set initial step number, used when starting from another chain
-  inline void setInitialStepNumber(const unsigned int stepNum = 0){stepStart = stepNum;};
   
   /// @brief Allow to start from previous fit/chain
   /// @param FitName Name of previous chain

--- a/python/fitter.cpp
+++ b/python/fitter.cpp
@@ -139,13 +139,6 @@ void initFitter(py::module &m){
             "Set how long chain should be.",
             py::arg("length")
         )
-
-        .def(
-            "set_init_step_num", 
-            &mcmc::setInitialStepNumber, 
-            "Set initial step number, used when starting from another chain.",
-            py::arg("step_num")
-        )
     ; // end of MCMC class binding
 
     py::class_<LikelihoodFit, PyLikelihoodFit /* <--- trampoline*/, FitterBase>(m_fitter, "LikelihoodFit")


### PR DESCRIPTION
# Pull request description
When you start from previous you should also set numebr of steps for adaption matrices. I don't think this affected anyone but should be fixed asap

## Changes or fixes
- Removed `setInitialStepNumber` people should use StartFromPrevious chain fucnitonality

## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
