### PR TITLE
tidy: Increase usage of groups in Doxygen 

### DIFF
--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -28,81 +28,86 @@ class ParameterHandlerBase {
   /// @brief Destructor
   virtual ~ParameterHandlerBase();
   
-  /// \defgroup Setters
+  /// \defgroup ParameterHandlerSetters
   /// Group of functions to set various parameters, names, and values.
+
+  /// \defgroup ParameterHandlerGetters
+  /// Group of functions to get various parameters, names, and values.
 
   // ETA - maybe need to add checks to index on the setters? i.e. if( i > _fPropVal.size()){throw;}
   /// @brief Set covariance matrix
   /// @param cov Covariance matrix which we set and will be used later for evaluation of penalty term
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerSetters
   void SetCovMatrix(TMatrixDSym *cov);
   /// @brief Set matrix name
   void SetName(std::string name) { matrixName = name; }
   /// @brief change parameter name
   /// @param i Parameter index
   /// @param name new name which will be set
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerSetters
   void SetParName(int i, std::string name) { _fNames.at(i) = name; }
-  /// \ingroup Setters
+  /// @brief Set value of single param to a given value
+  /// @ingroup ParameterHandlerSetters
   void SetSingleParameter(const int parNo, const double parVal);
   /// @brief Set all the covariance matrix parameters to a user-defined value
   /// @param i Parameter index
   /// @param val new value which will be set
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerSetters
   void SetPar(const int i, const double val);
   /// @brief Set current parameter value
   /// @param i Parameter index
   /// @param val new value which will be set
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerSetters
   void SetParCurrProp(const int i, const double val);
   /// @brief Set proposed parameter value
   /// @param i Parameter index
   /// @param val new value which will be set
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerSetters
   void SetParProp(const int i, const double val) {
     _fPropVal[i] = val;
     if (pca) PCAObj->TransferToPCA();
   }
   /// @brief Set parameter values using vector, it has to have same size as covariance class
   /// @param pars Vector holding new values for every parameter
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerSetters
   void SetParameters(const std::vector<double>& pars = {});
   /// @brief Set if parameter should have flat prior or not
   /// @param i Parameter index
   /// @param eL bool telling if it will be flat or not
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerSetters
   void SetFlatPrior(const int i, const bool eL);
   
   /// @brief Set random value useful for debugging/CI
   /// @param i Parameter index
   /// @param rand New value for random number
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerSetters
   void SetRandomThrow(const int i, const double rand) { randParams[i] = rand;}
   /// @brief Get random value useful for debugging/CI
   /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
   double GetRandomThrow(const int i) { return randParams[i];}
 
   /// @brief set branches for output file
   /// @param tree Tree to which we will save branches
   /// @param SaveProposal Normally we only save parameter after is accepted, for debugging purpose it is helpful to see also proposed values. That's what this variable controls
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerSetters
   void SetBranches(TTree &tree, bool SaveProposal = false);
   /// @brief Set global step scale for covariance object
   /// @param scale Value of global step scale
   /// @cite luengo2020survey
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerSetters
   void SetStepScale(const double scale);
   /// @brief DB Function to set fIndivStepScale from a vector (Can be used from execs and inside covariance constructors)
   /// @param ParameterIndex Parameter Index
   /// @param StepScale Value of individual step scale
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerSetters
   void SetIndivStepScale(const int ParameterIndex, const double StepScale){ _fIndivStepScale.at(ParameterIndex) = StepScale; }
   /// @brief DB Function to set fIndivStepScale from a vector (Can be used from execs and inside covariance constructors)
   /// @param stepscale Vector of individual step scale, should have same
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerSetters
   void SetIndivStepScale(const std::vector<double>& stepscale);
   /// @brief KS: In case someone really want to change this
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerSetters
   inline void SetPrintLength(const unsigned int PriLen) { PrintLength = PriLen; }
 
   /// @brief KS: After step scale, prefit etc. value were modified save this modified config.
@@ -123,45 +128,51 @@ class ParameterHandlerBase {
   /// @brief Calc penalty term based on inverted covariance matrix
   double CalcLikelihood() const _noexcept_;
   /// @brief Return CalcLikelihood if some params were thrown out of boundary return _LARGE_LOGL_
+  /// @ingroup ParameterHandlerGetters
   virtual double GetLikelihood();
 
   /// @brief Return covariance matrix
+  /// @ingroup ParameterHandlerGetters
   TMatrixDSym *GetCovMatrix() { return covMatrix; }
   /// @brief Return inverted covariance matrix
+  /// @ingroup ParameterHandlerGetters
   TMatrixDSym *GetInvCovMatrix() { return invCovMatrix; }
   /// @brief Return inverted covariance matrix
+  /// @ingroup ParameterHandlerGetters
   double GetInvCovMatrix(const int i, const int j) { return InvertCovMatrix[i][j]; }
 
   /// @brief Return correlated throws
   /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
   double GetCorrThrows(const int i) { return corr_throw[i]; }
 
   /// @brief Get if param has flat prior or not
   /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
   inline bool GetFlatPrior(const int i) { return _fFlatPrior[i]; }
 
   /// @brief Get name of covariance
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerGetters
   std::string GetName() const { return matrixName; }
   /// @brief Get name of covariance
   /// @param i Parameter index
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerGetters
   std::string GetParName(const int i) const {return _fNames[i];}
   /// @brief Get fancy name of the Parameter
   /// @param i Parameter index
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerGetters
   std::string GetParFancyName(const int i) const {return _fFancyNames[i];}
   /// @brief Get name of input file
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerGetters
   std::string GetInputFile() const { return inputFile; }
 
   /// @brief Get diagonal error for ith parameter
   /// @param i Parameter index
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerGetters
   inline double GetDiagonalError(const int i) const { return std::sqrt((*covMatrix)(i,i)); }
   /// @brief Get the error for the ith parameter
   /// @param i Parameter index
-  /// \ingroup Setters
+  /// @ingroup ParameterHandlerGetters
   inline double GetError(const int i) const {return _fError[i];}
 
   /// @brief Adaptive Step Tuning Stuff
@@ -175,28 +186,36 @@ class ParameterHandlerBase {
     AdaptiveHandler.SaveAdaptiveToFile(outFileName, systematicName); }
 
   /// @brief Do we adapt or not
+  /// @ingroup ParameterHandlerGetters
   bool GetDoAdaption(){return use_adaptive;}
   /// @brief Use new throw matrix, used in adaptive MCMC
+  /// @ingroup ParameterHandlerSetters
   void SetThrowMatrix(TMatrixDSym *cov);
   void UpdateThrowMatrix(TMatrixDSym *cov);
   /// @brief Set number of MCMC step, when running adaptive MCMC it is updated with given frequency. We need number of steps to determine frequency.
+   /// @ingroup ParameterHandlerSetters
   inline void SetNumberOfSteps(const int nsteps) {
     AdaptiveHandler.total_steps = nsteps;
     if(AdaptiveHandler.AdaptionUpdate()) ResetIndivStepScale();
   }
 
   /// @brief Get matrix used for step proposal
+  /// @ingroup ParameterHandlerGetters
   inline TMatrixDSym *GetThrowMatrix(){return throwMatrix;}
   /// @brief Get matrix used for step proposal
+  /// @ingroup ParameterHandlerGetters
   double GetThrowMatrix(int i, int j) { return throwMatrixCholDecomp[i][j];}
   /// @brief Get the Cholesky decomposition of the throw matrix
+  /// @ingroup ParameterHandlerGetters
   inline TMatrixD *GetThrowMatrix_CholDecomp(){return throwMatrix_CholDecomp;}
   /// @brief Get the parameter means used in the adaptive handler
+  /// @ingroup ParameterHandlerGetters
   inline std::vector<double> GetParameterMeans(){return AdaptiveHandler.par_means;}
   /// @brief KS: Convert covariance matrix to correlation matrix and return TH2D which can be used for fancy plotting
   /// @details This function converts the covariance matrix to a correlation matrix and
   ///          returns a TH2D object, which can be used for advanced plotting purposes.
   /// @return A pointer to a TH2D object representing the correlation matrix
+  /// @ingroup ParameterHandlerGetters
   TH2D* GetCorrelationMatrix();
 
   /// @brief DB Pointer return to param position
@@ -216,43 +235,58 @@ class ParameterHandlerBase {
 
   //Some Getters
   /// @brief Get total number of parameters
+  /// @ingroup ParameterHandlerGetters
   inline int  GetNumParams() const {return _fNumPar;}
   /// @brief Get the prior array for parameters.
+  /// @ingroup ParameterHandlerGetters
   virtual std::vector<double> GetNominalArray();
   /// @brief Get the pre-fit values of the parameters.
+  /// @ingroup ParameterHandlerGetters
   std::vector<double> GetPreFitValues() const {return _fPreFitValue;}
   /// @brief Get the generated values of the parameters.
+  /// @ingroup ParameterHandlerGetters
   std::vector<double> GetGeneratedValues() const {return _fGenerated;}
   /// @brief Get vector of all proposed parameter values
+  /// @ingroup ParameterHandlerGetters
   std::vector<double> GetProposed() const;
   /// @brief Get proposed parameter value
   /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
   inline double GetParProp(const int i) const { return _fPropVal[i]; }
   /// @brief Get current parameter value
   /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
   inline double GetParCurr(const int i) const { return _fCurrVal[i]; }
   /// @brief Get prior parameter value
   /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
   inline double GetParInit(const int i) const { return _fPreFitValue[i]; }
   /// @brief Return generated value, although is virtual so class inheriting might actual get prior not generated.
   /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
   virtual double GetNominal(const int i) { return GetParInit(i); }
   /// @brief Return generated value for a given parameter
   /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
   inline double GetGenerated(const int i) const { return _fGenerated[i];}
   /// @brief Get upper parameter bound in which it is physically valid
   /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
   inline double GetUpperBound(const int i) const { return _fUpBound[i];}
   /// @brief Get lower parameter bound in which it is physically valid
   /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
   inline double GetLowerBound(const int i) const { return _fLowBound[i]; }
   /// @brief Get individual step scale for selected parameter
   /// @param ParameterIndex Parameter index
+  /// @ingroup ParameterHandlerGetters
   inline double GetIndivStepScale(const int ParameterIndex) const {return _fIndivStepScale.at(ParameterIndex); }
   /// @brief Get global step scale for covariance object
+  /// @ingroup ParameterHandlerGetters
   inline double GetGlobalStepScale() const {return _fGlobalStepScale; }
   /// @brief Get current parameter value using PCA
   /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
   inline double GetParPropPCA(const int i)  {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     return PCAObj->_fParPropPCA(i);
@@ -260,6 +294,7 @@ class ParameterHandlerBase {
   
   /// @brief Get current parameter value using PCA
   /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
   inline double GetParCurrPCA(const int i) {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     return PCAObj->_fParCurrPCA(i);
@@ -267,26 +302,31 @@ class ParameterHandlerBase {
 
   /// @brief Is parameter fixed in PCA base or not
   /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
   inline bool IsParameterFixedPCA(const int i) {
     if (PCAObj->_fParSigmaPCA[i] < 0) { return true;  }
     else                              { return false; }
   }
   /// @brief Get transfer matrix allowing to go from PCA base to normal base
+  /// @ingroup ParameterHandlerGetters
   inline const TMatrixD GetTransferMatrix() {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     return PCAObj->TransferMat;
   }
   /// @brief Get eigen vectors of covariance matrix, only works with PCA
+  /// @ingroup ParameterHandlerGetters
   inline const TMatrixD GetEigenVectors() {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     return PCAObj->eigen_vectors;
   }
-  /// @brief Get eigen values for all parameters, if you want for decomposed only parameters use getEigenValuesMaster
+  /// @brief Get eigen values for all parameters, if you want for decomposed only parameters use GetEigenValuesMaster
+  /// @ingroup ParameterHandlerGetters
   inline const TVectorD GetEigenValues() {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     return PCAObj->eigen_values;
   }
-  /// @brief Get eigen value of only decomposed parameters, if you want for all parameters use getEigenValues
+  /// @brief Get eigen value of only decomposed parameters, if you want for all parameters use GetEigenValues
+  /// @ingroup ParameterHandlerGetters
   inline const std::vector<double> GetEigenValuesMaster() {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     return PCAObj->eigen_values_master;
@@ -303,6 +343,7 @@ class ParameterHandlerBase {
   /// @brief Set current value for parameter in PCA base
   /// @param i Parameter index
   /// @param value new value
+  /// @ingroup ParameterHandlerSetters
   inline void SetParCurrPCA(const int i, const double value) {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     PCAObj->_fParCurrPCA(i) = value;
@@ -312,6 +353,7 @@ class ParameterHandlerBase {
 
   /// @brief Set values for PCA parameters in PCA base
   /// @param pars vector with new values of PCA params
+  /// @ingroup ParameterHandlerSetters
   inline void SetParametersPCA(const std::vector<double> &pars) {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     if (int(pars.size()) != _fNumParPCA) {
@@ -327,6 +369,7 @@ class ParameterHandlerBase {
   }
 
   /// @brief Get number of params which will be different depending if using Eigen decomposition or not
+  /// @ingroup ParameterHandlerGetters
   inline int GetNParameters() {
     if (pca) return _fNumParPCA;
     else return _fNumPar;
@@ -388,6 +431,7 @@ class ParameterHandlerBase {
   inline double MatrixVectorMultiSingle(double** _restrict_ matrix, const double* _restrict_ vector, const int Length, const int i) const;
 
   /// @brief Getter to return a copy of the YAML node
+  /// @ingroup ParameterHandlerGetters
   YAML::Node GetConfig() const { return _fYAMLDoc; }
 
   // HH: Getter for AdaptiveHandler

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -28,10 +28,10 @@ class ParameterHandlerBase {
   /// @brief Destructor
   virtual ~ParameterHandlerBase();
   
-  /// \defgroup ParameterHandlerSetters
+  /// @defgroup ParameterHandlerSetters
   /// Group of functions to set various parameters, names, and values.
 
-  /// \defgroup ParameterHandlerGetters
+  /// @defgroup ParameterHandlerGetters
   /// Group of functions to get various parameters, names, and values.
 
   // ETA - maybe need to add checks to index on the setters? i.e. if( i > _fPropVal.size()){throw;}

--- a/Parameters/ParameterHandlerGeneric.h
+++ b/Parameters/ParameterHandlerGeneric.h
@@ -111,7 +111,7 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
 
     /// @brief KS Function to set to prior parameters of a given group
     /// @param Group name of group, like Xsec or Flux
-    /// \ingroup ParameterHandlerSetters
+    /// @ingroup ParameterHandlerSetters
     void SetGroupOnlyParameters(const std::string& Group);
 
     /// @brief Dump Matrix to ROOT file, useful when we need to pass matrix info to another fitting group

--- a/Parameters/ParameterHandlerGeneric.h
+++ b/Parameters/ParameterHandlerGeneric.h
@@ -24,58 +24,76 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
     // General Getter functions not split by detector
     /// @brief ETA - just return the int of the SampleName, this can be removed to do a string comp at some point.
     /// @param i parameter index
+    /// @ingroup ParameterHandlerSetters
     inline std::vector<std::string> GetParSampleID(const int i) const { return _fSampleNames[i];};
     /// @brief ETA - just return a string of "spline", "norm" or "functional"
     /// @param i parameter index
+    /// @ingroup ParameterHandlerSetters
     inline std::string GetParamTypeString(const int i) const { return SystType_ToString(_fParamType[i]); }
     /// @brief Returns enum describing our param type
     /// @param i parameter index
+    /// @ingroup ParameterHandlerSetters
     inline SystType GetParamType(const int i) const {return _fParamType[i];}
 
     /// @brief Get interpolation type for a given parameter
     /// @param i spline parameter index, not confuse with global index
     inline SplineInterpolation GetParSplineInterpolation(const int i) {return SplineParams.at(i)._SplineInterpolationType;}
     /// @brief Get the interpolation types for splines affecting a particular SampleName
+    /// @ingroup ParameterHandlerSetters
     const std::vector<SplineInterpolation> GetSplineInterpolationFromSampleName(const std::string& SampleName);
     /// @brief Get the name of the spline associated with the spline at index i
     /// @param i spline parameter index, not to be confused with global index
+    /// @ingroup ParameterHandlerSetters
     std::string GetParSplineName(const int i) {return _fSplineNames[i];}
 
     /// @brief DB Get spline parameters depending on given SampleName
+    /// @ingroup ParameterHandlerSetters
     const std::vector<int> GetGlobalSystIndexFromSampleName(const std::string& SampleName, const SystType Type);
     /// @brief EM: value at which we cap spline knot weight
     /// @param i spline parameter index, not confuse with global index
+    /// @ingroup ParameterHandlerSetters
     inline double GetParSplineKnotUpperBound(const int i) {return SplineParams.at(i)._SplineKnotUpBound;}
     /// @brief EM: value at which we cap spline knot weight
     /// @param i spline parameter index, not confuse with global index
+    /// @ingroup ParameterHandlerSetters
     inline double GetParSplineKnotLowerBound(const int i) {return SplineParams.at(i)._SplineKnotLowBound;}
 
     /// @brief DB Grab the number of parameters for the relevant SampleName
     /// @param Type Type of syst, for example kNorm, kSpline etc
+    /// @ingroup ParameterHandlerSetters
     int GetNumParamsFromSampleName(const std::string& SampleName, const SystType Type);
     /// @brief DB Grab the parameter names for the relevant SampleName
     /// @param Type Type of syst, for example kNorm, kSpline etc
+    /// @ingroup ParameterHandlerSetters
     const std::vector<std::string> GetParsNamesFromSampleName(const std::string& SampleName, const SystType Type);
     /// @brief DB Grab the parameter indices for the relevant SampleName
     /// @param Type Type of syst, for example kNorm, kSpline etc
+    /// @ingroup ParameterHandlerSetters
     const std::vector<int> GetParsIndexFromSampleName(const std::string& SampleName, const SystType Type);
 
     /// @brief DB Get spline parameters depending on given SampleName
+    /// @ingroup ParameterHandlerSetters
     const std::vector<std::string> GetSplineParsNamesFromSampleName(const std::string& SampleName);
     /// @brief DB Get spline parameters depending on given SampleName
+    /// @ingroup ParameterHandlerSetters
     const std::vector<std::string> GetSplineFileParsNamesFromSampleName(const std::string& SampleName);
 
     /// @brief DB Grab the Spline Modes for the relevant SampleName
+    /// @ingroup ParameterHandlerSetters
     const std::vector< std::vector<int> > GetSplineModeVecFromSampleName(const std::string& SampleName);
     /// @brief Grab the index of the syst relative to global numbering.
     /// @param Type Type of syst, for example kNorm, kSpline etc
+    /// @ingroup ParameterHandlerSetters
     const std::vector<int> GetSystIndexFromSampleName(const std::string& SampleName, const SystType Type);
     /// @brief DB Get norm/func parameters depending on given SampleName
+    /// @ingroup ParameterHandlerSetters
     const std::vector<NormParameter> GetNormParsFromSampleName(const std::string& SampleName);
     /// @brief HH Get functional parameters for the relevant SampleName
+    /// @ingroup ParameterHandlerSetters
     const std::vector<FunctionalParameter> GetFunctionalParametersFromSampleName(const std::string& SampleName);
 
     /// @brief KS: For most covariances prior and fparInit (prior) are the same, however for Xsec those can be different
+    /// @ingroup ParameterHandlerGetters
     std::vector<double> GetNominalArray() override
     {
       std::vector<double> prior(_fNumPar);
@@ -88,10 +106,12 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
     /// @param i parameter index
     /// @param Group name of group, like Xsec or Flux
     /// @return bool telling whether param is part of group
+    /// @ingroup ParameterHandlerSetters
     bool IsParFromGroup(const int i, const std::string& Group);
 
     /// @brief KS Function to set to prior parameters of a given group
     /// @param Group name of group, like Xsec or Flux
+    /// \ingroup ParameterHandlerSetters
     void SetGroupOnlyParameters(const std::string& Group);
 
     /// @brief Dump Matrix to ROOT file, useful when we need to pass matrix info to another fitting group

--- a/Parameters/ParameterHandlerOsc.h
+++ b/Parameters/ParameterHandlerOsc.h
@@ -16,8 +16,10 @@ class ParameterHandlerOsc : public ParameterHandlerBase
   /// @brief Propose MCMC step, including mass flipping
   void ProposeStep() override;
   /// @brief Sets whether to flip delta M23.
+  /// \ingroup ParameterHandlerSetters
   void SetFlipDeltaM23(bool flip){flipdelM = flip;}
   /// @brief Get pointers to Osc params from Sample name
+  /// @ingroup ParameterHandlerGetters
   std::vector<const double*> GetOscParsFromSampleName(const std::string& SampleName);
   /// @brief KS: Print all useful information's after initialization
   void Print();

--- a/Plotting/plottingUtils/inputManager.h
+++ b/Plotting/plottingUtils/inputManager.h
@@ -22,18 +22,17 @@ enum fileTypeEnum {
   kNFileTypes //!< Number of types of file
 };
 
+/// @brief Struct which wraps around the actual input file and also holds general information, and
+/// data from the file to be used by other classes.
+/// @details This is just a little guy thats
+/// intended to be just a plain old data type which simply holds and organises information and
+/// data read from the underlying input file, just some methods to inspect the contents of the
+/// object. As such it does not implement methods to manipulate such data, which is all done via
+/// the InputManager() class. Reason for this object is to try to smooth over the cracks that come
+/// from very different file structures used by different fitters and provide a common format to
+/// be used for plot making. Intended use of this objects is only via InputManager which contains
+/// the methods to fill and manipulate it.
 struct InputFile {
-  /// @brief Struct which wraps around the actual input file and also holds general information, and
-  /// data from the file to be used by other classes.
-  /// @details This is just a little guy thats
-  /// intended to be just a plain old data type which simply holds and organises information and
-  /// data read from the underlying input file, just some methods to inspect the contents of the
-  /// object. As such it does not implement methods to manipulate such data, which is all done via
-  /// the InputManager() class. Reason for this object is to try to smooth over the cracks that come
-  /// from very different file structures used by different fitters and provide a common format to
-  /// be used for plot making. Intended use of this objects is only via InputManager which contains
-  /// the methods to fill and manipulate it.
-
   /// @brief Create InputFile instance based on a specified file.
   /// @param fName The name of the file to open.
   /// @return The constructed InputFile.

--- a/Plotting/plottingUtils/styleManager.h
+++ b/Plotting/plottingUtils/styleManager.h
@@ -20,6 +20,8 @@
 
 namespace MaCh3Plotting {
 /// @author Ewan Miller
+
+/// @brief EW: provides centralized styling utilities for plots, including name prettification and style application
 class StyleManager {
 public:
   /// @brief Constructor

--- a/Samples/SampleHandlerBase.h
+++ b/Samples/SampleHandlerBase.h
@@ -29,23 +29,41 @@ class SampleHandlerBase
   /// @brief destructor
   virtual ~SampleHandlerBase();
 
+  /// \defgroup SampleHandlerSetters
+  /// Group of functions to set various parameters, names, and values.
+
+  /// \defgroup SampleHandlerGetters
+  /// Group of functions to get various parameters, names, and values.
+
+  /// @ingroup SampleHandlerGetters
   virtual inline M3::int_t GetNsamples(){ return nSamples; };
+  /// @ingroup SampleHandlerGetters
   virtual inline std::string GetTitle()const {return "SampleHandler";};
+  /// @ingroup SampleHandlerGetters
   virtual std::string GetSampleName(int Sample) const = 0;
+  /// @ingroup SampleHandlerGetters
   virtual inline double GetSampleLikelihood(const int isample){(void) isample; return GetLikelihood();};
 
   /// @brief Return pointer to MaCh3 modes
+  /// @ingroup SampleHandlerGetters
   MaCh3Modes* GetMaCh3Modes() const { return Modes; }
 
-  TH1D* Get1DHist();                                               
+  /// @ingroup SampleHandlerGetters
+  TH1D* Get1DHist();
+  /// @ingroup SampleHandlerGetters
   TH2D* Get2DHist();
+  /// @ingroup SampleHandlerGetters
   TH1D* Get1DDataHist(){return dathist;}
+  /// @ingroup SampleHandlerGetters
   TH2D* Get2DDataHist(){return dathist2d;}
       
   virtual void Reweight()=0;
+  /// @ingroup SampleHandlerGetters
   virtual double GetLikelihood() = 0;
 
+  /// @ingroup SampleHandlerGetters
   virtual int GetNEventsInSample(int sample){ (void) sample; throw MaCh3Exception(__FILE__ , __LINE__ , "Not implemented"); }
+  /// @ingroup SampleHandlerGetters
   virtual int GetNMCSamples(){ throw MaCh3Exception(__FILE__ , __LINE__ , "Not implemented"); }
 
   virtual void AddData(std::vector<double> &dat);
@@ -64,14 +82,20 @@ class SampleHandlerBase
   virtual inline std::string GetKinVarLabel(const int sample, const int Dimension) {
     (void) sample; (void) Dimension; throw MaCh3Exception(__FILE__ , __LINE__ , "Not implemented");  };
 
+  /// @brief Calculate test statistic for a single bin using Poisson
+  /// @param data is data
+  /// @param mc is mc
+  /// @ingroup SampleHandlerGetters
   double GetTestStatLLH(double data, double mc) const;
   /// @brief Calculate test statistic for a single bin. Calculation depends on setting of fTestStatistic
   /// @param data is data
   /// @param mc is mc
   /// @param w2 is is Sum(w_{i}^2) (sum of weights squared), which is sigma^2_{MC stats}
+  /// @ingroup SampleHandlerGetters
   double GetTestStatLLH(const double data, const double mc, const double w2) const;
   /// @brief Set the test statistic to be used when calculating the binned likelihoods
   /// @param testStat The test statistic to use.
+  /// @ingroup SampleHandlerGetters
   inline void SetTestStatistic(TestStatistic testStat){ fTestStatistic = testStat; }
 
   virtual void Fill1DHist()=0;

--- a/Samples/SampleHandlerBase.h
+++ b/Samples/SampleHandlerBase.h
@@ -29,10 +29,10 @@ class SampleHandlerBase
   /// @brief destructor
   virtual ~SampleHandlerBase();
 
-  /// \defgroup SampleHandlerSetters
+  /// @defgroup SampleHandlerSetters
   /// Group of functions to set various parameters, names, and values.
 
-  /// \defgroup SampleHandlerGetters
+  /// @defgroup SampleHandlerGetters
   /// Group of functions to get various parameters, names, and values.
 
   /// @ingroup SampleHandlerGetters

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -138,10 +138,10 @@ void SampleHandlerFD::ReadSampleConfig()
   if (!CheckNodeExists(SampleManager->raw(), "InputFiles", "mtupleprefix")){
     MACH3LOG_ERROR("InputFiles:mtupleprefix not given in {}, please add this", SampleManager->GetFileName());
   }
-  std::string mtupleprefix = SampleManager->raw()["InputFiles"]["mtupleprefix"].as<std::string>();
-  std::string mtuplesuffix = SampleManager->raw()["InputFiles"]["mtuplesuffix"].as<std::string>();
-  std::string splineprefix = SampleManager->raw()["InputFiles"]["splineprefix"].as<std::string>();
-  std::string splinesuffix = SampleManager->raw()["InputFiles"]["splinesuffix"].as<std::string>();
+  auto mtupleprefix  = Get<std::string>(SampleManager->raw()["InputFiles"]["mtupleprefix"], __FILE__, __LINE__);
+  auto mtuplesuffix  = Get<std::string>(SampleManager->raw()["InputFiles"]["mtuplesuffix"], __FILE__, __LINE__);
+  auto splineprefix  = Get<std::string>(SampleManager->raw()["InputFiles"]["splineprefix"], __FILE__, __LINE__);
+  auto splinesuffix  = Get<std::string>(SampleManager->raw()["InputFiles"]["splinesuffix"], __FILE__, __LINE__);
   
   nSamples = static_cast<M3::int_t>(SampleManager->raw()["SubSamples"].size());
   MCSamples.resize(nSamples);
@@ -796,8 +796,6 @@ void SampleHandlerFD::ApplyShifts(int iSample, int iEvent) {
     (*fp->funcPtr)(fp->valuePtr, iSample, iEvent);
   }
 }
-// =================================
-
 
 // ***************************************************************************
 // Calculate the spline weight for one event

--- a/Samples/SampleHandlerFD.h
+++ b/Samples/SampleHandlerFD.h
@@ -27,11 +27,16 @@ public:
   /// @brief destructor
   virtual ~SampleHandlerFD();
 
+  /// @ingroup SampleHandlerGetters
   int GetNDim(){return nDimensions;} //DB Function to differentiate 1D or 2D binning
+  /// @ingroup SampleHandlerGetters
   std::string GetSampleName(int iSample = 0) const override;
+  /// @ingroup SampleHandlerGetters
   std::string GetTitle() const override {return SampleTitle;}
 
+  /// @ingroup SampleHandlerGetters
   std::string GetXBinVarName() {return XVarStr;}
+  /// @ingroup SampleHandlerGetters
   std::string GetYBinVarName() {return YVarStr;}
 
   void PrintIntegral(TString OutputName="/dev/null", int WeightStyle=0, TString OutputCSVName="/dev/null");
@@ -60,8 +65,10 @@ public:
 
   void ReadSampleConfig();
 
+  /// @ingroup SampleHandlerGetters
   int GetNMCSamples() override {return int(MCSamples.size());}
 
+  /// @ingroup SampleHandlerGetters
   int GetNEventsInSample(int iSample) override {
     if (iSample < 0 || iSample > GetNMCSamples()) {
       MACH3LOG_ERROR("Invalid Sample Requested: {}",iSample);
@@ -70,6 +77,7 @@ public:
     return MCSamples[iSample].nEvents;
   }
   
+  /// @ingroup SampleHandlerGetters
   std::string GetFlavourName(int iSample) {
     if (iSample < 0 || iSample > GetNMCSamples()) {
       MACH3LOG_ERROR("Invalid Sample Requested: {}",iSample);
@@ -78,30 +86,40 @@ public:
     return MCSamples[iSample].flavourName;
   }
 
+  /// @ingroup SampleHandlerGetters
   TH1* Get1DVarHist(const std::string& ProjectionVar, const std::vector< KinematicCut >& SelectionVec = std::vector< KinematicCut >(),
                     int WeightStyle=0, TAxis* Axis=nullptr);
   TH2* Get2DVarHist(const std::string& ProjectionVarX, const std::string& ProjectionVarY,
                     const std::vector< KinematicCut >& SelectionVec = std::vector< KinematicCut >(),
                     int WeightStyle=0, TAxis* AxisX=nullptr, TAxis* AxisY=nullptr);
-
+  /// @ingroup SampleHandlerGetters
   TH1* Get1DVarHistByModeAndChannel(const std::string& ProjectionVar_Str, int kModeToFill=-1, int kChannelToFill=-1, int WeightStyle=0, TAxis* Axis=nullptr);
+  /// @ingroup SampleHandlerGetters
   TH2* Get2DVarHistByModeAndChannel(const std::string& ProjectionVar_StrX, const std::string& ProjectionVar_StrY, int kModeToFill=-1, int kChannelToFill=-1, int WeightStyle=0, TAxis* AxisX=nullptr, TAxis* AxisY=nullptr);
 
+  /// @ingroup SampleHandlerGetters
   TH1 *GetModeHist1D(int s, int m, int style = 0) {
     return Get1DVarHistByModeAndChannel(XVarStr,m,s,style);
   }
+  /// @ingroup SampleHandlerGetters
   TH2 *GetModeHist2D(int s, int m, int style = 0) {
     return Get2DVarHistByModeAndChannel(XVarStr,YVarStr,m,s,style);
   }
 
+  /// @ingroup SampleHandlerGetters
   std::vector<TH1*> ReturnHistsBySelection1D(std::string KinematicProjection, int Selection1, int Selection2=-1, int WeightStyle=0, TAxis* Axis=0);
+  /// @ingroup SampleHandlerGetters
   std::vector<TH2*> ReturnHistsBySelection2D(std::string KinematicProjectionX, std::string KinematicProjectionY, int Selection1, int Selection2=-1, int WeightStyle=0, TAxis* XAxis=0, TAxis* YAxis=0);
+  /// @ingroup SampleHandlerGetters
   THStack* ReturnStackedHistBySelection1D(std::string KinematicProjection, int Selection1, int Selection2=-1, int WeightStyle=0, TAxis* Axis=0);
+  /// @ingroup SampleHandlerGetters
   TLegend* ReturnStackHistLegend() {return THStackLeg;}
   
-  /// ETA function to generically convert a string from xsec cov to a kinematic type
+  /// @brief ETA function to generically convert a string from xsec cov to a kinematic type
+  /// @ingroup SampleHandlerGetters
   int ReturnKinematicParameterFromString(const std::string& KinematicStr) const;
-  /// ETA function to generically convert a kinematic type from xsec cov to a string
+  /// @brief ETA function to generically convert a kinematic type from xsec cov to a string
+  /// @ingroup SampleHandlerGetters
   std::string ReturnStringFromKinematicParameter(const int KinematicVariable) const;
 
  protected:

--- a/python/fitters.cpp
+++ b/python/fitters.cpp
@@ -9,7 +9,7 @@
 
 namespace py = pybind11;
 
-// As FitterBase is an abstract base class we have to do some gymnastics to get it to get it into python
+/// @brief EW: As FitterBase is an abstract base class we have to do some gymnastics to get it to get it into python
 class PyFitterBase : public FitterBase {
 public:
     /* Inherit the constructors */
@@ -35,7 +35,7 @@ public:
     }
 };
 
-// As LikelihoodFit is an abstract base class we have to do some gymnastics to get it to get it into python
+/// @brief EW: As LikelihoodFit is an abstract base class we have to do some gymnastics to get it to get it into python
 class PyLikelihoodFit : public LikelihoodFit {
 public:
     /* Inherit the constructors */

--- a/python/parameters.cpp
+++ b/python/parameters.cpp
@@ -10,7 +10,7 @@
 
 namespace py = pybind11;
 
-// As ParameterHandlerBase is an abstract base class we have to do some gymnastics to get it to get it into python
+/// @brief EW: As ParameterHandlerBase is an abstract base class we have to do some gymnastics to get it to get it into python
 class PyParameterHandlerBase : public ParameterHandlerBase {
 public:
     /* Inherit the constructors */

--- a/python/samples.cpp
+++ b/python/samples.cpp
@@ -6,7 +6,7 @@
 
 namespace py = pybind11;
 
-// As SampleHandlerBase is an abstract base class we have to do some gymnastics to get it to get it into python
+/// @brief EW: As SampleHandlerBase is an abstract base class we have to do some gymnastics to get it to get it into python
 class PySampleHandlerBase : public SampleHandlerBase {
 public:
     /* Inherit the constructors */
@@ -62,7 +62,7 @@ public:
 };
 
 
-// As SampleHandlerFD is an abstract base class we have to do some gymnastics to get it to get it into python
+/// @brief As SampleHandlerFD is an abstract base class we have to do some gymnastics to get it to get it into python
 class PySampleHandlerFD : public SampleHandlerFD {
 public:
     /* Inherit the constructors */

--- a/python/splines.cpp
+++ b/python/splines.cpp
@@ -15,7 +15,7 @@
 
 namespace py = pybind11;
 
-// As SplineBase is an abstract base class we have to do some gymnastics to get it to get it into python
+/// @brief EW: As SplineBase is an abstract base class we have to do some gymnastics to get it to get it into python
 class PySplineBase : public SplineBase {
 public:
     /* Inherit the constructors */


### PR DESCRIPTION
# Pull request description
We were using defgroup for some time but very restrictilvey. Using renaming as oprtunity to refurbish this featue.
![image](https://github.com/user-attachments/assets/1aaf7960-f0be-485f-81af-c011ea3c77d2)

Previously we had setters which was confusging. I decided to have ParameterHandlerSetters and sperate for SampleHandler.
This should make navigation easier. We could expand to not only have setters and getters but also interface fucntion, expand to other classes etc.

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
