### PR TITLE
tidy: More flexible parameter flipping

### DIFF
--- a/Parameters/ParameterHandlerOsc.cpp
+++ b/Parameters/ParameterHandlerOsc.cpp
@@ -50,17 +50,14 @@ void ParameterHandlerOsc::ProposeStep() {
   // HW It should now automatically set dcp to be with [-pi, pi]
   CircularPrior(kDeltaCP, -TMath::Pi(), TMath::Pi());
 
-  // Okay now we've done the standard steps, we can add in our nice flips
-  // hierarchy flip first
-  if(random_number[0]->Uniform() < 0.5 && flipdelM){
-    _fPropVal[kDeltaM23] *= -1;
+  // Okay now we've done the standard steps, we can add in our nice flips hierarchy flip first
+  if(flipdelM){
+    FlipParameterValue(kDeltaM23, 0.);
   }
-  // now octant flip
-  if(random_number[0]->Uniform() < 0.5) {
-    // flip octant around point of maximal disappearance (0.5112)
-    // this ensures we move to a parameter value which has the same oscillation probability
-    _fPropVal[kSinTheta23] = 0.5112 - (_fPropVal[kSinTheta23] - 0.5112);
-  }
+
+  // flip octant around point of maximal disappearance (0.5112)
+  // this ensures we move to a parameter value which has the same oscillation probability
+  FlipParameterValue(kSinTheta23, 0.5112);
 }
 
 // *************************************
@@ -71,6 +68,14 @@ void ParameterHandlerOsc::CircularPrior(const int index, const double LowBound, 
     _fPropVal[index] = LowBound + std::fmod(_fPropVal[index] - UpBound, UpBound - LowBound);
   } else if (_fPropVal[index] < LowBound) {
     _fPropVal[index] = UpBound - std::fmod(LowBound - _fPropVal[index], UpBound - LowBound);
+  }
+}
+
+// *************************************
+void ParameterHandlerOsc::FlipParameterValue(const int index, const double FlipPoint) {
+// *************************************
+  if(random_number[0]->Uniform() < 0.5) {
+    _fPropVal[index] = FlipPoint - (_fPropVal[index] - FlipPoint);
   }
 }
 

--- a/Parameters/ParameterHandlerOsc.cpp
+++ b/Parameters/ParameterHandlerOsc.cpp
@@ -75,7 +75,7 @@ void ParameterHandlerOsc::CircularPrior(const int index, const double LowBound, 
 void ParameterHandlerOsc::FlipParameterValue(const int index, const double FlipPoint) {
 // *************************************
   if(random_number[0]->Uniform() < 0.5) {
-    _fPropVal[index] = FlipPoint - (_fPropVal[index] - FlipPoint);
+    _fPropVal[index] = 2 * FlipPoint - _fPropVal[index];
   }
 }
 

--- a/Parameters/ParameterHandlerOsc.h
+++ b/Parameters/ParameterHandlerOsc.h
@@ -21,7 +21,10 @@ class ParameterHandlerOsc : public ParameterHandlerBase
   std::vector<const double*> GetOscParsFromSampleName(const std::string& SampleName);
   /// @brief KS: Print all useful information's after initialization
   void Print();
-
+  /// @brief KS: Flip parameter around given value, for example mass ordering around 0
+  /// @param index parameter index you want to flip
+  /// @param FlipPoint Value around which flipping is done
+  void FlipParameterValue(const int index, const double FlipPoint);
  protected:
     /// @brief HW :: This method is a tad hacky but modular arithmetic gives me a headache.
     /// @author Henry Wallace


### PR DESCRIPTION
# Pull request description
Instead of hardcdoing flipping let's make simple fucniton which does this.
In near future we could expand this to get whcih param should be flipped from config [with flipping point].
This would allow to fully incorporate Osc params into HandlerGeneric().

Not doing it right now as it would be treated as breaking change [not planning any of this for 2.0.0]

Also Dr Wallace has pleny of brilliant (wacky) ideas
## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
