### PR TITLE
breaking: Remove Oscillation Channel Loop Structure

### DIFF
--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -135,7 +135,7 @@ void FitterBase::SaveSettings() {
     MACH3LOG_INFO("{}: Cov name: {}, it has {} params", i, systematics[i]->GetName(), systematics[i]->GetNumParams());
   MACH3LOG_INFO("Number of SampleHandlers: {}", samples.size());
   for(unsigned int i = 0; i < samples.size(); ++i)
-    MACH3LOG_INFO("{}: SampleHandler name: {}, it has {} samples",i , samples[i]->GetTitle(), samples[i]->GetNsamples());
+    MACH3LOG_INFO("{}: SampleHandler name: {}, it has {} samples, {} OscChannels",i , samples[i]->GetTitle(), samples[i]->GetNsamples(), samples[i]->GetNOscChannels());
 
   SettingsSaved = true;
 }

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -6,6 +6,8 @@ SampleHandlerBase::SampleHandlerBase()
   dathist = NULL;
   dathist2d = NULL;
   Modes = nullptr;
+
+  nEvents = 0;
 }
 
 SampleHandlerBase::~SampleHandlerBase()

--- a/Samples/SampleHandlerBase.h
+++ b/Samples/SampleHandlerBase.h
@@ -62,7 +62,7 @@ class SampleHandlerBase
   virtual double GetLikelihood() = 0;
 
   /// @ingroup SampleHandlerGetters
-  virtual int GetNEvents(){throw MaCh3Exception(__FILE__ , __LINE__ , "Not implemented");}
+  unsigned int GetNEvents(){return nEvents;}
   /// @ingroup SampleHandlerGetters
   virtual int GetNMCSamples(){ throw MaCh3Exception(__FILE__ , __LINE__ , "Not implemented"); }
   /// @ingroup SampleHandlerGetters
@@ -130,6 +130,9 @@ protected:
   M3::int_t nSamples;
   /// KS: number of dimension for this sample
   int nDims;
+
+  /// Number of MC events are there
+  unsigned int nEvents;
 
   /// Holds information about used Generator and MaCh3 modes
   MaCh3Modes* Modes;

--- a/Samples/SampleHandlerBase.h
+++ b/Samples/SampleHandlerBase.h
@@ -62,9 +62,11 @@ class SampleHandlerBase
   virtual double GetLikelihood() = 0;
 
   /// @ingroup SampleHandlerGetters
-  virtual int GetNEventsInSample(int sample){ (void) sample; throw MaCh3Exception(__FILE__ , __LINE__ , "Not implemented"); }
+  virtual int GetNEvents(){throw MaCh3Exception(__FILE__ , __LINE__ , "Not implemented");}
   /// @ingroup SampleHandlerGetters
   virtual int GetNMCSamples(){ throw MaCh3Exception(__FILE__ , __LINE__ , "Not implemented"); }
+  /// @ingroup SampleHandlerGetters
+  virtual int GetNOscChannels(){ return 1; }
 
   virtual void AddData(std::vector<double> &dat);
   virtual void AddData(std::vector< std::vector <double> > &dat);

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -764,7 +764,7 @@ M3::float_t SampleHandlerFD::CalcWeightSpline(const int iEvent) const {
 }
 
 // ***************************************************************************
-// Calculate the normalisation weight for on event
+// Calculate the normalisation weight for an event
 M3::float_t SampleHandlerFD::CalcWeightNorm(const int iEvent) const {
 // ***************************************************************************
   M3::float_t xsecw = 1.0;

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -185,7 +185,7 @@ void SampleHandlerFD::Initialise() {
 
   nEvents = SetupExperimentMC();
 
-  InitialiseSingleFDMCObject(GetNEvents());
+  InitialiseSingleFDMCObject();
   SetupFDMC();
 
   MACH3LOG_INFO("=============================================");
@@ -1428,10 +1428,8 @@ double SampleHandlerFD::GetLikelihood() {
   return negLogL;
 }
 
-void SampleHandlerFD::InitialiseSingleFDMCObject(const int nEvents_) {
+void SampleHandlerFD::InitialiseSingleFDMCObject() {
   FarDetectorCoreInfo *fdobj = &MCSamples;
-  
-  nEvents = nEvents_;
   
   fdobj->x_var.resize(nEvents, &M3::Unity_D);
   fdobj->y_var.resize(nEvents, &M3::Unity_D);

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -183,12 +183,8 @@ void SampleHandlerFD::Initialise() {
   //Now initialise all the variables you will need
   Init();
 
-  int TotalMCEvents = 0;
-  for(int iChannel = 0 ; iChannel < static_cast<int>(OscChannels.size()); iChannel++){
-    MACH3LOG_INFO("=============================================");
-    TotalMCEvents += SetupExperimentMC(iChannel);
-    MACH3LOG_INFO("Initialised channel: {}/{}", iChannel, OscChannels.size());
-  }
+
+  int TotalMCEvents = SetupExperimentMC();
   MCSamples.nEvents = TotalMCEvents;
 
   InitialiseSingleFDMCObject(MCSamples.nEvents);

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -907,7 +907,6 @@ void SampleHandlerFD::CalcNormsBins() {
     fdobj->xsec_norms_bins[iEvent] = NormBins;
   }//end loop over events
   #ifdef DEBUG
-  MACH3LOG_DEBUG("Channel {}", iSample);
   MACH3LOG_DEBUG("┌──────────────────────────────────────────────────────────┐");
   for (std::size_t i = 0; i < norm_parameters.size(); ++i) {
     const auto& norm = norm_parameters[i];

--- a/Samples/SampleHandlerFD.h
+++ b/Samples/SampleHandlerFD.h
@@ -131,7 +131,7 @@ public:
   virtual void Init() = 0;
 
   /// @brief Experiment specific setup, returns the number of events which were loaded
-  virtual int SetupExperimentMC(int iSample) = 0;
+  virtual int SetupExperimentMC() = 0;
 
   /// @brief Function which translates experiment struct into core struct
   virtual void SetupFDMC() = 0;

--- a/Samples/SampleHandlerFD.h
+++ b/Samples/SampleHandlerFD.h
@@ -55,27 +55,20 @@ public:
   //===============================================================================
 
   void Reweight() override;
-  M3::float_t GetEventWeight(const int iSample, const int iEntry) const;
+  M3::float_t GetEventWeight(const int iEntry) const;
 
   ///  @brief including Dan's magic NuOscillator
   void InitialiseNuOscillatorObjects();
   void SetupNuOscillatorPointers();
 
-  virtual void setupSplines(FarDetectorCoreInfo *, const char *, int , int ){};
-
   void ReadSampleConfig();
 
   /// @ingroup SampleHandlerGetters
-  int GetNMCSamples() override {return int(MCSamples.size());}
-
+  int GetNMCSamples() override {return nSamples;}
   /// @ingroup SampleHandlerGetters
-  int GetNEventsInSample(int iSample) override {
-    if (iSample < 0 || iSample > GetNMCSamples()) {
-      MACH3LOG_ERROR("Invalid Sample Requested: {}",iSample);
-      throw MaCh3Exception(__FILE__ , __LINE__);
-    }
-    return MCSamples[iSample].nEvents;
-  }
+  int GetNOscChannels() {return static_cast<int>(OscChannels.size());}
+  /// @ingroup SampleHandlerGetters
+  int GetNEvents() override { return MCSamples.nEvents; }
   
   /// @ingroup SampleHandlerGetters
   std::string GetFlavourName(const int iChannel) {
@@ -141,7 +134,7 @@ public:
   virtual int SetupExperimentMC(int iSample) = 0;
 
   /// @brief Function which translates experiment struct into core struct
-  virtual void SetupFDMC(int iSample) = 0;
+  virtual void SetupFDMC() = 0;
 
   /// @brief Function which does a lot of the lifting regarding the workflow in creating different MC objects
   void Initialise();
@@ -213,15 +206,12 @@ public:
   /// @brief Update the functional parameter values to the latest propsed values. Needs to be called before every new reweight so is called in fillArray 
   virtual void PrepFunctionalParameters(){};
   /// @brief ETA - generic function applying shifts
-  virtual void ApplyShifts(int iSample, int iEvent);
+  virtual void ApplyShifts(int iEvent);
 
   /// @brief DB Function which determines if an event is selected, where Selection double looks like {{ND280KinematicTypes Var1, douuble LowBound}
-  bool IsEventSelected(const int iSample, const int iEvent);
+  bool IsEventSelected(const int iEvent);
   /// @brief HH - reset the shifted values to the original values
-  virtual void resetShifts(int iSample, int iEvent) {
-    (void)iSample;
-    (void)iEvent;
-  };
+  virtual void resetShifts(int iEvent) {(void)iEvent;};
   /// @brief HH - a vector that stores all the FuncPars struct
   std::vector<FunctionalParameter> funcParsVec;
   /// @brief HH - a map that relates the name of the functional parameter to
@@ -236,34 +226,34 @@ public:
   /// function
   std::unordered_map<int, FuncParFuncType> funcParsFuncMap;
   /// @brief HH - a grid of vectors of enums for each sample and event
-  std::vector<std::vector<std::vector<int>>> funcParsGrid;
+  std::vector<std::vector<int>> funcParsGrid;
   /// @brief HH - a vector of string names for each functional parameter
   std::vector<std::string> funcParsNamesVec = {};
 
   /// @brief Check whether a normalisation systematic affects an event or not
-  void CalcNormsBins(const int iSample);
+  void CalcNormsBins();
   /// @brief Calculate the spline weight for a given event
-  M3::float_t CalcWeightSpline(const int iSample, const int iEvent) const;
+  M3::float_t CalcWeightSpline(const int iEvent) const;
   /// @brief Calculate the norm weight for a given event
-  M3::float_t CalcWeightNorm(const int iSample, const int iEvent) const;
+  M3::float_t CalcWeightNorm(const int iEvent) const;
 
   /// @brief Calculate weights for function parameters
   ///
   /// First you need to setup additional pointers in you experiment code in SetupWeightPointers
   /// Then in this function you can calculate whatever fancy function you want by filling weight to which you have pointer
   /// This way func weight shall be used in GetEventWeight
-  virtual void CalcWeightFunc(int iSample, int iEvent){return; (void)iSample; (void)iEvent;};
+  virtual void CalcWeightFunc(int iEvent){return; (void)iEvent;};
 
   /// @brief Return the value of an assocaited kinematic parameter for an event
-  virtual double ReturnKinematicParameter(std::string KinematicParamter, int iSample, int iEvent) = 0;
-  virtual double ReturnKinematicParameter(int KinematicVariable, int iSample, int iEvent) = 0;
+  virtual double ReturnKinematicParameter(std::string KinematicParamter, int iEvent) = 0;
+  virtual double ReturnKinematicParameter(int KinematicVariable, int iEvent) = 0;
 
   /// @brief Return the binning used to draw a kinematic parameter
   virtual std::vector<double> ReturnKinematicParameterBinning(std::string KinematicParameter) = 0;
-  virtual const double* GetPointerToKinematicParameter(std::string KinematicParamter, int iSample, int iEvent) = 0; 
-  virtual const double* GetPointerToKinematicParameter(double KinematicVariable, int iSample, int iEvent) = 0;
+  virtual const double* GetPointerToKinematicParameter(std::string KinematicParamter, int iEvent) = 0;
+  virtual const double* GetPointerToKinematicParameter(double KinematicVariable, int iEvent) = 0;
 
-  const double* GetPointerToOscChannel(int iSample, int iEvent) const;
+  const double* GetPointerToOscChannel(const int iEvent) const;
 
   void SetupNormParameters();
 
@@ -309,7 +299,7 @@ public:
 
   //===============================================================================
   //MC variables
-  std::vector<FarDetectorCoreInfo> MCSamples;
+  FarDetectorCoreInfo MCSamples;
   std::vector<OscChannelInfo> OscChannels;
   //===============================================================================
 
@@ -357,7 +347,7 @@ public:
   std::unique_ptr<manager> SampleManager;
   /// @brief function to create the member of the FarDetectorInfo struct so
   /// they are the appropriate size.
-  void InitialiseSingleFDMCObject(int iSample, int nEvents);
+  void InitialiseSingleFDMCObject(const int nEvents);
   void InitialiseSplineObject();
 
   std::vector<std::string> mc_files;

--- a/Samples/SampleHandlerFD.h
+++ b/Samples/SampleHandlerFD.h
@@ -67,9 +67,7 @@ public:
   int GetNMCSamples() override {return nSamples;}
   /// @ingroup SampleHandlerGetters
   int GetNOscChannels() {return static_cast<int>(OscChannels.size());}
-  /// @ingroup SampleHandlerGetters
-  int GetNEvents() override { return MCSamples.nEvents; }
-  
+
   /// @ingroup SampleHandlerGetters
   std::string GetFlavourName(const int iChannel) {
     if (iChannel < 0 || iChannel > static_cast<int>(OscChannels.size())) {

--- a/Samples/SampleHandlerFD.h
+++ b/Samples/SampleHandlerFD.h
@@ -345,7 +345,7 @@ public:
   std::unique_ptr<manager> SampleManager;
   /// @brief function to create the member of the FarDetectorInfo struct so
   /// they are the appropriate size.
-  void InitialiseSingleFDMCObject(const int nEvents);
+  void InitialiseSingleFDMCObject();
   void InitialiseSplineObject();
 
   std::vector<std::string> mc_files;

--- a/Samples/Structs.h
+++ b/Samples/Structs.h
@@ -190,7 +190,7 @@ struct NormParameter : public TypeParameterBase {
 };
 
 // HH - a shorthand type for funcpar functions
-using FuncParFuncType = std::function<void (const double*, std::size_t, std::size_t)>;
+using FuncParFuncType = std::function<void (const double*, std::size_t)>;
 // *******************
 /// @brief HH - Functional parameters
 /// Carrier for whether you want to apply a systematic to an event or not

--- a/python/samples.cpp
+++ b/python/samples.cpp
@@ -102,24 +102,22 @@ public:
     }
     
     /* Trampoline (need one for each virtual function) */
-    int SetupExperimentMC(int) override {
+    int SetupExperimentMC() override {
         PYBIND11_OVERRIDE_PURE_NAME(
             int,             /* Return type */
             SampleHandlerFD, /* Parent class */
             "setup_experiment_MC", /*python name*/
             SetupExperimentMC,     /* Name of function in C++ */
-            py::arg("sample_id")   /* Argument(s) */
         );
     }
 
     /* Trampoline (need one for each virtual function) */
-    void SetupFDMC(int) override {
+    void SetupFDMC() override {
         PYBIND11_OVERRIDE_PURE_NAME(
             void,            /* Return type */
             SampleHandlerFD, /* Parent class */
             "setup_FD_MC",   /*python name*/
             SetupFDMC,       /* Name of function in C++ */
-            py::arg("sample_id") /* Argument(s) */
         );
     }
 
@@ -143,49 +141,45 @@ public:
         );
     }
 
-    double ReturnKinematicParameter(std::string, int, int) override {
+    double ReturnKinematicParameter(std::string, int) override {
         PYBIND11_OVERRIDE_PURE_NAME(
             double,                     /* Return type */
             SampleHandlerFD,            /* Parent class */
             "get_event_kinematic_value",/* python name*/
             ReturnKinematicParameter,  /* Name of function in C++ (must match Python name) */
             py::arg("variable"),
-            py::arg("sample"),
             py::arg("event")            /* Argument(s) */
         );
     }
 
-    double ReturnKinematicParameter(int, int, int) override {
+    double ReturnKinematicParameter(int, int) override {
         PYBIND11_OVERRIDE_PURE_NAME(
             double,                     /* Return type */
             SampleHandlerFD,            /* Parent class */
             "get_event_kinematic_value",/* python name*/
             ReturnKinematicParameter,  /* Name of function in C++ (must match Python name) */
             py::arg("variable"),
-            py::arg("sample"),
             py::arg("event")            /* Argument(s) */
         );
     }
 
-    const double *GetPointerToKinematicParameter(std::string, int, int) override {
+    const double *GetPointerToKinematicParameter(std::string, int) override {
         PYBIND11_OVERRIDE_PURE_NAME(
             const double *,                   /* Return type */
             SampleHandlerFD,            /* Parent class */
             "get_event_kinematic_value_reference",/* python name*/
             GetPointerToKinematicParameter, /* Name of function in C++ (must match Python name) */
             py::arg("variable"),
-            py::arg("sample"),
             py::arg("event")            /* Argument(s) */
         );
     }
-    const double *GetPointerToKinematicParameter(double, int, int) override {
+    const double *GetPointerToKinematicParameter(double, int) override {
         PYBIND11_OVERRIDE_PURE_NAME(
             const double *,                   /* Return type */
             SampleHandlerFD,            /* Parent class */
             "get_event_kinematic_value_reference",/* python name*/
             GetPointerToKinematicParameter, /* Name of function in C++ (must match Python name) */
             py::arg("variable"),
-            py::arg("sample"),
             py::arg("event")            /* Argument(s) */
         );
     }


### PR DESCRIPTION
# Pull request description
Currently used loop strucutre is genrally bad for perofmance, as we can't have loop over all events but need seprate loop for each channel.

In addition this change should enable having mutiple samples in one object much easier.

First merge tutorial: https://github.com/mach3-software/MaCh3Tutorial/pull/125

I did run locally all CI and it worked (LLH scnas for example).
Sample PDF requeird minor tweaks due to not having now Osc channed index in output. However weights are identical

## Changes or fixes


## Examples
Here are disributons made with tutrorial.
[Test_KinemPlot.pdf](https://github.com/user-attachments/files/20229728/Test_KinemPlot.pdf)

Weights are identical, code finds issue becasue I removed osc channel from output...
![example](https://github.com/user-attachments/assets/e379a19c-e30d-4534-a24b-d5b865114580)


---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
