### PR TITLE
breaking: Osc Channel Info

### DIFF
--- a/Samples/FarDetectorCoreInfoStruct.h
+++ b/Samples/FarDetectorCoreInfoStruct.h
@@ -4,7 +4,7 @@
 
 #include "Samples/Structs.h"
 
-/// @brief Store info about used osc channels
+/// @brief KS: Store info about used osc channels
 struct OscChannelInfo {
   /// Name of osc channel
   std::string flavourName;
@@ -15,9 +15,12 @@ struct OscChannelInfo {
   int InitPDG;
   /// PDG of oscillated/final flavour
   int FinalPDG;
+
+  /// In case experiment specific would like to have pointer to channel after using @GetOscChannel, they can set pointer to this
+  double ChannelIndex;
 };
 
-/// @brief Get Osc Channel Index based on initial and final PDG codes
+/// @brief KS: Get Osc Channel Index based on initial and final PDG codes
 /// @param OscChannel The vector of available oscillation channels
 /// @param InitFlav Initial flavour PDG code
 /// @param FinalFlav Final flavour PDG code
@@ -44,7 +47,6 @@ struct FarDetectorCoreInfo {
   ~FarDetectorCoreInfo(){if(isNC != nullptr) delete [] isNC;}
 
   int nEvents; ///< how many MC events are there
-  double ChannelIndex;
 
   std::vector<int*> Target; ///< target the interaction was on
   std::vector<const int*> nupdg;

--- a/Samples/FarDetectorCoreInfoStruct.h
+++ b/Samples/FarDetectorCoreInfoStruct.h
@@ -28,7 +28,7 @@ struct OscChannelInfo {
 inline int GetOscChannel(const std::vector<OscChannelInfo>& OscChannel, const int InitFlav, const int FinalFlav) {
   for (size_t i = 0; i < OscChannel.size(); ++i) {
     if (InitFlav == OscChannel[i].InitPDG && FinalFlav == OscChannel[i].FinalPDG) {
-      return static_cast<int>(i);
+      return static_cast<int>(OscChannel[i].ChannelIndex);
     }
   }
 

--- a/Samples/FarDetectorCoreInfoStruct.h
+++ b/Samples/FarDetectorCoreInfoStruct.h
@@ -1,7 +1,37 @@
 #pragma once
 #include <vector>
 #include <string>
+
 #include "Samples/Structs.h"
+
+/// @brief Store info about used osc channels
+struct OscChannelInfo {
+  /// Name of osc channel
+  std::string flavourName;
+  /// Fancy channel name (e.g., LaTeX formatted)
+  std::string flavourName_Latex;
+
+  /// PDG of initial flavour
+  int InitPDG;
+  /// PDG of oscillated/final flavour
+  int FinalPDG;
+};
+
+/// @brief Get Osc Channel Index based on initial and final PDG codes
+/// @param OscChannel The vector of available oscillation channels
+/// @param InitFlav Initial flavour PDG code
+/// @param FinalFlav Final flavour PDG code
+/// @return Index in OscChannel vector
+inline int GetOscChannel(const std::vector<OscChannelInfo>& OscChannel, const int InitFlav, const int FinalFlav) {
+  for (size_t i = 0; i < OscChannel.size(); ++i) {
+    if (InitFlav == OscChannel[i].InitPDG && FinalFlav == OscChannel[i].FinalPDG) {
+      return static_cast<int>(i);
+    }
+  }
+
+  MACH3LOG_ERROR("Didn't find Osc channel for InitFlav = {}, FinalFlav = {}", InitFlav, FinalFlav);
+  throw MaCh3Exception(__FILE__, __LINE__);
+}
 
 /// @brief constructors are same for all three so put in here
 struct FarDetectorCoreInfo {
@@ -15,8 +45,6 @@ struct FarDetectorCoreInfo {
 
   int nEvents; ///< how many MC events are there
   double ChannelIndex;
-  std::string flavourName;
-  std::string flavourName_Latex;
 
   std::vector<int*> Target; ///< target the interaction was on
   std::vector<const int*> nupdg;

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -3,7 +3,6 @@
 SampleHandlerBase::SampleHandlerBase() 
 {
   nDims = 0;
-  rnd = new TRandom3(0);
   dathist = NULL;
   dathist2d = NULL;
   Modes = nullptr;
@@ -14,7 +13,6 @@ SampleHandlerBase::~SampleHandlerBase()
   if(dathist != NULL) delete dathist;
   if(dathist2d != NULL) delete dathist2d;
   if(Modes != nullptr) delete Modes;
-  delete rnd;
 }
 
 void SampleHandlerBase::AddData(std::vector<double> &data)

--- a/Samples/SampleHandlerBase.h
+++ b/Samples/SampleHandlerBase.h
@@ -138,6 +138,4 @@ protected:
   // binned PDFs
   TH1D*_hPDF1D;
   TH2D*_hPDF2D;
-
-  TRandom3* rnd;
 };

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -132,6 +132,7 @@ void SampleHandlerFD::ReadSampleConfig()
     info.flavourName_Latex = osc_channel["LatexName"].as<std::string>();
     info.InitPDG           = static_cast<NuPDG>(osc_channel["nutype"].as<int>());
     info.FinalPDG          = static_cast<NuPDG>(osc_channel["oscnutype"].as<int>());
+    info.ChannelIndex      = static_cast<int>(OscChannels.size());
 
     OscChannels.push_back(std::move(info));
 
@@ -1974,4 +1975,13 @@ THStack* SampleHandlerFD::ReturnStackedHistBySelection1D(std::string KinematicPr
     StackHist->Add(HistList[i]);
   }
   return StackHist;
+}
+
+
+// ************************************************
+const double* SampleHandlerFD::GetPointerToOscChannel(int iSample, int iEvent) const {
+// ************************************************
+  int Channel = GetOscChannel(OscChannels, (*MCSamples[iSample].nupdgUnosc[iEvent]), (*MCSamples[iSample].nupdg[iEvent]));
+
+  return &(OscChannels[Channel].ChannelIndex);
 }

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -127,14 +127,14 @@ void SampleHandlerFD::ReadSampleConfig()
   OscChannels.reserve(nSamples);
 
   for (auto const &osc_channel : SampleManager->raw()["SubSamples"]) {
-    OscChannelInfo info;
-    info.flavourName       = osc_channel["Name"].as<std::string>();
-    info.flavourName_Latex = osc_channel["LatexName"].as<std::string>();
-    info.InitPDG           = static_cast<NuPDG>(osc_channel["nutype"].as<int>());
-    info.FinalPDG          = static_cast<NuPDG>(osc_channel["oscnutype"].as<int>());
-    info.ChannelIndex      = static_cast<int>(OscChannels.size());
+    OscChannelInfo OscInfo;
+    OscInfo.flavourName       = osc_channel["Name"].as<std::string>();
+    OscInfo.flavourName_Latex = osc_channel["LatexName"].as<std::string>();
+    OscInfo.InitPDG           = static_cast<NuPDG>(osc_channel["nutype"].as<int>());
+    OscInfo.FinalPDG          = static_cast<NuPDG>(osc_channel["oscnutype"].as<int>());
+    OscInfo.ChannelIndex      = static_cast<int>(OscChannels.size());
 
-    OscChannels.push_back(std::move(info));
+    OscChannels.push_back(std::move(OscInfo));
 
     mc_files.push_back(mtupleprefix+osc_channel["mtuplefile"].as<std::string>()+mtuplesuffix);
     spline_files.push_back(splineprefix+osc_channel["splinefile"].as<std::string>()+splinesuffix);

--- a/Samples/SampleHandlerFD.h
+++ b/Samples/SampleHandlerFD.h
@@ -78,12 +78,12 @@ public:
   }
   
   /// @ingroup SampleHandlerGetters
-  std::string GetFlavourName(int iSample) {
-    if (iSample < 0 || iSample > GetNMCSamples()) {
-      MACH3LOG_ERROR("Invalid Sample Requested: {}",iSample);
+  std::string GetFlavourName(const int iChannel) {
+    if (iChannel < 0 || iChannel > static_cast<int>(OscChannels.size())) {
+      MACH3LOG_ERROR("Invalid Channel Requested: {}", iChannel);
       throw MaCh3Exception(__FILE__ , __LINE__);      
     }
-    return MCSamples[iSample].flavourName;
+    return OscChannels[iChannel].flavourName;
   }
 
   /// @ingroup SampleHandlerGetters
@@ -308,6 +308,7 @@ public:
   //===============================================================================
   //MC variables
   std::vector<FarDetectorCoreInfo> MCSamples;
+  std::vector<OscChannelInfo> OscChannels;
   //===============================================================================
 
   //===============================================================================
@@ -357,12 +358,8 @@ public:
   void InitialiseSingleFDMCObject(int iSample, int nEvents);
   void InitialiseSplineObject();
 
-  std::vector<std::string> oscchan_flavnames;
-  std::vector<std::string> oscchan_flavnames_Latex;
   std::vector<std::string> mc_files;
   std::vector<std::string> spline_files;
-  std::vector<int> sample_nupdg;
-  std::vector<int> sample_nupdgunosc;
 
   std::unordered_map<std::string, double> _modeNomWeightMap;
   

--- a/Samples/SampleHandlerFD.h
+++ b/Samples/SampleHandlerFD.h
@@ -263,6 +263,8 @@ public:
   virtual const double* GetPointerToKinematicParameter(std::string KinematicParamter, int iSample, int iEvent) = 0; 
   virtual const double* GetPointerToKinematicParameter(double KinematicVariable, int iSample, int iEvent) = 0;
 
+  const double* GetPointerToOscChannel(int iSample, int iEvent) const;
+
   void SetupNormParameters();
 
   //===============================================================================


### PR DESCRIPTION
# Pull request description
We should get rid of OscChannel Loop structure. This PR introduces OscChannel info, this is supposed to give idea how we should retrieve info about osc channel post OscChannel loop removal.

This retreive ability to both retrieve OscChannel index as well as pointer to it

Merge this before: https://github.com/mach3-software/MaCh3Tutorial/pull/124
## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
