### PR TITLE
bugfix: Write the covariance settings to disk before closing the file

### DIFF
--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -137,6 +137,9 @@ void FitterBase::SaveSettings() {
   for(unsigned int i = 0; i < samples.size(); ++i)
     MACH3LOG_INFO("{}: SampleHandler name: {}, it has {} samples, {} OscChannels",i , samples[i]->GetTitle(), samples[i]->GetNsamples(), samples[i]->GetNOscChannels());
 
+  //TN: Have to close the folder in order to write it to disk before SaveOutput is called in the destructor
+  CovFolder->Close();
+  
   SettingsSaved = true;
 }
 


### PR DESCRIPTION
# Pull request description
Close the covariance folder within the output file so its content is written to disk prior closing the file itself from the FitterBase destructor. That's just what the ROOT wants.

Otherwise, unfinished or interrupted chains (prior destructing the FitterBase) won't save the covariance settings.

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
