### PR TITLE
tidy: Turn PCA Handler into proper class

### DIFF
--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -569,7 +569,7 @@ void FitterBase::RunLLHScan() {
       double upper;
       // Get the parameter priors and bounds
       double prior = cov->GetParInit(i);
-      if (IsPCA) prior = cov->GetParCurrPCA(i);
+      if (IsPCA) prior = cov->GetPCAHandler()->GetParCurrPCA(i);
 
       // Get the covariance matrix and do the +/- nSigma
       // Set lower and upper bounds relative the prior
@@ -577,9 +577,9 @@ void FitterBase::RunLLHScan() {
       upper = prior + nSigma*cov->GetDiagonalError(i);
       // If PCA, transform these parameter values to the PCA basis
       if (IsPCA) {
-        lower = prior - nSigma*std::sqrt((cov->GetEigenValues())(i));
-        upper = prior + nSigma*std::sqrt((cov->GetEigenValues())(i));
-        MACH3LOG_INFO("eval {} = {:.2f}", i, cov->GetEigenValues()(i));
+        lower = prior - nSigma*std::sqrt((cov->GetPCAHandler()->GetEigenValues())(i));
+        upper = prior + nSigma*std::sqrt((cov->GetPCAHandler()->GetEigenValues())(i));
+        MACH3LOG_INFO("eval {} = {:.2f}", i, cov->GetPCAHandler()->GetEigenValues()(i));
         MACH3LOG_INFO("prior {} = {:.2f}", i, prior);
         MACH3LOG_INFO("lower {} = {:.2f}", i, lower);
         MACH3LOG_INFO("upper {} = {:.2f}", i, upper);
@@ -659,7 +659,7 @@ void FitterBase::RunLLHScan() {
 
         // For PCA we have to do it differently
         if (IsPCA) {
-          cov->SetParPropPCA(i, hScan->GetBinCenter(j+1));
+          cov->GetPCAHandler()->SetParPropPCA(i, hScan->GetBinCenter(j+1));
         } else {
           // Set the parameter
           cov->SetParProp(i, hScan->GetBinCenter(j+1));
@@ -763,7 +763,7 @@ void FitterBase::RunLLHScan() {
 
       // Reset the parameters to their prior central values
       if (IsPCA) {
-        cov->SetParPropPCA(i, prior);
+        cov->GetPCAHandler()->SetParPropPCA(i, prior);
       } else {
         cov->SetParProp(i, prior);
       }
@@ -915,7 +915,7 @@ void FitterBase::Run2DLLHScan() {
 
       // Get the parameter priors and bounds
       double prior_x = cov->GetParInit(i);
-      if (IsPCA) prior_x = cov->GetParCurrPCA(i);
+      if (IsPCA) prior_x = cov->GetPCAHandler()->GetParCurrPCA(i);
 
       // Get the covariance matrix and do the +/- nSigma
       // Set lower and upper bounds relative the prior
@@ -923,9 +923,9 @@ void FitterBase::Run2DLLHScan() {
       double upper_x = prior_x + nSigma*cov->GetDiagonalError(i);
       // If PCA, transform these parameter values to the PCA basis
       if (IsPCA) {
-        lower_x = prior_x - nSigma*std::sqrt((cov->GetEigenValues())(i));
-        upper_x = prior_x + nSigma*std::sqrt((cov->GetEigenValues())(i));
-        MACH3LOG_INFO("eval {} = {:.2f}", i, cov->GetEigenValues()(i));
+        lower_x = prior_x - nSigma*std::sqrt((cov->GetPCAHandler()->GetEigenValues())(i));
+        upper_x = prior_x + nSigma*std::sqrt((cov->GetPCAHandler()->GetEigenValues())(i));
+        MACH3LOG_INFO("eval {} = {:.2f}", i, cov->GetPCAHandler()->GetEigenValues()(i));
         MACH3LOG_INFO("prior {} = {:.2f}", i, prior_x);
         MACH3LOG_INFO("lower {} = {:.2f}", i, lower_x);
         MACH3LOG_INFO("upper {} = {:.2f}", i, upper_x);
@@ -978,16 +978,16 @@ void FitterBase::Run2DLLHScan() {
 
         // Get the parameter priors and bounds
         double prior_y = cov->GetParInit(j);
-        if (IsPCA) prior_y = cov->GetParCurrPCA(j);
+        if (IsPCA) prior_y = cov->GetPCAHandler()->GetParCurrPCA(j);
 
         // Set lower and upper bounds relative the prior
         double lower_y = prior_y - nSigma*cov->GetDiagonalError(j);
         double upper_y = prior_y + nSigma*cov->GetDiagonalError(j);
         // If PCA, transform these parameter values to the PCA basis
         if (IsPCA) {
-          lower_y = prior_y - nSigma*std::sqrt((cov->GetEigenValues())(j));
-          upper_y = prior_y + nSigma*std::sqrt((cov->GetEigenValues())(j));
-          MACH3LOG_INFO("eval {} = {:.2f}", i, cov->GetEigenValues()(j));
+          lower_y = prior_y - nSigma*std::sqrt((cov->GetPCAHandler()->GetEigenValues())(j));
+          upper_y = prior_y + nSigma*std::sqrt((cov->GetPCAHandler()->GetEigenValues())(j));
+          MACH3LOG_INFO("eval {} = {:.2f}", i, cov->GetPCAHandler()->GetEigenValues()(j));
           MACH3LOG_INFO("prior {} = {:.2f}", i, prior_y);
           MACH3LOG_INFO("lower {} = {:.2f}", i, lower_y);
           MACH3LOG_INFO("upper {} = {:.2f}", i, upper_y);
@@ -1027,8 +1027,8 @@ void FitterBase::Run2DLLHScan() {
           {
             // For PCA we have to do it differently
             if (IsPCA) {
-              cov->SetParPropPCA(i, hScanSam->GetXaxis()->GetBinCenter(x+1));
-              cov->SetParPropPCA(j, hScanSam->GetYaxis()->GetBinCenter(y+1));
+              cov->GetPCAHandler()->SetParPropPCA(i, hScanSam->GetXaxis()->GetBinCenter(x+1));
+              cov->GetPCAHandler()->SetParPropPCA(j, hScanSam->GetYaxis()->GetBinCenter(y+1));
             } else {
               // Set the parameter
               cov->SetParProp(i, hScanSam->GetXaxis()->GetBinCenter(x+1));
@@ -1054,8 +1054,8 @@ void FitterBase::Run2DLLHScan() {
         hScanSam->Write();
         // Reset the parameters to their prior central values
         if (IsPCA) {
-          cov->SetParPropPCA(i, prior_x);
-          cov->SetParPropPCA(j, prior_y);
+          cov->GetPCAHandler()->SetParPropPCA(i, prior_x);
+          cov->GetPCAHandler()->SetParPropPCA(j, prior_y);
         } else {
           cov->SetParProp(i, prior_x);
           cov->SetParProp(j, prior_y);

--- a/Fitters/LikelihoodFit.cpp
+++ b/Fitters/LikelihoodFit.cpp
@@ -88,7 +88,7 @@ double LikelihoodFit::CalcChi2(const double* x) {
         //KS: Basically apply mirroring for parameters out of bounds
         pars[i] = ParVal;
       }
-      (*it)->SetParametersPCA(pars);
+      (*it)->GetPCAHandler()->SetParametersPCA(pars);
     }
     (*it)->AcceptStep();
   }

--- a/Fitters/MinuitFit.cpp
+++ b/Fitters/MinuitFit.cpp
@@ -49,10 +49,10 @@ void MinuitFit::RunMCMC() {
     {
       for(int i = 0; i < (*it)->GetNumParams(); ++i, ++ParCounter)
       {
-        //KS: Index, name, prior, step scale [differrent to MCMC],
+        //KS: Index, name, prior, step scale [different to MCMC],
         minuit->SetVariable(ParCounter, ((*it)->GetParName(i)), (*it)->GetParInit(i), (*it)->GetDiagonalError(i)/10);
         minuit->SetVariableValue(ParCounter, (*it)->GetParInit(i));
-        //KS: lower bound, upper bound, if Mirroring eneabled then ignore
+        //KS: lower bound, upper bound, if Mirroring enabled then ignore
         if(!fMirroring) minuit->SetVariableLimits(ParCounter, (*it)->GetLowerBound(i), (*it)->GetUpperBound(i));
         if((*it)->IsParameterFixed(i))
         {
@@ -64,8 +64,8 @@ void MinuitFit::RunMCMC() {
     {
       for(int i = 0; i < (*it)->GetNParameters(); ++i, ++ParCounter)
       {
-        minuit->SetVariable(ParCounter, Form("%i_PCA", i), (*it)->GetParPropPCA(i), (*it)->GetEigenValuesMaster()[i]/10);
-        if((*it)->IsParameterFixedPCA(i))
+        minuit->SetVariable(ParCounter, Form("%i_PCA", i), (*it)->GetPCAHandler()->GetParPropPCA(i), (*it)->GetPCAHandler()->GetEigenValuesMaster()[i]/10);
+        if((*it)->GetPCAHandler()->IsParameterFixedPCA(i))
         {
           minuit->FixVariable(ParCounter);
         }
@@ -121,7 +121,7 @@ void MinuitFit::RunMCMC() {
         }
         (*MinuitParValue)(ParCounter) = ParVal;
         (*MinuitParError)(ParCounter) = err[ParCounter];
-        //KS: For fixed params HESS will not calcuate error so we need to pass prior error
+        //KS: For fixed params HESS will not calculate error so we need to pass prior error
         if((*it)->IsParameterFixed(i))
         {
           (*MinuitParError)(ParCounter) = (*it)->GetDiagonalError(i);
@@ -154,9 +154,9 @@ void MinuitFit::RunMCMC() {
           MatrixVals_PCA(i,j) = minuit->CovMatrix(ParCounter,ParCounterMatrix);
         }
       }
-      ParVals = ((*it)->GetTransferMatrix())*ParVals_PCA;
-      ErrorVals = ((*it)->GetTransferMatrix())*ErrorVals_PCA;
-      MatrixVals.Mult(((*it)->GetTransferMatrix()),MatrixVals_PCA);
+      ParVals = ((*it)->GetPCAHandler()->GetTransferMatrix())*ParVals_PCA;
+      ErrorVals = ((*it)->GetPCAHandler()->GetTransferMatrix())*ErrorVals_PCA;
+      MatrixVals.Mult(((*it)->GetPCAHandler()->GetTransferMatrix()),MatrixVals_PCA);
 
       ParCounter = StartVal;
       //KS: Now after going from PCA to normal let';s save it
@@ -170,7 +170,7 @@ void MinuitFit::RunMCMC() {
           (*Postmatrix)(ParCounter,ParCounterMatrix)  = MatrixVals(i,j);
         }
         //If fixed take prior
-        if((*it)->IsParameterFixedPCA(i))
+        if((*it)->GetPCAHandler()->IsParameterFixedPCA(i))
         {
           (*MinuitParError)(ParCounter) = (*it)->GetDiagonalError(i);
           (*Postmatrix)(ParCounter,ParCounter) = (*MinuitParError)(ParCounter) * (*MinuitParError)(ParCounter);

--- a/Fitters/PSO.cpp
+++ b/Fitters/PSO.cpp
@@ -95,7 +95,7 @@ void PSO::init(){
           ranges_min.push_back(-100.0);
           ranges_max.push_back(100.0);
           prior.push_back((*it)->GetParInit(i));
-          if((*it)->IsParameterFixedPCA(i)){
+          if((*it)->GetPCAHandler()->IsParameterFixedPCA(i)){
             fixed.push_back(1);
           }
           else{
@@ -494,8 +494,8 @@ void PSO::WriteOutput(){
           ParVals_PCA(i) = minimum[ParCounter];
           ErrorVals_PCA(i) = (uncertainties[ParCounter][0]+uncertainties[ParCounter][1])/2.0;
         }
-        ParVals = ((*it)->GetTransferMatrix())*ParVals_PCA;
-        ErrorVals = ((*it)->GetTransferMatrix())*ErrorVals_PCA;
+        ParVals = ((*it)->GetPCAHandler()->GetTransferMatrix())*ParVals_PCA;
+        ErrorVals = ((*it)->GetPCAHandler()->GetTransferMatrix())*ErrorVals_PCA;
 
         ParCounter = StartVal;
         //KS: Now after going from PCA to normal let';s save it
@@ -505,7 +505,7 @@ void PSO::WriteOutput(){
           (*PSOParError)(ParCounter) = std::fabs(ErrorVals(i));
           //int ParCounterMatrix = StartVal;
           //If fixed take prior
-          if((*it)->IsParameterFixedPCA(i))
+          if((*it)->GetPCAHandler()->IsParameterFixedPCA(i))
           {
             (*PSOParError)(ParCounter) = (*it)->GetDiagonalError(i);
           }

--- a/Fitters/mcmc.cpp
+++ b/Fitters/mcmc.cpp
@@ -118,8 +118,8 @@ void mcmc::RunMCMC() {
 
   //Save the Adaptive output
   for(const auto& syst : systematics){
-    if(syst->getUseAdaptive()){
-      syst->getAdaptiveHandler()->SaveAdaptiveToFile(syst->getAdaptiveHandler()->output_file_name, syst->GetName(), true);
+    if(syst->GetDoAdaption()){
+      syst->GetAdaptiveHandler()->SaveAdaptiveToFile(syst->GetAdaptiveHandler()->output_file_name, syst->GetName(), true);
     }
   }
 

--- a/Parameters/AdaptiveMCMCHandler.cpp
+++ b/Parameters/AdaptiveMCMCHandler.cpp
@@ -280,7 +280,6 @@ void AdaptiveMCMCHandler::UpdateAdaptiveCovariance() {
       (*adaptive_covariance)(j, i) = cov_updated;
     }
   }
-
 }
 
 // ********************************************
@@ -336,5 +335,3 @@ double AdaptiveMCMCHandler::CurrVal(const int par_index){
 }
 
 } //end adaptive_mcmc
-
-

--- a/Parameters/AdaptiveMCMCHandler.h
+++ b/Parameters/AdaptiveMCMCHandler.h
@@ -83,7 +83,6 @@ class AdaptiveMCMCHandler{
     if(!_fFixedPars){
       return false;
     }
-
     return ((*_fFixedPars)[ipar] < 0);
   }
 

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -352,16 +352,14 @@ class ParameterHandlerBase {
   YAML::Node GetConfig() const { return _fYAMLDoc; }
 
   /// @brief Get pointer for AdaptiveHandler
-  inline adaptive_mcmc::AdaptiveMCMCHandler* getAdaptiveHandler() const  {
+  /// @ingroup ParameterHandlerGetters
+  inline adaptive_mcmc::AdaptiveMCMCHandler* GetAdaptiveHandler() const  {
     if (!use_adaptive) {
       MACH3LOG_ERROR("Am not running in Adaptive mode");
       throw MaCh3Exception(__FILE__ , __LINE__ );
     }
     return AdaptiveHandler.get();
   }
-
-  /// @brief Get bool for whether we are using adaptive MCMC
-  inline bool getUseAdaptive() const { return use_adaptive; }
 
   /// @brief Get pointer for PCAHandler
   inline PCAHandler* GetPCAHandler() const {

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -284,94 +284,11 @@ class ParameterHandlerBase {
   /// @brief Get global step scale for covariance object
   /// @ingroup ParameterHandlerGetters
   inline double GetGlobalStepScale() const {return _fGlobalStepScale; }
-  /// @brief Get current parameter value using PCA
-  /// @param i Parameter index
-  /// @ingroup ParameterHandlerGetters
-  inline double GetParPropPCA(const int i) const {
-    if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
-    return PCAObj->_fParPropPCA(i);
-  }
-  
-  /// @brief Get current parameter value using PCA
-  /// @param i Parameter index
-  /// @ingroup ParameterHandlerGetters
-  inline double GetParCurrPCA(const int i) const {
-    if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
-    return PCAObj->_fParCurrPCA(i);
-  }
-
-  /// @brief Is parameter fixed in PCA base or not
-  /// @param i Parameter index
-  /// @ingroup ParameterHandlerGetters
-  inline bool IsParameterFixedPCA(const int i) const {
-    if (PCAObj->_fParSigmaPCA[i] < 0) { return true;  }
-    else                              { return false; }
-  }
-  /// @brief Get transfer matrix allowing to go from PCA base to normal base
-  /// @ingroup ParameterHandlerGetters
-  inline const TMatrixD GetTransferMatrix() const {
-    if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
-    return PCAObj->TransferMat;
-  }
-  /// @brief Get eigen vectors of covariance matrix, only works with PCA
-  /// @ingroup ParameterHandlerGetters
-  inline const TMatrixD GetEigenVectors() const {
-    if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
-    return PCAObj->eigen_vectors;
-  }
-  /// @brief Get eigen values for all parameters, if you want for decomposed only parameters use GetEigenValuesMaster
-  /// @ingroup ParameterHandlerGetters
-  inline const TVectorD GetEigenValues() const {
-    if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
-    return PCAObj->eigen_values;
-  }
-  /// @brief Get eigen value of only decomposed parameters, if you want for all parameters use GetEigenValues
-  /// @ingroup ParameterHandlerGetters
-  inline const std::vector<double> GetEigenValuesMaster() const {
-    if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
-    return PCAObj->eigen_values_master;
-  }
-  /// @brief Set proposed value for parameter in PCA base
-  /// @param i Parameter index
-  /// @param value new value
-  inline void SetParPropPCA(const int i, const double value) {
-    if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
-    PCAObj->_fParPropPCA(i) = value;
-    // And then transfer back to the parameter basis
-    PCAObj->TransferToParam();
-  }
-  /// @brief Set current value for parameter in PCA base
-  /// @param i Parameter index
-  /// @param value new value
-  /// @ingroup ParameterHandlerSetters
-  inline void SetParCurrPCA(const int i, const double value) {
-    if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
-    PCAObj->_fParCurrPCA(i) = value;
-    // And then transfer back to the parameter basis
-    PCAObj->TransferToParam();
-  }
-
-  /// @brief Set values for PCA parameters in PCA base
-  /// @param pars vector with new values of PCA params
-  /// @ingroup ParameterHandlerSetters
-  inline void SetParametersPCA(const std::vector<double> &pars) {
-    if (!pca) { MACH3LOG_ERROR("Am not running in PCA mode"); throw MaCh3Exception(__FILE__ , __LINE__ ); }
-    if (int(pars.size()) != _fNumParPCA) {
-      MACH3LOG_ERROR("Parameter arrays of incompatible size! Not changing parameters! {} has size {} but was expecting {}", matrixName, pars.size(), _fNumPar);
-      throw MaCh3Exception(__FILE__ , __LINE__ );
-    }
-    int parsSize = int(pars.size());
-    for (int i = 0; i < parsSize; i++) {
-      PCAObj->_fParPropPCA(i) = pars[i];
-    }
-    //KS: Transfer to normal base
-    PCAObj->TransferToParam();
-  }
 
   /// @brief Get number of params which will be different depending if using Eigen decomposition or not
   /// @ingroup ParameterHandlerGetters
   inline int GetNParameters() const {
-    if (pca) return _fNumParPCA;
+    if (pca) return PCAObj->GetNumberPCAedParameters();
     else return _fNumPar;
   }
 
@@ -434,14 +351,26 @@ class ParameterHandlerBase {
   /// @ingroup ParameterHandlerGetters
   YAML::Node GetConfig() const { return _fYAMLDoc; }
 
-  // HH: Getter for AdaptiveHandler
   /// @brief Get pointer for AdaptiveHandler
-  inline adaptive_mcmc::AdaptiveMCMCHandler* getAdaptiveHandler() { return AdaptiveHandler.get(); }
+  inline adaptive_mcmc::AdaptiveMCMCHandler* getAdaptiveHandler() const  {
+    if (!use_adaptive) {
+      MACH3LOG_ERROR("Am not running in Adaptive mode");
+      throw MaCh3Exception(__FILE__ , __LINE__ );
+    }
+    return AdaptiveHandler.get();
+  }
 
-  // HH: Getter for use_adaptive
   /// @brief Get bool for whether we are using adaptive MCMC
   inline bool getUseAdaptive() const { return use_adaptive; }
 
+  /// @brief Get pointer for PCAHandler
+  inline PCAHandler* GetPCAHandler() const {
+    if (!pca) {
+      MACH3LOG_ERROR("Am not running in PCA mode");
+      throw MaCh3Exception(__FILE__ , __LINE__ );
+    }
+    return PCAObj.get();
+  }
 
 protected:
   /// @brief Initialisation of the class using matrix from root file
@@ -533,8 +462,6 @@ protected:
   bool pca;
   /// CW: Threshold based on which we remove parameters in eigen base
   double eigen_threshold;
-  /// Number of parameters in PCA base
-  int _fNumParPCA;
   /// Index of the first param that is being decomposed
   int FirstPCAdpar;
   /// Index of the last param that is being decomposed


### PR DESCRIPTION
# Pull request description
I was finding ton of PCA setters and getters in CovBase bit annoing. It made diffcult to find actual methods. Now all of PCA things ahve been moved to PCA Hander. Cov Base has GetPCAHandler, so you can still get PCA info.

Anohter advatnage of having getters in PCA handler is that we no longer need if(PCA) or throw error when accessing PCA methods.

Now all atributes of PCA Handler are private memeber.

First merge: https://github.com/mach3-software/MaCh3Tutorial/pull/127
## Changes or fixes
- Removed `getUseAdaptive `becasue we already had `GetDoAdaption`

## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
