### PR TITLE
bugfix: No more GPU compilation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ target_compile_options(MaCh3Warnings INTERFACE
   -Wformat-security       # Warn on functions that are potentially insecure for formatting
   -Walloca                # Warn if `alloca` is used, as it can lead to stack overflows
   -Wswitch-enum           # Warn if a `switch` statement on an enum does not cover all values
+  -pedantic               # Enforce strict ISO compliance (all versions of GCC, Clang >= 3.2)
   #-Wfloat-equal          # Warn if floating-point values are compared directly
   #-Wpadded               # Warn when padding is added to a structure or class for alignment
 )
@@ -130,7 +131,6 @@ add_library(MaCh3CompilerOptions INTERFACE)
 target_link_libraries(MaCh3CompilerOptions INTERFACE MaCh3CompileDefinitions)
 target_compile_options(MaCh3CompilerOptions INTERFACE
     -g                      # Generate debug information
-    -pedantic               # Enforce strict ISO compliance (all versions of GCC, Clang >= 3.2)
 )
 
 #If DEBUG_LEVEL was defined but MaCh3_DEBUG_ENABLED not, enable debug flag

--- a/Manager/Core.h
+++ b/Manager/Core.h
@@ -109,7 +109,6 @@ _Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"") \
 _Pragma("GCC diagnostic ignored \"-Wswitch-enum\"") \
 _Pragma("GCC diagnostic ignored \"-Wconversion\"") \
 _Pragma("GCC diagnostic ignored \"-Wshadow\"") \
-_Pragma("GCC diagnostic ignored \"-Wshadow\"") \
 _Pragma("GCC diagnostic ignored \"-Wswitch-enum\"")
 /// @brief KS: Restore warning checking after including external headers
 #define _MaCh3_Safe_Include_End_ \
@@ -125,7 +124,6 @@ _Pragma("GCC diagnostic pop")
   _Pragma("clang diagnostic ignored \"-Wformat-nonliteral\"") \
   _Pragma("clang diagnostic ignored \"-Wswitch-enum\"") \
   _Pragma("clang diagnostic ignored \"-Wconversion\"") \
-  _Pragma("clang diagnostic ignored \"-Wshadow\"") \
   _Pragma("clang diagnostic ignored \"-Wshadow\"") \
   _Pragma("clang diagnostic ignored \"-Wswitch-enum\"")
   #undef _MaCh3_Safe_Include_End_

--- a/Manager/Core.h
+++ b/Manager/Core.h
@@ -108,8 +108,9 @@ _Pragma("GCC diagnostic ignored \"-Wold-style-cast\"") \
 _Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"") \
 _Pragma("GCC diagnostic ignored \"-Wswitch-enum\"") \
 _Pragma("GCC diagnostic ignored \"-Wconversion\"") \
-_Pragma("GCC diagnostic ignored \"-Wshadow\"")
-
+_Pragma("GCC diagnostic ignored \"-Wshadow\"") \
+_Pragma("GCC diagnostic ignored \"-Wshadow\"") \
+_Pragma("GCC diagnostic ignored \"-Wswitch-enum\"")
 /// @brief KS: Restore warning checking after including external headers
 #define _MaCh3_Safe_Include_End_ \
 _Pragma("GCC diagnostic pop")
@@ -124,8 +125,9 @@ _Pragma("GCC diagnostic pop")
   _Pragma("clang diagnostic ignored \"-Wformat-nonliteral\"") \
   _Pragma("clang diagnostic ignored \"-Wswitch-enum\"") \
   _Pragma("clang diagnostic ignored \"-Wconversion\"") \
-  _Pragma("clang diagnostic ignored \"-Wshadow\"")
-
+  _Pragma("clang diagnostic ignored \"-Wshadow\"") \
+  _Pragma("clang diagnostic ignored \"-Wshadow\"") \
+  _Pragma("clang diagnostic ignored \"-Wswitch-enum\"")
   #undef _MaCh3_Safe_Include_End_
   #define _MaCh3_Safe_Include_End_ \
   _Pragma("clang diagnostic pop")

--- a/Splines/SplineMonolith.cpp
+++ b/Splines/SplineMonolith.cpp
@@ -310,7 +310,7 @@ void SMonolith::MoveToGPU() {
                 double(sizeof(short int) * NSplines_valid)) / 1.E6);
   MACH3LOG_INFO("Total TF1 size = {:.2f} MB memory on CPU to move to GPU",
                 double(sizeof(float) * NTF1_valid * _nTF1Coeff_) / 1.E6);
-  MACH3LOG_INFO("GPU weight array (GPU->CPU every step) = {:.2f} MB", double(sizeof(float) * (NSplines_valid + NTF1_valid) / 1.E6));
+  MACH3LOG_INFO("GPU weight array (GPU->CPU every step) = {:.2f} MB", static_cast<double>(sizeof(float)) * (NSplines_valid + NTF1_valid) / 1.0e6);
   #ifndef Weight_On_SplineBySpline_Basis
   MACH3LOG_INFO("Since you are running Total event weight mode then GPU weight array (GPU->CPU every step) = {:.2f} MB",
                 double(sizeof(float) * NEvents) / 1.E6);

--- a/cmake/Modules/CUDASetup.cmake
+++ b/cmake/Modules/CUDASetup.cmake
@@ -46,6 +46,7 @@ if(NOT MaCh3_DEBUG_ENABLED)
         "$<$<COMPILE_LANGUAGE:CUDA>:-prec-sqrt=false;-use_fast_math;-O3;-Werror;cross-execution-space-call;-w>"
         "$<$<COMPILE_LANGUAGE:CUDA>:-Xptxas=-allow-expensive-optimizations=true;-Xptxas=-fmad=true;-Xptxas=-O3;>"
         "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-fpic;-Xcompiler=-O3;-Xcompiler=-Wall;-Xcompiler=-Wextra;-Xcompiler=-Werror;-Xcompiler=-Wno-error=unused-parameter>"
+        "$<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe=--display_error_number>"
     )
 else()
 #CW: -g and -G for debug flags to use cuda-gdb; slows stuff A LOT
@@ -54,17 +55,12 @@ else()
         "$<$<COMPILE_LANGUAGE:CUDA>:-prec-sqrt=false;-use_fast_math;-Werror;cross-execution-space-call;-w>"
         "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-g;>"
         "$<$<COMPILE_LANGUAGE:CUDA>:-Xptxas=-dlcm=ca;-Xptxas=-warn-lmem-usage;-Xptxas=-warn-spills;-Xptxas=-v;-Xcompiler=-Wall;-Xcompiler=-Wextra;-Xcompiler=-Werror;-Xcompiler=-Wno-error=unused-parameter>"
+        "$<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe=--display_error_number>"
     )
     target_compile_definitions(MaCh3GPUCompilerOptions INTERFACE "$<$<COMPILE_LANGUAGE:CUDA>:CUDA_ERROR_CHECK>")
 endif()
 
-# KS: In newer CUDA nvcc likes to throw billions of billions of "warning: style of line directive is a GCC extension"
-# these aren't very helpfull but hide real problems. Let's turn if off
-if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "12.0")
-    target_compile_options(MaCh3GPUCompilerOptions INTERFACE
-       "$<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe=--diag_suppress=20012>"
-    )
-endif()
+
 target_include_directories(MaCh3GPUCompilerOptions INTERFACE ${CUDAToolkit_INCLUDE_DIRS})
 if(MaCh3_DEBUG_ENABLED)
   include(${CMAKE_CURRENT_LIST_DIR}/CUDASamples.cmake)


### PR DESCRIPTION
# Pull request description
Becasue pedantic was being treated as compilation flag not warning flag it was leaking into GPU code too much. Which resulted in ton of warning about gcc style which were super annoing.

Remaining issues have been solved with:
https://github.com/dbarrow257/CUDAProb3/pull/8

## Changes or fixes


## Examples
![Uploading Bug.png…]()



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
