### PR TITLE
tidy: OscParams Sanity

### DIFF
--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -1294,6 +1294,11 @@ void SampleHandlerFD::InitialiseNuOscillatorObjects() {
     }
   }
   std::vector<const double*> OscParams = OscParHandler->GetOscParsFromSampleName(SampleName);
+  if (OscParams.empty()) {
+    MACH3LOG_ERROR("OscParams is empty for sample '{}'.", GetTitle());
+    MACH3LOG_ERROR("This likely indicates an error in your oscillation YAML configuration.");
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
   Oscillator = std::make_shared<OscillationHandler>(NuOscillatorConfigFile, EqualBinningPerOscChannel, OscParams, static_cast<int>(OscChannels.size()));
 
   if (!EqualBinningPerOscChannel) {


### PR DESCRIPTION
# Pull request description
Recenrly two independet people forgot to add SampleNames in yaml osc. NuOscillator is throwing error that number of params is 0. So this isn;t fully neccessary.

However I figured It might be more helpfull to throw error earlier on MaCh3 level with more helfpull message

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
