### PR TITLE
feat: Doxygen interactive SVG

### DIFF
--- a/Diagnostics/CombineMaCh3Chains.cpp
+++ b/Diagnostics/CombineMaCh3Chains.cpp
@@ -17,7 +17,7 @@ _MaCh3_Safe_Include_Start_ //{
 #include "TROOT.h"
 _MaCh3_Safe_Include_End_ //}
 
-/// @file CombineMaCh3Chains
+/// @file CombineMaCh3Chains.cpp
 /// @author Ewan Miller
 /// @author Kamil Skwarczynski
 

--- a/Doc/Doxyfile
+++ b/Doc/Doxyfile
@@ -817,7 +817,7 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        = std::* __gnu_cxx::* std::__cxx11::*
+EXCLUDE_SYMBOLS        =
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include

--- a/Doc/Doxyfile
+++ b/Doc/Doxyfile
@@ -817,7 +817,7 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = std::* __gnu_cxx::* std::__cxx11::*
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
@@ -2208,7 +2208,7 @@ DIRECTORY_GRAPH        = YES
 # The default value is: png.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_IMAGE_FORMAT       = png
+DOT_IMAGE_FORMAT       = svg
 
 # If DOT_IMAGE_FORMAT is set to svg, then this option can be set to YES to
 # enable generation of interactive SVG images that allow zooming and panning.
@@ -2220,7 +2220,7 @@ DOT_IMAGE_FORMAT       = png
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-INTERACTIVE_SVG        = NO
+INTERACTIVE_SVG        = YES
 
 # The DOT_PATH tag can be used to specify the path where the dot tool can be
 # found. If left blank, it is assumed the dot tool can be found in the path.

--- a/Fitters/MCMCProcessor.h
+++ b/Fitters/MCMCProcessor.h
@@ -120,7 +120,6 @@ class MCMCProcessor {
     /// @param CredibleRegions Vector with values of credible intervals, must be in descending order
     /// @param CredibleRegionStyle Style_t telling what line style to use for each Interval line
     /// @param CredibleRegionColor Color_t telling what colour to use for each Interval line
-    /// @param CredibleInSigmas Bool telling whether intervals are in percentage or in sigmas, then special conversions is used
     void MakeTrianglePlot(const std::vector<std::string>& ParNames,
                           // 1D
                           const std::vector<double>& CredibleIntervals = {0.99, 0.90, 0.68 },
@@ -166,7 +165,7 @@ class MCMCProcessor {
                          const std::vector<double>& EvaluationPoint,
                          const std::vector<std::vector<double>>& Bounds);
     /// @brief Reweight Prior by giving new central value and new error
-    /// @param ParName Parameter names for which we do reweighting
+    /// @param Names Parameter names for which we do reweighting
     /// @param NewCentral New central value for which we reweight
     /// @param NewError New error used for calculating weight
     void ReweightPrior(const std::vector<std::string>& Names,
@@ -174,7 +173,7 @@ class MCMCProcessor {
                        const std::vector<double>& NewError);
     
     /// @brief Make .gif of parameter evolution
-    /// @param ParName Parameter names for which we do .gif
+    /// @param Names Parameter names for which we do .gif
     /// @param NIntervals Number of intervals for a gif
     void ParameterEvolution(const std::vector<std::string>& Names,
                             const std::vector<int>& NIntervals);

--- a/Fitters/MaCh3Factory.h
+++ b/Fitters/MaCh3Factory.h
@@ -18,8 +18,6 @@
 
 /// @brief MaCh3 Factory initiates one of implemented fitting algorithms
 /// @param fitMan pointer to Manager class
-/// @param Samples vector of Sample PDF which will be used in the fits
-/// @param Covariances vector of Systematic objects which will be used in the fits
 ///
 /// @note Example YAML configuration:
 /// @code
@@ -41,8 +39,8 @@ std::unique_ptr<manager> MaCh3ManagerFactory(int argc, char **argv);
 // ********************************************
 /// @brief Factory function for creating a covariance class for systematic handling.
 ///
-/// @param fitMan Pointer to the manager class that holds the configuration settings.
-/// @param name Prefix, for example Xsec, then code will look for XsecCovFile
+/// @param FitManager Pointer to the manager class that holds the configuration settings.
+/// @param PreFix Prefix, for example Xsec, then code will look for XsecCovFile
 /// @return Pointer to the initialized covarianceXsec matrix object.
 ///
 /// @note Example YAML configuration:

--- a/Fitters/StatisticalUtils.h
+++ b/Fitters/StatisticalUtils.h
@@ -111,12 +111,12 @@ void GetCredibleIntervalSig(const std::unique_ptr<TH1D>& hist, std::unique_ptr<T
 
 /// @brief KS: Set 2D contour within some coverage
 /// @param hist2D histograms based on which we calculate credible regions
-/// @param CredibleInSigmas Whether interval is in sigmas or percentage
 /// @param coverage What is defined coverage, by default 0.6827 (1 sigma)
 void GetCredibleRegion(std::unique_ptr<TH2D>& hist2D, const double coverage = 0.6827);
 
 /// @brief KS: Set 2D contour within some coverage
 /// @param hist2D histograms based on which we calculate credible regions
+/// @param CredibleInSigmas Whether interval is in sigmas or percentage
 /// @param coverage What is defined coverage, by default 0.6827 (1 sigma)
 void GetCredibleRegionSig(std::unique_ptr<TH2D>& hist2D, const bool CredibleInSigmas, const double coverage = 0.6827);
 

--- a/Fitters/gpuMCMCProcessorUtils.cuh
+++ b/Fitters/gpuMCMCProcessorUtils.cuh
@@ -9,7 +9,7 @@
 
 #include "Manager/gpuUtils.cuh"
 
-/// @file gpuMCMCProcessorUtils
+/// @file gpuMCMCProcessorUtils.cuh
 /// @author Kamil Skwarczynski
 
 /// @brief KS: Initialiser, here we allocate memory for variables and copy constants

--- a/Manager/YamlHelper.h
+++ b/Manager/YamlHelper.h
@@ -221,6 +221,15 @@ inline bool compareYAMLNodes(const YAML::Node& node1, const YAML::Node& node2) {
 
 // **********************
 /// @brief Overrides the configuration settings based on provided arguments.
+/// @param node YAML node that will be modified
+template <typename TValue>
+void OverrideConfig(YAML::Node node, std::string const &key, TValue val) {
+// **********************
+  node[key] = val;
+}
+
+// **********************
+/// @brief Overrides the configuration settings based on provided arguments.
 ///
 /// This function allows you to set configuration options in a nested YAML node.
 /// @param node YAML node that will be modified
@@ -232,11 +241,6 @@ inline bool compareYAMLNodes(const YAML::Node& node1, const YAML::Node& node2) {
 /// OverrideConfig(config, "General", "OutputFile", "Wooimbouttamakeanameformyselfere.root");
 /// OverrideConfig(config, "General", "MyDouble", 5.3);
 /// @endcode
-template <typename TValue>
-void OverrideConfig(YAML::Node node, std::string const &key, TValue val) {
-// **********************
-  node[key] = val;
-}
 template <typename... Args>
 void OverrideConfig(YAML::Node node, std::string const &key, Args... args) {
 // **********************

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -28,10 +28,10 @@ class ParameterHandlerBase {
   /// @brief Destructor
   virtual ~ParameterHandlerBase();
   
-  /// @defgroup ParameterHandlerSetters
+  /// @defgroup ParameterHandlerSetters Parameter Handler Setters
   /// Group of functions to set various parameters, names, and values.
 
-  /// @defgroup ParameterHandlerGetters
+  /// @defgroup ParameterHandlerGetters Parameter Handler Getters
   /// Group of functions to get various parameters, names, and values.
 
   // ETA - maybe need to add checks to index on the setters? i.e. if( i > _fPropVal.size()){throw;}

--- a/Plotting/GetPostfitParamPlots.cpp
+++ b/Plotting/GetPostfitParamPlots.cpp
@@ -26,7 +26,7 @@ _MaCh3_Safe_Include_Start_ //{
 #include "TGraphAsymmErrors.h"
 _MaCh3_Safe_Include_End_ //}
 
-/// @file GetPostfitParamPlots
+/// @file GetPostfitParamPlots.cpp
 /// This script generates post-fit parameter plots. The central postfit value is
 /// taken as the Highest Posterior Density (HPD), but can be easily changed to
 /// another method such as Gaussian. Be cautious as parameter names and the number

--- a/Plotting/PlotLLH.cpp
+++ b/Plotting/PlotLLH.cpp
@@ -9,7 +9,7 @@
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
 #pragma GCC diagnostic ignored "-Wconversion"
 
-/// @file PlotLLH
+/// @file PlotLLH.cpp
 /// @author Ewan Miller
 
 // some options for the plots

--- a/Samples/SampleHandlerBase.h
+++ b/Samples/SampleHandlerBase.h
@@ -29,10 +29,10 @@ class SampleHandlerBase
   /// @brief destructor
   virtual ~SampleHandlerBase();
 
-  /// @defgroup SampleHandlerSetters
+  /// @defgroup SampleHandlerSetters Sample Handler Setters
   /// Group of functions to set various parameters, names, and values.
 
-  /// @defgroup SampleHandlerGetters
+  /// @defgroup SampleHandlerGetters Sample Handler Getters
   /// Group of functions to get various parameters, names, and values.
 
   /// @ingroup SampleHandlerGetters

--- a/cmake/Templates/Doxyfile.in
+++ b/cmake/Templates/Doxyfile.in
@@ -817,7 +817,7 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        = std::* __gnu_cxx::* std::__cxx11::*
+EXCLUDE_SYMBOLS        =
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include

--- a/cmake/Templates/Doxyfile.in
+++ b/cmake/Templates/Doxyfile.in
@@ -817,7 +817,7 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = std::* __gnu_cxx::* std::__cxx11::*
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
@@ -2208,7 +2208,7 @@ DIRECTORY_GRAPH        = YES
 # The default value is: png.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_IMAGE_FORMAT       = png
+DOT_IMAGE_FORMAT       = svg
 
 # If DOT_IMAGE_FORMAT is set to svg, then this option can be set to YES to
 # enable generation of interactive SVG images that allow zooming and panning.
@@ -2220,7 +2220,7 @@ DOT_IMAGE_FORMAT       = png
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-INTERACTIVE_SVG        = NO
+INTERACTIVE_SVG        = YES
 
 # The DOT_PATH tag can be used to specify the path where the dot tool can be
 # found. If left blank, it is assumed the dot tool can be found in the path.


### PR DESCRIPTION
# Pull request description
Some doxygen graphs are HUGE, png are not readable. 
Using SVG can solve this issue [sort of] as we can simply zoom in or out.

I tried to use EXCLUDE_SYMBOLS, to remvoe some of STL, but then graphs have too few info [see in examples]

## Changes or fixes
- We had plenty of warnigns in doxygen like missing arguemnt, same argumetn twice etc. I tried to fix everyone

## Examples
Before
![image](https://github.com/user-attachments/assets/136adb23-204f-46cd-a9c6-1bbe38d5820d)

After
![image](https://github.com/user-attachments/assets/174fedd6-a8b8-4ed0-9e84-9e7f36934bbf)

Example with `EXCLUDE_SYMBOLS        = std::*` [not in PR]
![image](https://github.com/user-attachments/assets/b445ac7f-22c2-4d0e-83b0-0c55bc9588d5)

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
