### PR TITLE
tidy: Minor update to logger message 

### DIFF
--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -93,7 +93,7 @@ void SampleHandlerFD::ReadSampleConfig()
   SampleYBins = GetFromManager(SampleManager->raw()["Binning"]["YVarBins"], std::vector<double>());
   if(YVarStr.length() > 0){
     if(XVarStr.length() == 0){
-      MACH3LOG_ERROR("Please specify an Y-variable string in sample config {}", SampleManager->GetFileName());
+      MACH3LOG_ERROR("Please specify an X-variable string in sample config {}. I won't work only with a Y-variable", SampleManager->GetFileName());
       throw MaCh3Exception(__FILE__, __LINE__);
     }
     nDimensions++;


### PR DESCRIPTION
# Pull request description
A minor logger message update: Notify the user when you only supply YVarStr without an XVarStr in the FD sample yaml that the code will crash.

Note: This is not to be confused with checking whether there are no bins at all. 

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
