### PR TITLE
breaking: Introdcue Tunes

### DIFF
--- a/Parameters/CMakeLists.txt
+++ b/Parameters/CMakeLists.txt
@@ -5,6 +5,7 @@ set(HEADERS
     ParameterHandlerGeneric.h
     AdaptiveMCMCHandler.h
     PCAHandler.h
+    ParameterTunes.h
 )
 
 add_library(Parameters SHARED
@@ -13,6 +14,7 @@ add_library(Parameters SHARED
     ParameterHandlerGeneric.cpp
     AdaptiveMCMCHandler.cpp
     PCAHandler.cpp
+    ParameterTunes.cpp
 )
 
 set_target_properties(Parameters PROPERTIES

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -191,7 +191,6 @@ void ParameterHandlerBase::Init(const std::vector<std::string>& YAMLFile) {
   {
     _fFancyNames[i] = Get<std::string>(param["Systematic"]["Names"]["FancyName"], __FILE__ , __LINE__);
     _fPreFitValue[i] = Get<double>(param["Systematic"]["ParameterValues"]["PreFitValue"], __FILE__ , __LINE__);
-    _fGenerated[i] = Get<double>(param["Systematic"]["ParameterValues"]["Generated"], __FILE__ , __LINE__);
     _fIndivStepScale[i] = Get<double>(param["Systematic"]["StepScale"]["MCMC"], __FILE__ , __LINE__);
     _fError[i] = Get<double>(param["Systematic"]["Error"], __FILE__ , __LINE__);
     _fSampleNames[i] = GetFromManager<std::vector<std::string>>(param["Systematic"]["SampleNames"], {}, __FILE__, __LINE__);
@@ -272,6 +271,8 @@ void ParameterHandlerBase::Init(const std::vector<std::string>& YAMLFile) {
   }
   _fNumParPCA = _fNumPar;
 
+  Tunes = std::make_unique<ParameterTunes>(_fYAMLDoc["Systematics"]);
+
   MACH3LOG_INFO("Created covariance matrix from files: ");
   for(const auto &file : YAMLFile){
     MACH3LOG_INFO("{} ", file);
@@ -309,7 +310,6 @@ void ParameterHandlerBase::ReserveMemory(const int SizeVec) {
 // ********************************************
   _fNames = std::vector<std::string>(SizeVec);
   _fFancyNames = std::vector<std::string>(SizeVec);
-  _fGenerated = std::vector<double>(SizeVec);
   _fPreFitValue = std::vector<double>(SizeVec);
   _fError = std::vector<double>(SizeVec);
   _fCurrVal = std::vector<double>(SizeVec);
@@ -326,7 +326,6 @@ void ParameterHandlerBase::ReserveMemory(const int SizeVec) {
 
   // Set the defaults to true
   for(int i = 0; i < SizeVec; i++) {
-    _fGenerated.at(i) = 1.;
     _fPreFitValue.at(i) = 1.;
     _fError.at(i) = 1.;
     _fCurrVal.at(i) = 0.;
@@ -1149,17 +1148,6 @@ void ParameterHandlerBase::MakeClosestPosDef(TMatrixDSym *cov) {
 }
 
 // ********************************************
-std::vector<double> ParameterHandlerBase::GetNominalArray() {
-// ********************************************
-  std::vector<double> prior(_fNumPar);
-  for (int i = 0; i < _fNumPar; ++i)
-  {
-    prior[i] = _fPreFitValue[i];
-  }
-  return prior;
-}
-
-// ********************************************
 // KS: Convert covariance matrix to correlation matrix and return TH2D which can be used for fancy plotting
 TH2D* ParameterHandlerBase::GetCorrelationMatrix() {
 // ********************************************
@@ -1243,4 +1231,17 @@ bool ParameterHandlerBase::AppliesToSample(const int SystIndex, const std::strin
     }
   }
   return Applies;
+}
+
+// ********************************************
+// Set proposed parameter values vector to be base on tune values
+void ParameterHandlerBase::SetTune(const std::string& TuneName) {
+// ********************************************
+  if(Tunes == nullptr) {
+    MACH3LOG_ERROR("Tunes haven't been initialised, which are being loaded from YAML, have you used some deprecated constructor");
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+  auto Values = Tunes->GetTune(TuneName);
+
+  SetParameters(Values);
 }

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -5,6 +5,7 @@
 #include "Parameters/ParameterHandlerUtils.h"
 #include "Parameters/AdaptiveMCMCHandler.h"
 #include "Parameters/PCAHandler.h"
+#include "Parameters/ParameterTunes.h"
 
 /// @brief Base class responsible for handling of systematic error parameters. Capable of using PCA or using adaptive throw matrix
 /// @see For more details, visit the [Wiki](https://github.com/mach3-software/MaCh3/wiki/02.-Implementation-of-Systematic).
@@ -237,15 +238,9 @@ class ParameterHandlerBase {
   /// @brief Get total number of parameters
   /// @ingroup ParameterHandlerGetters
   inline int  GetNumParams() const {return _fNumPar;}
-  /// @brief Get the prior array for parameters.
-  /// @ingroup ParameterHandlerGetters
-  virtual std::vector<double> GetNominalArray();
   /// @brief Get the pre-fit values of the parameters.
   /// @ingroup ParameterHandlerGetters
   std::vector<double> GetPreFitValues() const {return _fPreFitValue;}
-  /// @brief Get the generated values of the parameters.
-  /// @ingroup ParameterHandlerGetters
-  std::vector<double> GetGeneratedValues() const {return _fGenerated;}
   /// @brief Get vector of all proposed parameter values
   /// @ingroup ParameterHandlerGetters
   std::vector<double> GetProposed() const;
@@ -261,14 +256,6 @@ class ParameterHandlerBase {
   /// @param i Parameter index
   /// @ingroup ParameterHandlerGetters
   inline double GetParInit(const int i) const { return _fPreFitValue[i]; }
-  /// @brief Return generated value, although is virtual so class inheriting might actual get prior not generated.
-  /// @param i Parameter index
-  /// @ingroup ParameterHandlerGetters
-  virtual double GetNominal(const int i) { return GetParInit(i); }
-  /// @brief Return generated value for a given parameter
-  /// @param i Parameter index
-  /// @ingroup ParameterHandlerGetters
-  inline double GetGenerated(const int i) const { return _fGenerated[i];}
   /// @brief Get upper parameter bound in which it is physically valid
   /// @param i Parameter index
   /// @ingroup ParameterHandlerGetters
@@ -442,6 +429,9 @@ class ParameterHandlerBase {
   /// @brief Get bool for whether we are using adaptive MCMC
   inline bool getUseAdaptive() const { return use_adaptive; }
 
+  /// @brief KS: Set proposed parameter values vector to be base on tune values, for example set proposed values to be of generated or maybe PostND
+  /// @ingroup ParameterHandlerSetters
+  void SetTune(const std::string& TuneName);
 
 protected:
   /// @brief Initialisation of the class using matrix from root file
@@ -514,8 +504,6 @@ protected:
   std::vector<double> _fCurrVal;
   /// Proposed value of the parameter
   std::vector<double> _fPropVal;
-  /// Generated value of the parameter
-  std::vector<double> _fGenerated;
   /// Prior error on the parameter
   std::vector<double> _fError;
   /// Lowest physical bound, parameter will not be able to go beyond it
@@ -554,4 +542,6 @@ protected:
   std::unique_ptr<PCAHandler> PCAObj;
   /// Struct containing information about adaption
   std::unique_ptr<adaptive_mcmc::AdaptiveMCMCHandler> AdaptiveHandler;
+  /// Struct containing information about adaption
+  std::unique_ptr<ParameterTunes> Tunes;
 };

--- a/Parameters/ParameterHandlerGeneric.cpp
+++ b/Parameters/ParameterHandlerGeneric.cpp
@@ -456,7 +456,7 @@ void ParameterHandlerGeneric::Print() {
 void ParameterHandlerGeneric::PrintGlobablInfo() {
 // ********************************************
   MACH3LOG_INFO("============================================================================================================================================================");
-  MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10}", "#", "|", "Name", "|", "Gen.", "|", "Prior", "|", "Error", "|", "Lower", "|", "Upper", "|", "StepScale", "|", "SampleNames", "|", "Type");
+  MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<20} {:2} {:<10}", "#", "|", "Name", "|", "Prior", "|", "Error", "|", "Lower", "|", "Upper", "|", "StepScale", "|", "SampleNames", "|", "Type");
   MACH3LOG_INFO("------------------------------------------------------------------------------------------------------------------------------------------------------------");
   for (int i = 0; i < GetNumParams(); i++) {
     std::string ErrString = fmt::format("{:.2f}", _fError[i]);
@@ -467,7 +467,7 @@ void ParameterHandlerGeneric::PrintGlobablInfo() {
       }
       SampleNameString += SampleName;
     }
-    MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10}", i, "|", GetParFancyName(i), "|", _fGenerated[i], "|", _fPreFitValue[i], "|", "+/- " + ErrString, "|", _fLowBound[i], "|", _fUpBound[i], "|", _fIndivStepScale[i], "|", SampleNameString, "|", SystType_ToString(_fParamType[i]));
+    MACH3LOG_INFO("{:<5} {:2} {:<40} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<10} {:2} {:<20} {:2} {:<10}", i, "|", GetParFancyName(i), "|", _fPreFitValue[i], "|", "+/- " + ErrString, "|", _fLowBound[i], "|", _fUpBound[i], "|", _fIndivStepScale[i], "|", SampleNameString, "|", SystType_ToString(_fParamType[i]));
   }
   MACH3LOG_INFO("============================================================================================================================================================");
 }
@@ -664,7 +664,6 @@ void ParameterHandlerGeneric::DumpMatrixToFile(const std::string& Name) {
   TVectorD* xsec_param_prior = new TVectorD(_fNumPar);
   TVectorD* xsec_flat_prior = new TVectorD(_fNumPar);
   TVectorD* xsec_stepscale = new TVectorD(_fNumPar);
-  TVectorD* xsec_param_generated = new TVectorD(_fNumPar);
   TVectorD* xsec_param_lb = new TVectorD(_fNumPar);
   TVectorD* xsec_param_ub = new TVectorD(_fNumPar);
 
@@ -684,7 +683,6 @@ void ParameterHandlerGeneric::DumpMatrixToFile(const std::string& Name) {
     xsec_spline_names->AddLast(splineName);
 
     (*xsec_param_prior)[i] = _fPreFitValue[i];
-    (*xsec_param_generated)[i] = _fGenerated[i];
     (*xsec_flat_prior)[i] = _fFlatPrior[i];
     (*xsec_stepscale)[i] = _fIndivStepScale[i];
     (*xsec_error)[i] = _fError[i];
@@ -723,8 +721,6 @@ void ParameterHandlerGeneric::DumpMatrixToFile(const std::string& Name) {
   delete xsec_flat_prior;
   xsec_stepscale->Write("xsec_stepscale");
   delete xsec_stepscale;
-  xsec_param_generated->Write("xsec_param_nom");
-  delete xsec_param_generated;
   xsec_param_lb->Write("xsec_param_lb");
   delete xsec_param_lb;
   xsec_param_ub->Write("xsec_param_ub");

--- a/Parameters/ParameterHandlerGeneric.h
+++ b/Parameters/ParameterHandlerGeneric.h
@@ -95,16 +95,6 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
     /// @ingroup ParameterHandlerGetters
     const std::vector<SplineParameter> GetSplineParsFromSampleName(const std::string& SampleName) const;
 
-    /// @brief KS: For most covariances prior and fparInit (prior) are the same, however for Xsec those can be different
-    /// @ingroup ParameterHandlerGetters
-    std::vector<double> GetNominalArray() override
-    {
-      std::vector<double> prior(_fNumPar);
-      for (int i = 0; i < _fNumPar; i++) {
-        prior[i] = _fPreFitValue.at(i);
-      }
-      return prior;
-    }
     /// @brief Checks if parameter belongs to a given group
     /// @param i parameter index
     /// @param Group name of group, like Xsec or Flux

--- a/Parameters/ParameterTunes.cpp
+++ b/Parameters/ParameterTunes.cpp
@@ -1,0 +1,98 @@
+#include "Parameters/ParameterTunes.h"
+
+// ********************************************
+ParameterTunes::ParameterTunes(const YAML::Node& Settings) {
+// ********************************************
+  std::map<std::string, std::vector<double>> orderedTunes;
+
+  // Loop over all systematics
+  for (const auto& sysNode : Settings) {
+    const auto& values = sysNode["Systematic"]["ParameterValues"];
+
+    for (const auto& tuneNode : values) {
+      std::string key = tuneNode.first.as<std::string>();
+      if (key == "PreFitValue") continue;
+
+      double val = tuneNode.second.as<double>();
+      orderedTunes[key].push_back(val);
+    }
+  }
+
+  size_t expectedSize = 0;
+  bool hasMismatch = false;
+  std::ostringstream errorMsg;
+  errorMsg << "Inconsistent number of parameter values across tunes:\n";
+
+  for (const auto& kv : orderedTunes) {
+    const auto& vals = kv.second;
+    if (expectedSize == 0) {
+      expectedSize = vals.size();
+    } else if (vals.size() != expectedSize) {
+      hasMismatch = true;
+    }
+    errorMsg << " - Tune '" << kv.first << "': " << vals.size() << " values\n";
+  }
+
+  if (hasMismatch) {
+    errorMsg << "Expected all tunes to have " << expectedSize << " values.";
+    MACH3LOG_ERROR("{}", errorMsg.str());
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+
+  int idx = 0;
+  for (const auto& kv : orderedTunes) {
+    TuneNames.push_back(kv.first);
+    TuneValues.push_back(kv.second);
+    TuneMap[kv.first] = idx++;
+  }
+
+  // KS: Log final summary of found tunes
+  MACH3LOG_INFO("Found {} tunes:", TuneNames.size());
+  for (size_t i = 0; i < TuneNames.size(); ++i) {
+    MACH3LOG_INFO("  Tune {} {}", i, TuneNames[i]);
+  }
+  #ifdef DEBUG
+  PrintTunes();
+  #endif
+}
+
+// ********************************************
+ParameterTunes::~ParameterTunes() {
+// ********************************************
+
+}
+
+// ********************************************
+std::vector<double> ParameterTunes::ParameterTunes::GetTune(const int TuneNumber) const {
+// ********************************************
+  if (TuneNumber >= static_cast<int>(TuneValues.size())) {
+    MACH3LOG_ERROR("I only have {} tune(s), but you asked for index {}", TuneValues.size(), TuneNumber);
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+
+  return TuneValues[TuneNumber];
+}
+
+// ********************************************
+std::vector<double> ParameterTunes::ParameterTunes::GetTune(const std::string& TuneName) const {
+// ********************************************
+  auto it = TuneMap.find(TuneName);
+  if (it == TuneMap.end()) {
+    MACH3LOG_ERROR("Tune '{}' not found. Available tunes: {}", TuneName, fmt::join(TuneNames, ", "));
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+
+  return GetTune(it->second);
+}
+
+// ********************************************
+void ParameterTunes::ParameterTunes::PrintTunes() const {
+// ********************************************
+  MACH3LOG_INFO("Available tunes:");
+  for (size_t i = 0; i < TuneNames.size(); ++i) {
+    MACH3LOG_INFO("  Tune {} {}", i, TuneNames[i]);
+      for (size_t j = 0; j < TuneValues[i].size(); ++j) {
+        MACH3LOG_INFO("    Value {} = {}", j, TuneValues[i][j]);
+    }
+  }
+}

--- a/Parameters/ParameterTunes.h
+++ b/Parameters/ParameterTunes.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// MaCh3 Includes
+#include "Manager/Manager.h"
+#include "Parameters/ParameterHandlerUtils.h"
+
+/// @brief Class storing tune values, for example allowing flexibly to retrieve parameter values for for PostND tunes
+/// @author Kamil Skwarczynski
+class ParameterTunes{
+ public:
+  /// @brief Constructor
+  ParameterTunes(const YAML::Node& Settings);
+  /// @brief
+  virtual ~ParameterTunes();
+
+  /// @brief Return vector of tune vales for each parameter
+  std::vector<double> GetTune(const int TuneNumber) const;
+  /// @brief Return vector of tune vales for each parameter
+  std::vector<double> GetTune(const std::string& TuneName) const;
+  /// @brief Simply print all tunes and associated values
+  void PrintTunes() const;
+ private:
+  /// Name of each Tun
+   std::vector<std::string> TuneNames;
+  /// Values for each Tune and Parameter
+  std::vector<std::vector<double>> TuneValues;
+  /// Map between tune name and value
+  std::unordered_map<std::string, int> TuneMap;
+};

--- a/python/parameters.cpp
+++ b/python/parameters.cpp
@@ -25,32 +25,13 @@ public:
             GetLikelihood     /* Name of function in C++ (must match Python name) */
         );
     }
-    
-    double GetNominal(int i) override {
-        PYBIND11_OVERRIDE_NAME(
-            double,          /* Return type */
-            ParameterHandlerBase,  /* Parent class */
-            "get_nominal",   /* Name in python*/
-            GetNominal,      /* Name of function in C++ (must match Python name) */
-            i                /* Arguments*/
-        );
-    }
-    
+
     void ProposeStep() override {
         PYBIND11_OVERRIDE_NAME(
             void,            /* Return type */
             ParameterHandlerBase,  /* Parent class */
             "propose_step",  /* Name in python*/
             ProposeStep      /* Name of function in C++ (must match Python name) */
-        );
-    }
-
-    std::vector<double> GetNominalArray() override {
-        PYBIND11_OVERRIDE_NAME(
-            std::vector<double>, /* Return type */
-            ParameterHandlerBase,      /* Parent class */
-            "get_nominal_array", /* Name in python*/
-            GetNominalArray      /* Name of function in C++ (must match Python name) */
         );
     }
 };
@@ -199,12 +180,6 @@ void initParameters(py::module &m){
             "Get the name of the spline associated with a spline parameter. This is generally what it is called in input spline files and can in principle be different to the parameters name. \n\
             :param index: The index of the spline parameter",
             py::arg("index")
-        )
-        
-        .def(
-            "get_nominal_par_values",
-            &ParameterHandlerGeneric::GetNominalArray,
-            "Get the nominal values of all the parameters as a list. "
         )
 
     ; // End of ParameterHandlerGeneric binding


### PR DESCRIPTION
# Pull request description
This allow to set turnes define in yaml simplgy doing
`Cov->SetTune("WackyTune");
`

This depracte Generated, in a sense Genrated is treated as tune, old interface to gnerated will have to be switched to newer, better.

Also removed GetNominal, it was having same purpose as GetPrior so only cofnusgin

For more see: https://github.com/mach3-software/MaCh3Tutorial/pull/126
## Changes or fixes


## Examples
Full pritn for debug
![message](https://github.com/user-attachments/assets/cde9c655-36ca-49bf-ae3a-9f8c3ee9b63c)

Normal Print
![tunes](https://github.com/user-attachments/assets/88b990b6-f59f-4ad6-89a8-a089fb4dd70d)

Some exmaple of error
![image](https://github.com/user-attachments/assets/75e767e0-4c84-450f-84fe-11aaedffeaab)
![image](https://github.com/user-attachments/assets/c37ccaef-c929-4e21-8a8d-5f8dec57a0dd)

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
