### PR TITLE
feat: adaptive fix par interface

### DIFF
--- a/Parameters/AdaptiveMCMCHandler.cpp
+++ b/Parameters/AdaptiveMCMCHandler.cpp
@@ -246,6 +246,7 @@ void AdaptiveMCMCHandler::UpdateAdaptiveCovariance() {
   }
 
   // Step 2: Update covariance
+  #pragma omp parallel for
   for (int i = 0; i < GetNumParams(); ++i) {
     if (IsFixed(i)) {
       (*adaptive_covariance)(i, i) = 1.0;

--- a/Parameters/AdaptiveMCMCHandler.cpp
+++ b/Parameters/AdaptiveMCMCHandler.cpp
@@ -24,7 +24,8 @@ AdaptiveMCMCHandler::~AdaptiveMCMCHandler() {
 }
 
 // ********************************************
-bool AdaptiveMCMCHandler::InitFromConfig(const YAML::Node& adapt_manager, const std::string& matrix_name_str, std::vector<double>* parameters, std::vector<double>* fixed) {
+bool AdaptiveMCMCHandler::InitFromConfig(const YAML::Node& adapt_manager, const std::string& matrix_name_str,
+                                        const std::vector<double>* parameters, const std::vector<double>* fixed) {
 // ********************************************
   /*
    * HW: Idea is that adaption can simply read the YAML config

--- a/Parameters/AdaptiveMCMCHandler.cpp
+++ b/Parameters/AdaptiveMCMCHandler.cpp
@@ -250,50 +250,7 @@ void AdaptiveMCMCHandler::UpdateAdaptiveCovariance() {
     if (IsFixed(i)) {
       (*adaptive_covariance)(i, i) = 1.0;
       continue;
-    }  std::vector<double> par_means_prev = par_means;
-  int steps_post_burn = total_steps - start_adaptive_update;
-
-  // Step 1: Update means and compute deviations
-  for (int i = 0; i < GetNPars(); ++i) {
-    if (IsFixed(i)) continue;
-
-    par_means[i] =  (CurrVal(i) + par_means_prev[i]*steps_post_burn)/(steps_post_burn+1);
-    // Left over from cyclic means
-  }
-
-  // Step 2: Update covariance
-  for (int i = 0; i < GetNPars(); ++i) {
-    if (IsFixed(i)) {
-      (*adaptive_covariance)(i, i) = 1.0;
-      continue;
     }
-
-    int block_i = adapt_block_matrix_indices[i];
-
-    for (int j = 0; j <= i; ++j) {
-      if (IsFixed(j) || adapt_block_matrix_indices[j] != block_i) {
-        (*adaptive_covariance)(i, j) = 0.0;
-        (*adaptive_covariance)(j, i) = 0.0;
-        continue;
-      }
-
-      double cov_prev = (*adaptive_covariance)(i, j);
-      double cov_updated = 0.0;
-
-      if (steps_post_burn > 0) {
-      // Haario-style update
-        double cov_t = cov_prev * (steps_post_burn - 1) / steps_post_burn;
-        double prev_means_t = steps_post_burn * par_means_prev[i] * par_means_prev[j];
-        double curr_means_t = (steps_post_burn + 1) * par_means[i] * par_means[j];
-        double curr_step_t = CurrVal(i) * CurrVal(j);
-
-        cov_updated = cov_t + adaption_scale * (prev_means_t - curr_means_t + curr_step_t) / steps_post_burn;
-      }
-
-      (*adaptive_covariance)(i, j) = cov_updated;
-      (*adaptive_covariance)(j, i) = cov_updated;
-    }
-  }
 
     int block_i = adapt_block_matrix_indices[i];
 

--- a/Parameters/AdaptiveMCMCHandler.cpp
+++ b/Parameters/AdaptiveMCMCHandler.cpp
@@ -246,7 +246,9 @@ void AdaptiveMCMCHandler::UpdateAdaptiveCovariance() {
   }
 
   // Step 2: Update covariance
+  #ifdef MULTITHREAD
   #pragma omp parallel for
+  #endif
   for (int i = 0; i < GetNumParams(); ++i) {
     if (IsFixed(i)) {
       (*adaptive_covariance)(i, i) = 1.0;

--- a/Parameters/AdaptiveMCMCHandler.cpp
+++ b/Parameters/AdaptiveMCMCHandler.cpp
@@ -24,7 +24,7 @@ AdaptiveMCMCHandler::~AdaptiveMCMCHandler() {
 }
 
 // ********************************************
-bool AdaptiveMCMCHandler::InitFromConfig(const YAML::Node& adapt_manager, const std::string& matrix_name_str, const int Npars) {
+bool AdaptiveMCMCHandler::InitFromConfig(const YAML::Node& adapt_manager, const std::string& matrix_name_str, std::vector<double>* parameters, std::vector<double>* fixed) {
 // ********************************************
   /*
    * HW: Idea is that adaption can simply read the YAML config
@@ -73,24 +73,29 @@ bool AdaptiveMCMCHandler::InitFromConfig(const YAML::Node& adapt_manager, const 
 
   // We also want to check for "blocks" by default all parameters "know" about each other
   // but we can split the matrix into independent block matrices
+  SetParams(parameters);
+  SetFixed(fixed);
 
+  /// HW: This is technically wrong, should be across all systematics but will be addressed in a later PR
+  adaption_scale = 2.38*2.38/GetNPars(); 
+  
   // We"ll set a dummy variable here
   auto matrix_blocks = GetFromManager<std::vector<std::vector<int>>>(adapt_manager["AdaptionOptions"]["Covariance"][matrix_name_str]["MatrixBlocks"], {{}});
 
-  SetAdaptiveBlocks(matrix_blocks, Npars);
+  SetAdaptiveBlocks(matrix_blocks);
   return true;
 }
 
 // ********************************************
-void AdaptiveMCMCHandler::CreateNewAdaptiveCovariance(const int Npars) {
+void AdaptiveMCMCHandler::CreateNewAdaptiveCovariance() {
 // ********************************************
-  adaptive_covariance = new TMatrixDSym(Npars);
+  adaptive_covariance = new TMatrixDSym(GetNPars());
   adaptive_covariance->Zero();
-  par_means = std::vector<double>(Npars, 0);
+  par_means = std::vector<double>(GetNPars(), 0);
 }
 
 // ********************************************
-void AdaptiveMCMCHandler::SetAdaptiveBlocks(std::vector<std::vector<int>> block_indices, const int Npars) {
+void AdaptiveMCMCHandler::SetAdaptiveBlocks(std::vector<std::vector<int>> block_indices) {
 // ********************************************
   /*
    *   In order to adapt efficient we want to setup our throw matrix to be a serious of block-diagonal (ish) matrices
@@ -99,11 +104,11 @@ void AdaptiveMCMCHandler::SetAdaptiveBlocks(std::vector<std::vector<int>> block_
    *   [[0,4],[4, 6]] in your config will set up two blocks one with all indices 0<=i<4 and the other with 4<=i<6
    */
   // Set up block regions
-  adapt_block_matrix_indices = std::vector<int>(Npars, 0);
+  adapt_block_matrix_indices = std::vector<int>(GetNPars(), 0);
 
   // Should also make a matrix of block sizes
   adapt_block_sizes = std::vector<int>(block_indices.size()+1, 0);
-  adapt_block_sizes[0] = Npars;
+  adapt_block_sizes[0] = GetNPars();
 
   if(block_indices.size()==0 || block_indices[0].size()==0) return;
 
@@ -116,9 +121,9 @@ void AdaptiveMCMCHandler::SetAdaptiveBlocks(std::vector<std::vector<int>> block_
       int block_lb = block_indices[iblock][isubblock];
       int block_ub = block_indices[iblock][isubblock+1];
 
-      if(block_lb > Npars || block_ub > Npars){
+      if(block_lb > GetNPars() || block_ub > GetNPars()){
         MACH3LOG_ERROR("Cannot set matrix block with edges {}, {} for matrix of size {}",
-                       block_lb, block_ub, Npars);
+                       block_lb, block_ub, GetNPars());
         throw MaCh3Exception(__FILE__, __LINE__);;
       }
       for(int ipar = block_lb; ipar < block_ub; ipar++){
@@ -177,8 +182,7 @@ void AdaptiveMCMCHandler::SaveAdaptiveToFile(const std::string &outFileName,
 void AdaptiveMCMCHandler::SetThrowMatrixFromFile(const std::string& matrix_file_name,
                                                  const std::string& matrix_name,
                                                  const std::string& means_name,
-                                                 bool& use_adaptive,
-                                                 const int Npars) {
+                                                 bool& use_adaptive) {
 // ********************************************
   // Lets you set the throw matrix externally
   // Open file
@@ -205,12 +209,12 @@ void AdaptiveMCMCHandler::SetThrowMatrixFromFile(const std::string& matrix_file_
     // Yay our vector exists! Let's loop and fill it
     // Should check this is done
     if(means_vector->GetNrows()){
-      MACH3LOG_ERROR("External means vec size ({}) != matrix size ({})", means_vector->GetNrows(), Npars);
+      MACH3LOG_ERROR("External means vec size ({}) != matrix size ({})", means_vector->GetNrows(), GetNPars());
       throw MaCh3Exception(__FILE__, __LINE__);
     }
 
-    par_means = std::vector<double>(Npars);
-    for(int i = 0; i < Npars; i++){
+    par_means = std::vector<double>(GetNPars());
+    for(int i = 0; i < GetNPars(); i++){
       par_means[i] = (*means_vector)(i);
     }
     MACH3LOG_INFO("Found Means in External File, Will be able to adapt");
@@ -227,42 +231,96 @@ void AdaptiveMCMCHandler::SetThrowMatrixFromFile(const std::string& matrix_file_
 }
 
 // ********************************************
-void AdaptiveMCMCHandler::UpdateAdaptiveCovariance(const std::vector<double>& _fCurrVal, const int Npars) {
+void AdaptiveMCMCHandler::UpdateAdaptiveCovariance() {
 // ********************************************
   std::vector<double> par_means_prev = par_means;
-
   int steps_post_burn = total_steps - start_adaptive_update;
 
-  #ifdef MULTITHREAD
-  #pragma omp parallel for
-  #endif
-  for(int iRow = 0; iRow < Npars; iRow++) {
-    par_means[iRow] = (_fCurrVal[iRow]+par_means[iRow]*steps_post_burn)/(steps_post_burn+1);
+  // Step 1: Update means and compute deviations
+  for (int i = 0; i < GetNPars(); ++i) {
+    if (IsFixed(i)) continue;
+
+    par_means[i] =  (CurrVal(i) + par_means_prev[i]*steps_post_burn)/(steps_post_burn+1);
+    // Left over from cyclic means
   }
 
-  //Now we update the covariances using cov(x,y)=E(xy)-E(x)E(y)
-  #ifdef MULTITHREAD
-  #pragma omp parallel for
-  #endif
-  for(int irow = 0; irow < Npars; irow++){
-    int block = adapt_block_matrix_indices[irow];
-    // int scale_factor = 5.76/double(adapt_block_sizes[block]);
-    for(int icol = 0; icol <= irow; icol++){
-      double cov_val=0;
-      // Not in the same blocks
-      if(adapt_block_matrix_indices[icol] == block){
-        // Calculate Covariance for block
-        // https://projecteuclid.org/journals/bernoulli/volume-7/issue-2/An-adaptive-Metropolis-algorithm/bj/1080222083.full
-        cov_val = (*adaptive_covariance)(irow, icol)*Npars/5.6644;
-        cov_val += par_means_prev[irow]*par_means_prev[icol]; //First we remove the current means
-        cov_val = (cov_val*steps_post_burn+_fCurrVal[irow]*_fCurrVal[icol])/(steps_post_burn+1); //Now get mean(iRow*iCol)
-        cov_val -= par_means[icol]*par_means[irow];
-        cov_val*=5.6644/Npars;
+  // Step 2: Update covariance
+  for (int i = 0; i < GetNPars(); ++i) {
+    if (IsFixed(i)) {
+      (*adaptive_covariance)(i, i) = 1.0;
+      continue;
+    }  std::vector<double> par_means_prev = par_means;
+  int steps_post_burn = total_steps - start_adaptive_update;
+
+  // Step 1: Update means and compute deviations
+  for (int i = 0; i < GetNPars(); ++i) {
+    if (IsFixed(i)) continue;
+
+    par_means[i] =  (CurrVal(i) + par_means_prev[i]*steps_post_burn)/(steps_post_burn+1);
+    // Left over from cyclic means
+  }
+
+  // Step 2: Update covariance
+  for (int i = 0; i < GetNPars(); ++i) {
+    if (IsFixed(i)) {
+      (*adaptive_covariance)(i, i) = 1.0;
+      continue;
+    }
+
+    int block_i = adapt_block_matrix_indices[i];
+
+    for (int j = 0; j <= i; ++j) {
+      if (IsFixed(j) || adapt_block_matrix_indices[j] != block_i) {
+        (*adaptive_covariance)(i, j) = 0.0;
+        (*adaptive_covariance)(j, i) = 0.0;
+        continue;
       }
-      (*adaptive_covariance)(icol, irow) = cov_val;
-      (*adaptive_covariance)(irow, icol) = cov_val;
+
+      double cov_prev = (*adaptive_covariance)(i, j);
+      double cov_updated = 0.0;
+
+      if (steps_post_burn > 0) {
+      // Haario-style update
+        double cov_t = cov_prev * (steps_post_burn - 1) / steps_post_burn;
+        double prev_means_t = steps_post_burn * par_means_prev[i] * par_means_prev[j];
+        double curr_means_t = (steps_post_burn + 1) * par_means[i] * par_means[j];
+        double curr_step_t = CurrVal(i) * CurrVal(j);
+
+        cov_updated = cov_t + adaption_scale * (prev_means_t - curr_means_t + curr_step_t) / steps_post_burn;
+      }
+
+      (*adaptive_covariance)(i, j) = cov_updated;
+      (*adaptive_covariance)(j, i) = cov_updated;
     }
   }
+
+    int block_i = adapt_block_matrix_indices[i];
+
+    for (int j = 0; j <= i; ++j) {
+      if (IsFixed(j) || adapt_block_matrix_indices[j] != block_i) {
+        (*adaptive_covariance)(i, j) = 0.0;
+        (*adaptive_covariance)(j, i) = 0.0;
+        continue;
+      }
+
+      double cov_prev = (*adaptive_covariance)(i, j);
+      double cov_updated = 0.0;
+
+      if (steps_post_burn > 0) {
+      // Haario-style update
+        double cov_t = cov_prev * (steps_post_burn - 1) / steps_post_burn;
+        double prev_means_t = steps_post_burn * par_means_prev[i] * par_means_prev[j];
+        double curr_means_t = (steps_post_burn + 1) * par_means[i] * par_means[j];
+        double curr_step_t = CurrVal(i) * CurrVal(j);
+
+        cov_updated = cov_t + adaption_scale * (prev_means_t - curr_means_t + curr_step_t) / steps_post_burn;
+      }
+
+      (*adaptive_covariance)(i, j) = cov_updated;
+      (*adaptive_covariance)(j, i) = cov_updated;
+    }
+  }
+
 }
 
 // ********************************************
@@ -311,4 +369,12 @@ void AdaptiveMCMCHandler::Print() {
   MACH3LOG_INFO("Will only save every {} iterations"     , adaptive_save_n_iterations);
 }
 
+double AdaptiveMCMCHandler::CurrVal(int par_index){
+  /// HW Implemented as its own method to allow for
+  /// different behaviour in the future
+  return (*_fCurrVal)[par_index];
+}
+
 } //end adaptive_mcmc
+
+

--- a/Parameters/AdaptiveMCMCHandler.h
+++ b/Parameters/AdaptiveMCMCHandler.h
@@ -24,14 +24,15 @@ class AdaptiveMCMCHandler{
 
   /// @brief Read initial values from config file
   /// @param adapt_manager Config file from which we update matrix
-  bool InitFromConfig(const YAML::Node& adapt_manager, const std::string& matrix_name_str, const int Npars);
+  bool InitFromConfig(const YAML::Node& adapt_manager, const std::string& matrix_name_str,
+                         std::vector<double>* parameters, std::vector<double>* fixed);
 
   /// @brief If we don't have a covariance matrix to start from for adaptive tune we need to make one!
-  void CreateNewAdaptiveCovariance(const int Npars);
+  void CreateNewAdaptiveCovariance();
 
   /// @brief HW: sets adaptive block matrix
   /// @param block_indices Values for sub-matrix blocks
-  void SetAdaptiveBlocks(std::vector<std::vector<int>> block_indices, const int Npars);
+  void SetAdaptiveBlocks(std::vector<std::vector<int>> block_indices);
 
   /// @brief HW: Save adaptive throw matrix to file
   void SaveAdaptiveToFile(const std::string& outFileName, const std::string& systematicName, const bool is_final=false);
@@ -43,13 +44,12 @@ class AdaptiveMCMCHandler{
   void SetThrowMatrixFromFile(const std::string& matrix_file_name,
                               const std::string& matrix_name,
                               const std::string& means_name,
-                              bool& use_adaptive,
-                              const int Npars);
+                              bool& use_adaptive);
 
   /// @brief Method to update adaptive MCMC
   /// @cite haario2001adaptive
   /// @param _fCurrVal Value of each parameter necessary for updating throw matrix
-  void UpdateAdaptiveCovariance(const std::vector<double>& _fCurrVal, const int Npars);
+  void UpdateAdaptiveCovariance();
 
   /// @brief Tell whether we want reset step scale or not
   bool IndivStepScaleAdapt();
@@ -62,6 +62,33 @@ class AdaptiveMCMCHandler{
 
   /// @brief Tell if we are Skipping Adaption
   bool SkipAdaption();
+
+  /// @brief Set the current values of the parameters
+  void SetParams(std::vector<double>* params){
+    _fCurrVal = params;
+  }
+
+  /// @brief Set the fixed parameters
+  void SetFixed(std::vector<double>* fix){
+    _fFixedPars = fix;
+  }
+
+  /// @brief Get the current values of the parameters
+  int GetNPars(){
+    return static_cast<int>(_fCurrVal->size());
+  }
+
+  /// @brief Check if a parameter is fixed
+  bool IsFixed(int ipar){
+
+    if(!_fFixedPars){
+      return false;
+    }
+
+    return ((*_fFixedPars)[ipar] < 0);
+  }
+
+ 
 
   /// Meta variables related to adaption run time
   /// When do we start throwing
@@ -98,6 +125,18 @@ class AdaptiveMCMCHandler{
 
   /// Total number of MCMC steps
   int total_steps;
+
+  /// Scaling factor
+  double adaption_scale;
+
+  /// Vector of fixed parameters
+  std::vector<double>* _fFixedPars;
+  /// Current values of parameters
+  std::vector<double>* _fCurrVal;
+
+  /// @brief Get Current value of parameter
+  double CurrVal(int par_index);
+
 };
 
 } // adaptive_mcmc namespace

--- a/Parameters/AdaptiveMCMCHandler.h
+++ b/Parameters/AdaptiveMCMCHandler.h
@@ -25,7 +25,7 @@ class AdaptiveMCMCHandler{
   /// @brief Read initial values from config file
   /// @param adapt_manager Config file from which we update matrix
   bool InitFromConfig(const YAML::Node& adapt_manager, const std::string& matrix_name_str,
-                         std::vector<double>* parameters, std::vector<double>* fixed);
+                      const std::vector<double>* parameters, const std::vector<double>* fixed);
 
   /// @brief If we don't have a covariance matrix to start from for adaptive tune we need to make one!
   void CreateNewAdaptiveCovariance();
@@ -132,9 +132,9 @@ class AdaptiveMCMCHandler{
   double adaption_scale;
 
   /// Vector of fixed parameters
-  std::vector<double>* _fFixedPars;
+  const std::vector<double>* _fFixedPars;
   /// Current values of parameters
-  std::vector<double>* _fCurrVal;
+  const std::vector<double>* _fCurrVal;
 
 };
 

--- a/Parameters/AdaptiveMCMCHandler.h
+++ b/Parameters/AdaptiveMCMCHandler.h
@@ -64,12 +64,12 @@ class AdaptiveMCMCHandler{
   bool SkipAdaption();
 
   /// @brief Set the current values of the parameters
-  void SetParams(std::vector<double>* params){
+  void SetParams(const std::vector<double>* params){
     _fCurrVal = params;
   }
 
   /// @brief Set the fixed parameters
-  void SetFixed(std::vector<double>* fix){
+  void SetFixed(const std::vector<double>* fix){
     _fFixedPars = fix;
   }
 

--- a/Parameters/AdaptiveMCMCHandler.h
+++ b/Parameters/AdaptiveMCMCHandler.h
@@ -74,7 +74,7 @@ class AdaptiveMCMCHandler{
   }
 
   /// @brief Get the current values of the parameters
-  int GetNPars(){
+  int GetNumParams(){
     return static_cast<int>(_fCurrVal->size());
   }
 
@@ -90,7 +90,6 @@ class AdaptiveMCMCHandler{
 
   /// @brief Get Current value of parameter
   double CurrVal(int par_index);
-
 
   /// Meta variables related to adaption run time
   /// When do we start throwing
@@ -133,6 +132,7 @@ class AdaptiveMCMCHandler{
 
   /// Vector of fixed parameters
   const std::vector<double>* _fFixedPars;
+
   /// Current values of parameters
   const std::vector<double>* _fCurrVal;
 

--- a/Parameters/AdaptiveMCMCHandler.h
+++ b/Parameters/AdaptiveMCMCHandler.h
@@ -88,7 +88,9 @@ class AdaptiveMCMCHandler{
     return ((*_fFixedPars)[ipar] < 0);
   }
 
- 
+  /// @brief Get Current value of parameter
+  double CurrVal(int par_index);
+
 
   /// Meta variables related to adaption run time
   /// When do we start throwing
@@ -133,9 +135,6 @@ class AdaptiveMCMCHandler{
   std::vector<double>* _fFixedPars;
   /// Current values of parameters
   std::vector<double>* _fCurrVal;
-
-  /// @brief Get Current value of parameter
-  double CurrVal(int par_index);
 
 };
 

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -1047,7 +1047,7 @@ void ParameterHandlerBase::UpdateThrowMatrix(TMatrixDSym *cov){
 void ParameterHandlerBase::InitialiseAdaption(const YAML::Node& adapt_manager){
 // ********************************************
   // Now we read the general settings [these SHOULD be common across all matrices!]
-  bool success = AdaptiveHandler.InitFromConfig(adapt_manager, matrixName, GetNParameters());
+  bool success = AdaptiveHandler.InitFromConfig(adapt_manager, matrixName, &_fCurrVal, &_fError);
   if(!success) return;
   AdaptiveHandler.Print();
 
@@ -1057,7 +1057,7 @@ void ParameterHandlerBase::InitialiseAdaption(const YAML::Node& adapt_manager){
     MACH3LOG_WARN("Not using external matrix for {}, initialising adaption from scratch", matrixName);
     // If we don't have a covariance matrix to start from for adaptive tune we need to make one!
     use_adaptive = true;
-    AdaptiveHandler.CreateNewAdaptiveCovariance(_fNumPar);
+    AdaptiveHandler.CreateNewAdaptiveCovariance();
     return;
   }
 
@@ -1066,7 +1066,7 @@ void ParameterHandlerBase::InitialiseAdaption(const YAML::Node& adapt_manager){
   auto external_matrix_name = GetFromManager<std::string>(adapt_manager["AdaptionOptions"]["Covariance"][matrixName]["ExternalMatrixName"], "", __FILE__ , __LINE__);
   auto external_mean_name = GetFromManager<std::string>(adapt_manager["AdaptionOptions"]["Covariance"][matrixName]["ExternalMeansName"], "", __FILE__ , __LINE__);
 
-  AdaptiveHandler.SetThrowMatrixFromFile(external_file_name, external_matrix_name, external_mean_name, use_adaptive, _fNumPar);
+  AdaptiveHandler.SetThrowMatrixFromFile(external_file_name, external_matrix_name, external_mean_name, use_adaptive);
   SetThrowMatrix(AdaptiveHandler.adaptive_covariance);
   MACH3LOG_INFO("Successfully Set External Throw Matrix Stored in {}", external_file_name);
 }
@@ -1085,7 +1085,7 @@ void ParameterHandlerBase::UpdateAdaptiveCovariance(){
   }
 
   // Call main adaption function
-  AdaptiveHandler.UpdateAdaptiveCovariance(_fCurrVal, _fNumPar);
+  AdaptiveHandler.UpdateAdaptiveCovariance();
 
   //This is likely going to be the slow bit!
   if(AdaptiveHandler.IndivStepScaleAdapt()) {


### PR DESCRIPTION
# Pull request description
Calculating adaptive MCMC with fixed parameters was incorrect. This allows AMCMC to skip these parameters whilst adapting

## Changes or fixes
- Adds ability to correctly handle fixed parameters
- Re-arranges covariance calculation to match the form in https://projecteuclid.org/journals/bernoulli/volume-7/issue-2/An-adaptive-Metropolis-algorithm/bj/1080222083.full [note the calculation is exactly the same just neater]
- Adaption now takes pointers to errors + current parameter values as part of the constructor. This removes some clunk from the interface and allows it to keep track of fixed parameters

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
