### PR TITLE
tidy: TypeParameterBase and unifcation of GetXParsFromSampleName

### DIFF
--- a/Parameters/ParameterHandlerGeneric.cpp
+++ b/Parameters/ParameterHandlerGeneric.cpp
@@ -53,7 +53,7 @@ void ParameterHandlerGeneric::InitXsecFromConfig() {
       //Set param type
       _fParamType[i] = SystType::kSpline;
       // Fill Spline info
-      SplineParams.push_back(GetSplineParameter(param["Systematic"]));
+      SplineParams.push_back(GetSplineParameter(param["Systematic"], i));
 
       if (param["Systematic"]["SplineInformation"]["SplineName"]) {
         _fSplineNames.push_back(param["Systematic"]["SplineInformation"]["SplineName"].as<std::string>());
@@ -157,7 +157,8 @@ const std::vector< std::vector<int> > ParameterHandlerGeneric::GetSplineModeVecF
 NormParameter ParameterHandlerGeneric::GetNormParameter(const YAML::Node& param, const int Index) {
 // ********************************************
   NormParameter norm;
-  norm.name = GetParFancyName(Index);
+
+  GetBaseParameter(param, Index, norm);
 
   // ETA Empty DummyVector can be used to specify no cut for mode, target and neutrino flavour
   // ETA Has to be of size 0 to mean apply to all
@@ -204,11 +205,22 @@ NormParameter ParameterHandlerGeneric::GetNormParameter(const YAML::Node& param,
   norm.hasKinBounds = HasKinBounds;
   //End of kinematic bound checking
 
-  // Set the global parameter index of the normalisation parameter
-  norm.index = Index;
-
   return norm;
 }
+
+// ********************************************
+// Get Base Param
+void ParameterHandlerGeneric::GetBaseParameter(const YAML::Node& param, const int Index, TypeParameterBase& Parameter) {
+// ********************************************
+  // KS: For now we don't use so avoid compilation error
+  (void) param;
+
+  Parameter.name = GetParFancyName(Index);
+
+  // Set the global parameter index of the normalisation parameter
+  Parameter.index = Index;
+}
+
 
 // ********************************************
 // Grab the global syst index for the relevant SampleName
@@ -243,10 +255,11 @@ const std::vector<int> ParameterHandlerGeneric::GetSystIndexFromSampleName(const
 
 // ********************************************
 // Get Norm params
-SplineParameter ParameterHandlerGeneric::GetSplineParameter(const YAML::Node& param) {
+SplineParameter ParameterHandlerGeneric::GetSplineParameter(const YAML::Node& param, const int Index) {
 // ********************************************
   SplineParameter Spline;
 
+  GetBaseParameter(param, Index, Spline);
   //Now get the Spline interpolation type
   if (param["SplineInformation"]["InterpolationType"]){
     for(int InterpType = 0; InterpType < kSplineInterpolations ; ++InterpType){
@@ -274,7 +287,8 @@ SplineParameter ParameterHandlerGeneric::GetSplineParameter(const YAML::Node& pa
 FunctionalParameter ParameterHandlerGeneric::GetFunctionalParameters(const YAML::Node& param, const int Index) {
 // ********************************************
   FunctionalParameter func;
-  func.name = GetParFancyName(Index);
+  GetBaseParameter(param, Index, func);
+
   func.pdgs = GetFromManager<std::vector<int>>(param["NeutrinoFlavour"], std::vector<int>(), __FILE__ , __LINE__);
   func.targets = GetFromManager<std::vector<int>>(param["TargetNuclei"], std::vector<int>(), __FILE__ , __LINE__);
   func.modes = GetFromManager<std::vector<int>>(param["Mode"], std::vector<int>(), __FILE__ , __LINE__);
@@ -304,7 +318,6 @@ FunctionalParameter ParameterHandlerGeneric::GetFunctionalParameters(const YAML:
     func.KinematicVarStr = TempKinematicStrings;
     func.Selection = TempKinematicBounds;
   }
-  func.index = Index;
   func.valuePtr = RetPointer(Index);
   return func;
 }

--- a/Parameters/ParameterHandlerGeneric.cpp
+++ b/Parameters/ParameterHandlerGeneric.cpp
@@ -324,29 +324,35 @@ FunctionalParameter ParameterHandlerGeneric::GetFunctionalParameters(const YAML:
 
 // ********************************************
 // HH: Grab the Functional parameters for the relevant SampleName
-const std::vector<FunctionalParameter> ParameterHandlerGeneric::GetFunctionalParametersFromSampleName(const std::string& SampleName) {
-  // ********************************************
-  std::vector<FunctionalParameter> returnVec;
-  for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kFunc]) {
-    auto &FuncIndex = pair.first;
-    auto &GlobalIndex = pair.second;
-    if (AppliesToSample(GlobalIndex, SampleName)) {
-      returnVec.push_back(FuncParams[FuncIndex]);
-    }
-  }
-  return returnVec;
+const std::vector<FunctionalParameter> ParameterHandlerGeneric::GetFunctionalParametersFromSampleName(const std::string& SampleName) const {
+// ********************************************
+  return GetTypeParamsFromSampleName(_fSystToGlobalSystIndexMap[SystType::kFunc], FuncParams, SampleName);
 }
 
 // ********************************************
 // DB Grab the Normalisation parameters for the relevant SampleName
-const std::vector<NormParameter> ParameterHandlerGeneric::GetNormParsFromSampleName(const std::string& SampleName) {
+const std::vector<NormParameter> ParameterHandlerGeneric::GetNormParsFromSampleName(const std::string& SampleName) const {
 // ********************************************
-  std::vector<NormParameter> returnVec;
-  for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kNorm]) {
-    auto &NormIndex = pair.first;
-    auto &GlobalIndex = pair.second;
-    if (AppliesToSample(GlobalIndex, SampleName)) {
-      returnVec.push_back(NormParams[NormIndex]);
+  return GetTypeParamsFromSampleName(_fSystToGlobalSystIndexMap[SystType::kNorm], NormParams, SampleName);
+}
+
+// ********************************************
+// DB Grab the Normalisation parameters for the relevant SampleName
+const std::vector<SplineParameter> ParameterHandlerGeneric::GetNormParsFromSampleName(const std::string& SampleName) const {
+// ********************************************
+  return GetTypeParamsFromSampleName(_fSystToGlobalSystIndexMap[SystType::kSpline], SplineParams, SampleName);
+}
+
+// ********************************************
+template<typename ParamT>
+std::vector<ParamT> GetTypeParamsFromSampleName(const std::map<int, int>& indexMap, const std::vector<ParamT>& params, const std::string& SampleName) const {
+// ********************************************
+  std::vector<ParamT> returnVec;
+  for (const auto& pair : indexMap) {
+    const auto& localIndex = pair.first;
+    const auto& globalIndex = pair.second;
+    if (AppliesToSample(globalIndex, SampleName)) {
+      returnVec.push_back(params[localIndex]);
     }
   }
   return returnVec;

--- a/Parameters/ParameterHandlerGeneric.h
+++ b/Parameters/ParameterHandlerGeneric.h
@@ -73,7 +73,7 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
     /// @brief DB Get norm/func parameters depending on given SampleName
     const std::vector<NormParameter> GetNormParsFromSampleName(const std::string& SampleName);
     /// @brief HH Get functional parameters for the relevant SampleName
-    const std::vector<FunctionalParameter> GetFunctionalParametersFromSampleName(const std::string& SampleName);
+    const std::vector<FunctionalParameter> GetFunctionalParametersFromSampleName(const std::string& SampleName) const;
 
     /// @brief KS: For most covariances prior and fparInit (prior) are the same, however for Xsec those can be different
     std::vector<double> GetNominalArray() override
@@ -156,6 +156,9 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
     /// @param Index Global parameter index
     /// @param Parameter Object storing info
     inline void GetBaseParameter(const YAML::Node& param, const int Index, TypeParameterBase& Parameter);
+
+    template<typename ParamT>
+    std::vector<ParamT> GetTypeParamsFromSampleName(const std::map<int, int>& indexMap, const std::vector<ParamT>& params, const std::string& SampleName) const
 
     /// Type of parameter like norm, spline etc.
     std::vector<SystType> _fParamType;

--- a/Parameters/ParameterHandlerGeneric.h
+++ b/Parameters/ParameterHandlerGeneric.h
@@ -149,7 +149,13 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
     inline FunctionalParameter GetFunctionalParameters(const YAML::Node& param, const int Index);
     /// @brief Get Spline params
     /// @param param Yaml node describing param
-    inline SplineParameter GetSplineParameter(const YAML::Node& param);
+    /// @param Index Global parameter index
+    inline SplineParameter GetSplineParameter(const YAML::Node& param, const int Index);
+    /// @brief Fill base parameters
+    /// @param param Yaml node describing param
+    /// @param Index Global parameter index
+    /// @param Parameter Object storing info
+    inline void GetBaseParameter(const YAML::Node& param, const int Index, TypeParameterBase& Parameter);
 
     /// Type of parameter like norm, spline etc.
     std::vector<SystType> _fParamType;

--- a/Samples/Structs.h
+++ b/Samples/Structs.h
@@ -152,12 +152,20 @@ constexpr unsigned int str2int(const char* str, int h = 0) {
 }
 
 // *******************
-/// @brief ETA - Normalisations for cross-section parameters
-/// Carrier for whether you want to apply a systematic to an event or not
-struct NormParameter {
+/// @brief Base class storing info for parameters types, helping unify codebase
+struct TypeParameterBase {
 // *******************
   /// Name of parameters
   std::string name;
+
+  /// Parameter number of this normalisation in current systematic model
+  int index = M3::_BAD_INT_;
+};
+
+// *******************
+/// @brief ETA - Normalisations for cross-section parameters
+/// Carrier for whether you want to apply a systematic to an event or not
+struct NormParameter : public TypeParameterBase {
   /// Mode which parameter applies to
   std::vector<int> modes;
   /// Horn currents which parameter applies to
@@ -179,9 +187,6 @@ struct NormParameter {
   /// within a SampleHandler daughter class
   /// The bounds for each kinematic variable are given in Selection
   std::vector< std::string > KinematicVarStr;
-
-  /// Parameter number of this normalisation in current systematic model
-  int index;
 };
 
 // HH - a shorthand type for funcpar functions
@@ -189,10 +194,8 @@ using FuncParFuncType = std::function<void (const double*, std::size_t, std::siz
 // *******************
 /// @brief HH - Functional parameters
 /// Carrier for whether you want to apply a systematic to an event or not
-struct FunctionalParameter {
+struct FunctionalParameter : public TypeParameterBase {
 // *******************
-  /// Name of parameters
-  std::string name;
   /// Mode which parameter applies to
   std::vector<int> modes;
   /// Horn currents which parameter applies to
@@ -214,9 +217,6 @@ struct FunctionalParameter {
   /// within a SampleHandler daughter class
   /// The bounds for each kinematic variable are given in Selection
   std::vector< std::string > KinematicVarStr;
-
-  /// Parameter number of this functional in current systematic model
-  int index;
 
   /// Parameter value pointer
   const double* valuePtr;
@@ -339,7 +339,7 @@ enum SystType {
 
 // *******************
 /// @brief KS: Struct holding info about Spline Systematics
-struct SplineParameter {
+struct SplineParameter : public TypeParameterBase {
 // *******************
   /// Spline interpolation vector
   SplineInterpolation _SplineInterpolationType;


### PR DESCRIPTION
# Pull request description
First merge: https://github.com/mach3-software/MaCh3/pull/443

This introudces `TypeParameterBase`, from which SplineParam, NormParams and FuncParams inherit. New function GetBaseParameter fill common variables making code less complex.


Laslty GetNormParsFromSampleName, GetFunctionalParameters uses `GetTypeParamsFromSampleName` whcih redcues code duplciate.
## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
