### PR TITLE
tidy: General post renaming tidy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,13 +20,19 @@
 *.cu @kskwarczynski
 *.cuh @kskwarczynski
 
+/Manager/YamlHelper* @kskwarczynski
+/Manager/MaCh3Logger* @kskwarczynski
+
 /Parameters/AdaptiveMCMCHandler* @henry-wallace-phys
+/Parameters/PCAHandler* @kskwarczynski
+
 /Fitters/* @kskwarczynski
 
 /Samples/SampleHandlerFD* @edatkin @dbarrow257
 /Samples/OscillationHandler* @dbarrow257
 
 /Splines/BinnedSplineHandler* @edatkin @dbarrow257
+/Splines/SplineMonolith* @kskwarczynski
 
 /Plotting/* @ewanwm
 *.py @henry-wallace-phys @ewanwm

--- a/Manager/MaCh3Modes.cpp
+++ b/Manager/MaCh3Modes.cpp
@@ -47,7 +47,6 @@ MaCh3Modes::MaCh3Modes(std::string const &filename) {
 // *******************
 void MaCh3Modes::Print() {
 // *******************
-
   MACH3LOG_INFO("Printing MaCh3 Modes Called: {}", Title);
 
   MACH3LOG_INFO("========================================================================");
@@ -111,7 +110,6 @@ void MaCh3Modes::DeclareNewMode(std::string const &name,
 // *******************
 void MaCh3Modes::PrepareMap() {
 // *******************
-
   int maxElement = 0;
   for(int i = 0; i < NModes; ++i) {
     for(size_t j = 0; j < fMode[i].GeneratorMaping.size(); j++) {

--- a/Manager/MaCh3Modes.h
+++ b/Manager/MaCh3Modes.h
@@ -49,7 +49,7 @@ class MaCh3Modes {
   void Print();
 
   /// @brief KS: Get number of modes, keep in mind actual number is +1 greater due to unknown category
-  inline int GetNModes(){return NModes;}
+  inline int GetNModes() const {return NModes;}
   /// @brief KS: Get mode number based on name, if mode not known you will get UNKNOWN_BAD
   MaCh3Modes_t GetMode(const std::string& name);
   /// @brief KS: Get normal name of mode, if mode not known you will get UNKNOWN_BAD
@@ -65,9 +65,9 @@ class MaCh3Modes {
   /// @brief KS: Get MaCh3 mode from generator mode
   MaCh3Modes_t GetModeFromGenerator(const int Index);
   /// @brief Get class name
-  inline std::string GetName()const {return "MaCh3Modes";};
+  inline std::string GetName() const {return "MaCh3Modes";};
   /// @brief Return count of CC modes
-  inline int GetNCCModes()const {return nCCModes;};
+  inline int GetNCCModes() const {return nCCModes;};
 
  private:
   /// @brief KS: Make sure we don't have two modes with the same name

--- a/Parameters/AdaptiveMCMCHandler.cpp
+++ b/Parameters/AdaptiveMCMCHandler.cpp
@@ -96,7 +96,7 @@ void AdaptiveMCMCHandler::CreateNewAdaptiveCovariance() {
 }
 
 // ********************************************
-void AdaptiveMCMCHandler::SetAdaptiveBlocks(std::vector<std::vector<int>> block_indices) {
+void AdaptiveMCMCHandler::SetAdaptiveBlocks(const std::vector<std::vector<int>>& block_indices) {
 // ********************************************
   /*
    *   In order to adapt efficient we want to setup our throw matrix to be a serious of block-diagonal (ish) matrices
@@ -140,8 +140,7 @@ void AdaptiveMCMCHandler::SetAdaptiveBlocks(std::vector<std::vector<int>> block_
 //HW: Truly adaptive MCMC!
 void AdaptiveMCMCHandler::SaveAdaptiveToFile(const std::string &outFileName,
                                              const std::string &systematicName, bool is_final) {
-  // ********************************************
-
+// ********************************************
   if (((total_steps - start_adaptive_throw) / adaptive_update_step) % adaptive_save_n_iterations == 0 || is_final) {
 
     TFile *outFile = new TFile(outFileName.c_str(), "UPDATE");
@@ -330,7 +329,7 @@ void AdaptiveMCMCHandler::Print() {
   MACH3LOG_INFO("Will only save every {} iterations"     , adaptive_save_n_iterations);
 }
 
-double AdaptiveMCMCHandler::CurrVal(int par_index){
+double AdaptiveMCMCHandler::CurrVal(const int par_index){
   /// HW Implemented as its own method to allow for
   /// different behaviour in the future
   return (*_fCurrVal)[par_index];

--- a/Parameters/AdaptiveMCMCHandler.h
+++ b/Parameters/AdaptiveMCMCHandler.h
@@ -32,7 +32,7 @@ class AdaptiveMCMCHandler{
 
   /// @brief HW: sets adaptive block matrix
   /// @param block_indices Values for sub-matrix blocks
-  void SetAdaptiveBlocks(std::vector<std::vector<int>> block_indices);
+  void SetAdaptiveBlocks(const std::vector<std::vector<int>>& block_indices);
 
   /// @brief HW: Save adaptive throw matrix to file
   void SaveAdaptiveToFile(const std::string& outFileName, const std::string& systematicName, const bool is_final=false);
@@ -74,13 +74,12 @@ class AdaptiveMCMCHandler{
   }
 
   /// @brief Get the current values of the parameters
-  int GetNumParams(){
+  int GetNumParams() const {
     return static_cast<int>(_fCurrVal->size());
   }
 
   /// @brief Check if a parameter is fixed
-  bool IsFixed(int ipar){
-
+  bool IsFixed(const int ipar) const {
     if(!_fFixedPars){
       return false;
     }
@@ -89,7 +88,7 @@ class AdaptiveMCMCHandler{
   }
 
   /// @brief Get Current value of parameter
-  double CurrVal(int par_index);
+  double CurrVal(const int par_index);
 
   /// Meta variables related to adaption run time
   /// When do we start throwing
@@ -104,11 +103,11 @@ class AdaptiveMCMCHandler{
   /// Steps between changing throw matrix
   int adaptive_update_step;
 
-  /// If you don't want to save every adpation then
+  /// If you don't want to save every adaption then
   /// you can specify this here
   int adaptive_save_n_iterations;
 
-  /// Name of the file to save the adpative matrices into
+  /// Name of the file to save the adaptive matrices into
   std::string output_file_name;
 
   /// Indices for block-matrix adaption
@@ -135,7 +134,6 @@ class AdaptiveMCMCHandler{
 
   /// Current values of parameters
   const std::vector<double>* _fCurrVal;
-
 };
 
 } // adaptive_mcmc namespace

--- a/Parameters/PCAHandler.h
+++ b/Parameters/PCAHandler.h
@@ -36,11 +36,19 @@ class PCAHandler{
   virtual ~PCAHandler();
 
   /// @brief KS: Setup pointers to current and proposed parameter value which we need to convert them to PCA base each step
+  /// @param fCurr_Val pointer to current position of parameter
+  /// @param fProp_Val pointer to proposed position of parameter
   void SetupPointers(std::vector<double>* fCurr_Val,
                      std::vector<double>* fProp_Val);
 
   /// @brief CW: Calculate eigen values, prepare transition matrices and remove param based on defined threshold
-  void ConstructPCA(TMatrixDSym * covMatrix, const int firstPCAd, const int lastPCAd,
+  /// @param CovMatrix       Symmetric covariance matrix used for eigen decomposition.
+  /// @param firstPCAd       Index of the first PCA component to include.
+  /// @param lastPCAd        Index of the last PCA component to include.
+  /// @param eigen_thresh    Threshold for eigenvalues below which parameters are discarded.
+  /// @param _fNumParPCA     Output: number of parameters retained in PCA basis.
+  /// @param _fNumPar        Total number of parameters in the original (non-PCA) basis.
+  void ConstructPCA(TMatrixDSym * CovMatrix, const int firstPCAd, const int lastPCAd,
                     const double eigen_thresh, int& _fNumParPCA, const int _fNumPar);
 
   /// @brief Transfer param values from normal base to PCA base

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -85,7 +85,7 @@ class ParameterHandlerBase {
   /// @brief Get random value useful for debugging/CI
   /// @param i Parameter index
   /// @ingroup ParameterHandlerGetters
-  double GetRandomThrow(const int i) { return randParams[i];}
+  double GetRandomThrow(const int i) const { return randParams[i];}
 
   /// @brief set branches for output file
   /// @param tree Tree to which we will save branches
@@ -133,23 +133,23 @@ class ParameterHandlerBase {
 
   /// @brief Return covariance matrix
   /// @ingroup ParameterHandlerGetters
-  TMatrixDSym *GetCovMatrix() { return covMatrix; }
+  TMatrixDSym *GetCovMatrix() const { return covMatrix; }
   /// @brief Return inverted covariance matrix
   /// @ingroup ParameterHandlerGetters
-  TMatrixDSym *GetInvCovMatrix() { return invCovMatrix; }
+  TMatrixDSym *GetInvCovMatrix() const { return invCovMatrix; }
   /// @brief Return inverted covariance matrix
   /// @ingroup ParameterHandlerGetters
-  double GetInvCovMatrix(const int i, const int j) { return InvertCovMatrix[i][j]; }
+  double GetInvCovMatrix(const int i, const int j) const { return InvertCovMatrix[i][j]; }
 
   /// @brief Return correlated throws
   /// @param i Parameter index
   /// @ingroup ParameterHandlerGetters
-  double GetCorrThrows(const int i) { return corr_throw[i]; }
+  double GetCorrThrows(const int i) const { return corr_throw[i]; }
 
   /// @brief Get if param has flat prior or not
   /// @param i Parameter index
   /// @ingroup ParameterHandlerGetters
-  inline bool GetFlatPrior(const int i) { return _fFlatPrior[i]; }
+  inline bool GetFlatPrior(const int i) const { return _fFlatPrior[i]; }
 
   /// @brief Get name of covariance
   /// @ingroup ParameterHandlerGetters
@@ -187,7 +187,7 @@ class ParameterHandlerBase {
 
   /// @brief Do we adapt or not
   /// @ingroup ParameterHandlerGetters
-  bool GetDoAdaption(){return use_adaptive;}
+  bool GetDoAdaption() const {return use_adaptive;}
   /// @brief Use new throw matrix, used in adaptive MCMC
   /// @ingroup ParameterHandlerSetters
   void SetThrowMatrix(TMatrixDSym *cov);
@@ -201,16 +201,16 @@ class ParameterHandlerBase {
 
   /// @brief Get matrix used for step proposal
   /// @ingroup ParameterHandlerGetters
-  inline TMatrixDSym *GetThrowMatrix(){return throwMatrix;}
+  inline TMatrixDSym *GetThrowMatrix() const {return throwMatrix;}
   /// @brief Get matrix used for step proposal
   /// @ingroup ParameterHandlerGetters
-  double GetThrowMatrix(int i, int j) { return throwMatrixCholDecomp[i][j];}
+  double GetThrowMatrix(int i, int j) const { return throwMatrixCholDecomp[i][j];}
   /// @brief Get the Cholesky decomposition of the throw matrix
   /// @ingroup ParameterHandlerGetters
-  inline TMatrixD *GetThrowMatrix_CholDecomp(){return throwMatrix_CholDecomp;}
+  inline TMatrixD *GetThrowMatrix_CholDecomp() const {return throwMatrix_CholDecomp;}
   /// @brief Get the parameter means used in the adaptive handler
   /// @ingroup ParameterHandlerGetters
-  inline std::vector<double> GetParameterMeans(){return AdaptiveHandler->par_means;}
+  inline std::vector<double> GetParameterMeans() const {return AdaptiveHandler->par_means;}
   /// @brief KS: Convert covariance matrix to correlation matrix and return TH2D which can be used for fancy plotting
   /// @details This function converts the covariance matrix to a correlation matrix and
   ///          returns a TH2D object, which can be used for advanced plotting purposes.
@@ -264,7 +264,7 @@ class ParameterHandlerBase {
   /// @brief Return generated value, although is virtual so class inheriting might actual get prior not generated.
   /// @param i Parameter index
   /// @ingroup ParameterHandlerGetters
-  virtual double GetNominal(const int i) { return GetParInit(i); }
+  virtual double GetNominal(const int i) const { return GetParInit(i); }
   /// @brief Return generated value for a given parameter
   /// @param i Parameter index
   /// @ingroup ParameterHandlerGetters
@@ -287,7 +287,7 @@ class ParameterHandlerBase {
   /// @brief Get current parameter value using PCA
   /// @param i Parameter index
   /// @ingroup ParameterHandlerGetters
-  inline double GetParPropPCA(const int i)  {
+  inline double GetParPropPCA(const int i) const {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     return PCAObj->_fParPropPCA(i);
   }
@@ -295,7 +295,7 @@ class ParameterHandlerBase {
   /// @brief Get current parameter value using PCA
   /// @param i Parameter index
   /// @ingroup ParameterHandlerGetters
-  inline double GetParCurrPCA(const int i) {
+  inline double GetParCurrPCA(const int i) const {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     return PCAObj->_fParCurrPCA(i);
   }
@@ -303,31 +303,31 @@ class ParameterHandlerBase {
   /// @brief Is parameter fixed in PCA base or not
   /// @param i Parameter index
   /// @ingroup ParameterHandlerGetters
-  inline bool IsParameterFixedPCA(const int i) {
+  inline bool IsParameterFixedPCA(const int i) const {
     if (PCAObj->_fParSigmaPCA[i] < 0) { return true;  }
     else                              { return false; }
   }
   /// @brief Get transfer matrix allowing to go from PCA base to normal base
   /// @ingroup ParameterHandlerGetters
-  inline const TMatrixD GetTransferMatrix() {
+  inline const TMatrixD GetTransferMatrix() const {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     return PCAObj->TransferMat;
   }
   /// @brief Get eigen vectors of covariance matrix, only works with PCA
   /// @ingroup ParameterHandlerGetters
-  inline const TMatrixD GetEigenVectors() {
+  inline const TMatrixD GetEigenVectors() const {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     return PCAObj->eigen_vectors;
   }
   /// @brief Get eigen values for all parameters, if you want for decomposed only parameters use GetEigenValuesMaster
   /// @ingroup ParameterHandlerGetters
-  inline const TVectorD GetEigenValues() {
+  inline const TVectorD GetEigenValues() const {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     return PCAObj->eigen_values;
   }
   /// @brief Get eigen value of only decomposed parameters, if you want for all parameters use GetEigenValues
   /// @ingroup ParameterHandlerGetters
-  inline const std::vector<double> GetEigenValuesMaster() {
+  inline const std::vector<double> GetEigenValuesMaster() const {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     return PCAObj->eigen_values_master;
   }
@@ -357,7 +357,7 @@ class ParameterHandlerBase {
   inline void SetParametersPCA(const std::vector<double> &pars) {
     if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
     if (int(pars.size()) != _fNumParPCA) {
-      MACH3LOG_ERROR("Warning: parameter arrays of incompatible size! Not changing parameters! {} has size {} but was expecting {}", matrixName, pars.size(), _fNumPar);
+      MACH3LOG_ERROR("Parameter arrays of incompatible size! Not changing parameters! {} has size {} but was expecting {}", matrixName, pars.size(), _fNumPar);
       throw MaCh3Exception(__FILE__ , __LINE__ );
     }
     int parsSize = int(pars.size());
@@ -370,7 +370,7 @@ class ParameterHandlerBase {
 
   /// @brief Get number of params which will be different depending if using Eigen decomposition or not
   /// @ingroup ParameterHandlerGetters
-  inline int GetNParameters() {
+  inline int GetNParameters() const {
     if (pca) return _fNumParPCA;
     else return _fNumPar;
   }
@@ -419,7 +419,7 @@ class ParameterHandlerBase {
   void ConstructPCA();
 
   /// @brief is PCA, can use to query e.g. LLH scans
-  inline bool IsPCA() { return pca; }
+  inline bool IsPCA() const { return pca; }
 
   /// @brief KS: Custom function to perform multiplication of matrix and vector with multithreading
   /// @param VecMulti Output Vector, VecMulti = matrix x vector
@@ -440,7 +440,7 @@ class ParameterHandlerBase {
 
   // HH: Getter for use_adaptive
   /// @brief Get bool for whether we are using adaptive MCMC
-  inline bool getUseAdaptive() { return use_adaptive; }
+  inline bool getUseAdaptive() const { return use_adaptive; }
 
 
 protected:

--- a/Parameters/ParameterHandlerGeneric.cpp
+++ b/Parameters/ParameterHandlerGeneric.cpp
@@ -8,7 +8,7 @@
 ParameterHandlerGeneric::ParameterHandlerGeneric(const std::vector<std::string>& YAMLFile, std::string name, double threshold, int FirstPCA, int LastPCA)
                : ParameterHandlerBase(YAMLFile, name, threshold, FirstPCA, LastPCA){
 // ********************************************
-  InitXsecFromConfig();
+  InitParametersTypeFromConfig();
 
   //ETA - again this really doesn't need to be hear...
   for (int i = 0; i < _fNumPar; i++)
@@ -17,14 +17,14 @@ ParameterHandlerGeneric::ParameterHandlerGeneric(const std::vector<std::string>&
     if(int(_fNames[i].length()) > PrintLength) PrintLength = int(_fNames[i].length());
   } // end the for loop
 
-  MACH3LOG_DEBUG("Constructing instance of covarianceXsec");
+  MACH3LOG_DEBUG("Constructing instance of ParameterHandler");
   InitParams();
   // Print
   Print();
 }
 
 // ********************************************
-void ParameterHandlerGeneric::InitXsecFromConfig() {
+void ParameterHandlerGeneric::InitParametersTypeFromConfig() {
 // ********************************************
   _fSystToGlobalSystIndexMap.resize(SystType::kSystTypes);
 
@@ -101,7 +101,7 @@ void ParameterHandlerGeneric::InitXsecFromConfig() {
 // ********************************************
 ParameterHandlerGeneric::~ParameterHandlerGeneric() {
 // ********************************************
-  MACH3LOG_DEBUG("Deleting covarianceXsec");
+  MACH3LOG_DEBUG("Deleting ParameterHandler");
 }
 
 // ********************************************
@@ -173,8 +173,7 @@ NormParameter ParameterHandlerGeneric::GetNormParameter(const YAML::Node& param,
 
   //ETA - I think this can go in the norm parameters only if statement above
   int NumKinematicCuts = 0;
-  if(param["KinematicCuts"]){
-
+  if(param["KinematicCuts"]) {
     NumKinematicCuts = int(param["KinematicCuts"].size());
 
     std::vector<std::string> TempKinematicStrings;
@@ -187,7 +186,7 @@ NormParameter ParameterHandlerGeneric::GetNormParameter(const YAML::Node& param,
         TempKinematicBounds.push_back(it->second.as<std::vector<double>>());
       }
       if(TempKinematicStrings.size() == 0) {
-        MACH3LOG_ERROR("Recived a KinematicCuts node but couldn't read the contents (it's a list of single-element dictionaries (python) = map of pairs (C++))");
+        MACH3LOG_ERROR("Received a KinematicCuts node but couldn't read the contents (it's a list of single-element dictionaries (python) = map of pairs (C++))");
         MACH3LOG_ERROR("For Param {}", norm.name);
         throw MaCh3Exception(__FILE__, __LINE__);
       }
@@ -310,7 +309,7 @@ FunctionalParameter ParameterHandlerGeneric::GetFunctionalParameters(const YAML:
         TempKinematicBounds.push_back(it->second.as<std::vector<double>>());
       }
       if(TempKinematicStrings.size() == 0) {
-        MACH3LOG_ERROR("Recived a KinematicCuts node but couldn't read the contents (it's a list of single-element dictionaries (python) = map of pairs (C++))");
+        MACH3LOG_ERROR("Received a KinematicCuts node but couldn't read the contents (it's a list of single-element dictionaries (python) = map of pairs (C++))");
         MACH3LOG_ERROR("For Param {}", func.name);
         throw MaCh3Exception(__FILE__, __LINE__);
       }
@@ -435,7 +434,7 @@ void ParameterHandlerGeneric::InitParams() {
 void ParameterHandlerGeneric::Print() {
 // ********************************************
   MACH3LOG_INFO("#################################################");
-  MACH3LOG_INFO("Printing covarianceXsec:");
+  MACH3LOG_INFO("Printing ParameterHandlerGeneric:");
 
   PrintGlobablInfo();
 
@@ -633,7 +632,7 @@ void ParameterHandlerGeneric::SetGroupOnlyParameters(const std::string& Group) {
       if(IsParFromGroup(i, Group)) _fPropVal[i] = _fPreFitValue[i];
     }
   } else {
-    MACH3LOG_ERROR("SetGroupOnlyParameters not implemented for PCA");
+    MACH3LOG_ERROR("{} not implemented for PCA", __func__);
     throw MaCh3Exception(__FILE__, __LINE__);
   }
 }
@@ -746,5 +745,5 @@ void ParameterHandlerGeneric::DumpMatrixToFile(const std::string& Name) {
   outputFile->Close();
   delete outputFile;
 
-  MACH3LOG_INFO("Finished dumping covariance object");
+  MACH3LOG_INFO("Finished dumping ParameterHandler object");
 }

--- a/Parameters/ParameterHandlerGeneric.h
+++ b/Parameters/ParameterHandlerGeneric.h
@@ -124,7 +124,7 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
   protected:
     /// @brief Print information about the whole object once it is set
     void Print();
-    /// @brief Prints general information about the covarianceXsec object.
+    /// @brief Prints general information about the ParameterHandler object.
     void PrintGlobablInfo();
     /// @brief Prints normalization parameters.
     void PrintNormParams();
@@ -160,7 +160,7 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
 
     /// @brief Parses the YAML configuration to set up cross-section parameters.
     /// The YAML file defines the types of systematic errors, interpolation types, and bounds for splines.
-    inline void InitXsecFromConfig();
+    inline void InitParametersTypeFromConfig();
 
     /// @brief Get Norm params
     /// @param param Yaml node describing param

--- a/Plotting/plottingUtils/inputManager.cpp
+++ b/Plotting/plottingUtils/inputManager.cpp
@@ -108,7 +108,6 @@ void InputManager::print(const std::string &printLevel) const {
 
 double InputManager::getPostFitError(int fileNum, const std::string &paramName,
                                           std::string errorType) const {
-
   const InputFile &inputFileDef = getFile(fileNum);
 
   // set default type if not specified
@@ -137,7 +136,6 @@ double InputManager::getPostFitError(int fileNum, const std::string &paramName,
 
 double InputManager::getPostFitValue(int fileNum, const std::string &paramName,
                                           std::string errorType) const {
-  
   const InputFile &inputFileDef = getFile(fileNum);
 
   // set default type if not specified
@@ -172,7 +170,6 @@ double InputManager::getPostFitValue(int fileNum, const std::string &paramName,
 std::vector<std::string> InputManager::getTaggedValues(const std::vector<std::string> &values, 
                                                        const std::unordered_map<std::string, std::vector<std::string>> &tagMap, 
                                                        const std::vector<std::string> &tags, std::string checkType) const {
-                                                          
   // check that checkType is valid
   if(
     checkType != "all" &&
@@ -232,7 +229,6 @@ std::vector<std::string> InputManager::getTaggedValues(const std::vector<std::st
 std::vector<std::string> InputManager::parseLocation(const std::string &rawLocationString, std::string &fitter,
                                                      fileTypeEnum fileType, const std::string &parameter,
                                                      const std::string &sample, const std::string &parameter2) const {
-
   std::string locationString(rawLocationString);
   std::vector<std::string> tokens;
 
@@ -290,7 +286,6 @@ std::vector<std::string> InputManager::parseLocation(const std::string &rawLocat
 
 std::shared_ptr<TObject> InputManager::findRootObject(const InputFile &fileDef,
                                       const std::vector<std::string> &locationVec) const {
-
   std::shared_ptr<TObject> object = nullptr;
 
   // if vector only has one element, just interpret it as the absolute path to the object
@@ -401,7 +396,6 @@ bool InputManager::findRawChainSteps(InputFile &inputFileDef, const std::string 
   // make sure that the filedef object has all the necessary stuff to read from the posterior tree
   if ( (inputFileDef.mcmcProc != nullptr) && (inputFileDef.posteriorTree != nullptr) )
   {
-
     const std::vector<TString> branchNames = inputFileDef.mcmcProc->GetBranchNames();
 
     std::string specificName = getFitterSpecificParamName(fitter, kMCMC, parameter);
@@ -539,7 +533,6 @@ void InputManager::fillFileInfo(InputFile &inputFileDef, bool printThoughts) {
     // check for all 3 LLH directory types
     for (std::string LLHType : {"sample", "penalty", "total"})
     {
-
       if (printThoughts)
         MACH3LOG_INFO(".... searching for {} LLH scans... ", LLHType);
 

--- a/Splines/BinnedSplineHandler.cpp
+++ b/Splines/BinnedSplineHandler.cpp
@@ -13,13 +13,13 @@ _MaCh3_Safe_Include_End_ //}
 BinnedSplineHandler::BinnedSplineHandler(ParameterHandlerGeneric *xsec_, MaCh3Modes *Modes_) : SplineBase() {
 //****************************************
   if (!xsec_) {
-    MACH3LOG_ERROR("Trying to create splineFDBase with uninitialized covariance object");
+    MACH3LOG_ERROR("Trying to create BinnedSplineHandler with uninitialized covariance object");
     throw MaCh3Exception(__FILE__, __LINE__);
   }
   xsec = xsec_;
 
   if (!Modes_) {
-    MACH3LOG_ERROR("Trying to create splineFDBase with uninitialized MaCh3Modes object");
+    MACH3LOG_ERROR("Trying to create BinnedSplineHandler with uninitialized MaCh3Modes object");
     throw MaCh3Exception(__FILE__, __LINE__);
   }
   Modes = Modes_;
@@ -330,7 +330,7 @@ std::vector<TAxis *> BinnedSplineHandler::FindSplineBinning(const std::string& F
     Obj = File->Get(TemplateName.c_str());
     if (!Obj)
     {
-      MACH3LOG_ERROR("Error: could not find dev_tmp_0_0 in spline file. Spline binning cannot be set!");
+      MACH3LOG_ERROR("Could not find dev_tmp_0_0 in spline file. Spline binning cannot be set!");
       MACH3LOG_ERROR("FileName: {}", FileName);
       throw MaCh3Exception(__FILE__ , __LINE__ );
     }
@@ -916,7 +916,7 @@ void BinnedSplineHandler::FillSampleArray(std::string SampleName, std::vector<st
       // If the syst doesn't match any of the spline names then skip it
       if (SystNum == -1){
         MACH3LOG_DEBUG("Couldn't match!!");
-        MACH3LOG_DEBUG("Couldn't Match any systematic name in xsec yaml with spline name: {}" , FullSplineName);
+        MACH3LOG_DEBUG("Couldn't Match any systematic name in ParameterHandler with spline name: {}" , FullSplineName);
         continue;
       }
 


### PR DESCRIPTION
# Pull request description


## Changes or fixes
- Increase usage of const
- Some fucntions/logger/text were still referring to preRenaming names [I am certain there are more such cases]
- Several logger messages had hardcoded fucntion name, which post renaming make no sense, isntead use `__func__ `which is much more flexible appraoch
- Plus fix some typos and increase docueamtnion

## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
