### PR TITLE
tidy: turn off sliglhy annoing cuda warnings

### DIFF
--- a/cmake/Modules/CUDASetup.cmake
+++ b/cmake/Modules/CUDASetup.cmake
@@ -57,6 +57,14 @@ else()
     )
     target_compile_definitions(MaCh3GPUCompilerOptions INTERFACE "$<$<COMPILE_LANGUAGE:CUDA>:CUDA_ERROR_CHECK>")
 endif()
+
+# KS: In newer CUDA nvcc likes to throw billions of billions of "warning: style of line directive is a GCC extension"
+# these aren't very helpfull but hide real problems. Let's turn if off
+if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "12.0")
+    target_compile_options(MaCh3GPUCompilerOptions INTERFACE
+       "$<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe=--diag_suppress=20012>"
+    )
+endif()
 target_include_directories(MaCh3GPUCompilerOptions INTERFACE ${CUDAToolkit_INCLUDE_DIRS})
 if(MaCh3_DEBUG_ENABLED)
   include(${CMAKE_CURRENT_LIST_DIR}/CUDASamples.cmake)


### PR DESCRIPTION
# Pull request description
I haven't noticed before [maybe it is due to changes to NuOscillator] but newer cuda throws a lot of warnings.
This isn't MaCh3 only problem see:
https://mmg-gitlab.fjfi.cvut.cz/gitlab/tnl/tnl-dev/-/commit/18aeeef8988d03f3c3ae24c83f664dce17110226
https://github.com/cms-sw/cmssw/issues/33369
etc.

PS: google suggests problem started aroudn cuda 11.2, while our CI is based on 12, while I have access to 10 or 12. 
I can't check personally if 11.2 would really by ok. If someone can validate then we can redcue CUDA version requeird for addign this flag

## Changes or fixes


## Examples
![image](https://github.com/user-attachments/assets/d6d9e261-f33f-48d2-8843-f7598d1a1e4e)



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
