### PR TITLE
feat: Make Sure shared NuOscillator has same number of paramters

### DIFF
--- a/Samples/FarDetectorCoreInfoStruct.h
+++ b/Samples/FarDetectorCoreInfoStruct.h
@@ -46,8 +46,6 @@ struct FarDetectorCoreInfo {
 
   ~FarDetectorCoreInfo(){if(isNC != nullptr) delete [] isNC;}
 
-  int nEvents; ///< how many MC events are there
-
   std::vector<int*> Target; ///< target the interaction was on
   std::vector<const int*> nupdg;
   std::vector<const int*> nupdgUnosc;

--- a/Samples/OscillationHandler.h
+++ b/Samples/OscillationHandler.h
@@ -30,6 +30,9 @@ class OscillationHandler
 
   /// @brief Setup binning, arrays correspond to events and their energy bins
   void SetOscillatorBinning(const int Channel, const std::vector<M3::float_t>& EnergyArray, const std::vector<M3::float_t>& CosineZArray);
+
+  /// @brief return size of oscillation parameter pointer vector
+  unsigned int GetOscParamsSize() const {return static_cast<unsigned int>(OscParams.size());};
  private:
   /// flag used to define whether all oscillation channels have a probability calculated using the same binning
   bool EqualBinningPerOscChannel;

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -199,6 +199,13 @@ void SampleHandlerFD::Initialise() {
         MACH3LOG_ERROR("Trying to run shared NuOscillator without EqualBinningPerOscChannel, this will not work");
         throw MaCh3Exception(__FILE__, __LINE__);
       }
+      auto OscParams = OscParHandler->GetOscParsFromSampleName(SampleName);
+      if(OscParams.size() != Oscillator->GetOscParamsSize()){
+        MACH3LOG_ERROR("Sample {} with {} has {} osc params, while shared NuOsc has {} osc params", GetTitle(), GetSampleName(),
+                       OscParams.size(), Oscillator->GetOscParamsSize());
+        MACH3LOG_ERROR("This indicate misconfiguration in your Osc yaml");
+        throw MaCh3Exception(__FILE__, __LINE__);
+      }
     } else {
       InitialiseNuOscillatorObjects();
     }


### PR DESCRIPTION
# Pull request description
Within old implemntation it was techcically possible to pass ATM Oscillator to Beam. Which would casue error when running NuOscillator.

Problem is it would be harder to spot.

Also tidy nEvents

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
