### PR TITLE
breaking: Reduce Unity type weirdness

### DIFF
--- a/Manager/Core.h
+++ b/Manager/Core.h
@@ -44,11 +44,20 @@ namespace M3 {
   constexpr static const double _DEFAULT_RETURN_VAL_ = -999999.123456;
 
   /// Some commonly used variables to which we set pointers to
-  constexpr static const double Unity = 1.;
-  constexpr static const double Zero = 0.;
+  constexpr static const double Unity_D = 1.;
   constexpr static const float Unity_F = 1.;
+  #ifdef _LOW_MEMORY_STRUCTS_
+  constexpr static const float_t Unity = Unity_F;
+  #else
+  constexpr static const float_t Unity = Unity_D;
+  #endif
+  constexpr static const double Zero_D = 0.;
   constexpr static const float Zero_F = 0.;
-  constexpr static const int Unity_Int = 1;
+  #ifdef _LOW_MEMORY_STRUCTS_
+  constexpr static const float_t Zero = Zero_F;
+  #else
+  constexpr static const float_t Zero = Zero_D;
+  #endif
 
   constexpr static const double KinematicLowBound = std::numeric_limits<double>::lowest();
   constexpr static const double KinematicUpBound = std::numeric_limits<double>::max();

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -1405,25 +1405,12 @@ void SampleHandlerFD::SetupNuOscillatorPointers() {
   for (size_t iSample=0;iSample<MCSamples.size();iSample++) {
 
     for (int iEvent=0;iEvent<MCSamples[iSample].nEvents;iEvent++) {
-      // KS: Sry but if we use low memory we need to point to float not double...
-#ifdef _LOW_MEMORY_STRUCTS_
-      MCSamples[iSample].osc_w_pointer[iEvent] = &M3::Unity_F;
-#else
       MCSamples[iSample].osc_w_pointer[iEvent] = &M3::Unity;
-#endif
       if (MCSamples[iSample].isNC[iEvent]) {
         if (*MCSamples[iSample].nupdg[iEvent] != *MCSamples[iSample].nupdgUnosc[iEvent]) {
-#ifdef _LOW_MEMORY_STRUCTS_
-          MCSamples[iSample].osc_w_pointer[iEvent] = &M3::Zero_F;
-#else
           MCSamples[iSample].osc_w_pointer[iEvent] = &M3::Zero;
-#endif
         } else {
-#ifdef _LOW_MEMORY_STRUCTS_
-          MCSamples[iSample].osc_w_pointer[iEvent] = &M3::Unity_F;
-#else
           MCSamples[iSample].osc_w_pointer[iEvent] = &M3::Unity;
-#endif
         }
       } else {
         int InitFlav = M3::_BAD_INT_;
@@ -1566,9 +1553,9 @@ void SampleHandlerFD::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
   fdobj->ChannelIndex = iSample;
   
   int nEvents = fdobj->nEvents;
-  fdobj->x_var.resize(nEvents, &M3::Unity);
-  fdobj->y_var.resize(nEvents, &M3::Unity);
-  fdobj->rw_etru.resize(nEvents, &M3::Unity);
+  fdobj->x_var.resize(nEvents, &M3::Unity_D);
+  fdobj->y_var.resize(nEvents, &M3::Unity_D);
+  fdobj->rw_etru.resize(nEvents, &M3::Unity_D);
   fdobj->XBin.resize(nEvents, -1);
   fdobj->YBin.resize(nEvents, -1);
   fdobj->NomXBin.resize(nEvents, -1);
@@ -1577,7 +1564,7 @@ void SampleHandlerFD::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
   fdobj->rw_lower_lower_xbinedge.resize(nEvents, -1);
   fdobj->rw_upper_xbinedge.resize(nEvents, -1);
   fdobj->rw_upper_upper_xbinedge.resize(nEvents, -1);
-  fdobj->mode.resize(nEvents, &M3::Unity);
+  fdobj->mode.resize(nEvents, &M3::Unity_D);
   fdobj->nxsec_norm_pointers.resize(nEvents);
   fdobj->xsec_norm_pointers.resize(nEvents);
   fdobj->xsec_norms_bins.resize(nEvents);
@@ -1590,11 +1577,7 @@ void SampleHandlerFD::InitialiseSingleFDMCObject(int iSample, int nEvents_) {
   fdobj->ntotal_weight_pointers.resize(nEvents);
   fdobj->total_weight_pointers.resize(nEvents);
   fdobj->Target.resize(nEvents, 0);
-#ifdef _LOW_MEMORY_STRUCTS_
-  fdobj->osc_w_pointer.resize(nEvents, &M3::Unity_F);
-#else
   fdobj->osc_w_pointer.resize(nEvents, &M3::Unity);
-#endif
 
   for(int iEvent = 0 ; iEvent < fdobj->nEvents ; ++iEvent){
     fdobj->isNC[iEvent] = false;


### PR DESCRIPTION
# Pull request description
We have Unity which was always double, but some variabels are float or double. Pointer to float cant point to doable vice versta.

Therafore to remove lot of ugly ifdefs in the code let's intorudce 
`Unity_F `-> For floats
`Unity_D `for doubel
`Unity `for flaot or double depdning on cmake flag

Marked as breaking, as this in reality changes Old Unity into Unity_D. So expeirmental specyfic code might need to adjust sliglhy.
## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
