### PR TITLE
tidy: Do not allow adpation and PCA

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -62,6 +62,11 @@ ParameterHandlerBase::~ParameterHandlerBase(){
 // ********************************************
 void ParameterHandlerBase::ConstructPCA() {
 // ********************************************
+  if(AdaptiveHandler) {
+    MACH3LOG_ERROR("Adaption has been enabled and now trying to enable PCA. Right now both configuration don't work with each other");
+    throw MaCh3Exception(__FILE__ , __LINE__ );
+  }
+
   PCAObj = std::make_unique<PCAHandler>();
   //Check whether first and last pcadpar are set and if not just PCA everything
   if(FirstPCAdpar == -999 || LastPCAdpar == -999){
@@ -996,6 +1001,10 @@ void ParameterHandlerBase::UpdateThrowMatrix(TMatrixDSym *cov){
 // HW : Here be adaption
 void ParameterHandlerBase::InitialiseAdaption(const YAML::Node& adapt_manager){
 // ********************************************
+  if(PCAObj){
+    MACH3LOG_ERROR("PCA has been enabled and now trying to enable Adaption. Right now both configuration don't work with each other");
+    throw MaCh3Exception(__FILE__ , __LINE__ );
+  }
   AdaptiveHandler = std::make_unique<adaptive_mcmc::AdaptiveMCMCHandler>();
   // Now we read the general settings [these SHOULD be common across all matrices!]
   bool success = AdaptiveHandler->InitFromConfig(adapt_manager, matrixName, &_fCurrVal, &_fError);


### PR DESCRIPTION
# Pull request description
Right now one could run adaption and PCA. Which would not work in a sense hard to predict outcome as parmaters in PCA base doon't use throw matrix, while there is no itnerface to use Adaption for undecomposed params. Adaption and PCA handler are independet.

Might be worth to fix it in future [if somone has time]. Right now simply throw error.

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
