### PR TITLE
feat: Expand usage of Param Group

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -755,6 +755,19 @@ void ParameterHandlerBase::SetStepScale(const double scale) {
 }
 
 // ********************************************
+int ParameterHandlerBase::GetParIndex(const std::string& name) const {
+// ********************************************
+  int Index = M3::_BAD_INT_;
+  for (int i = 0; i <_fNumPar; ++i) {
+    if(name == _fFancyNames[i]) {
+      Index = i;
+      break;
+    }
+  }
+  return Index;
+}
+
+// ********************************************
 void ParameterHandlerBase::ToggleFixAllParameters() {
 // ********************************************
   // fix or unfix all parameters by multiplying by -1
@@ -785,24 +798,24 @@ void ParameterHandlerBase::ToggleFixParameter(const int i) {
 // ********************************************
 void ParameterHandlerBase::ToggleFixParameter(const std::string& name) {
 // ********************************************
-  for (int i = 0; i <_fNumPar; ++i) {
-    if(name == _fFancyNames[i]) {
-      ToggleFixParameter(i);
-      return;
-    }
+  const int Index = GetParIndex(name);
+  if(Index != M3::_BAD_INT_) {
+    ToggleFixParameter(Index);
+    return;
   }
+
   MACH3LOG_WARN("I couldn't find parameter with name {}, therefore will not fix it", name);
 }
 
 // ********************************************
 bool ParameterHandlerBase::IsParameterFixed(const std::string& name) const {
 // ********************************************
-  for (int i = 0; i <_fNumPar; ++i) {
-    if(name == _fFancyNames[i]) {
-      return IsParameterFixed(i);
-    }
+  const int Index = GetParIndex(name);
+  if(Index != M3::_BAD_INT_) {
+    return IsParameterFixed(Index);
   }
-  MACH3LOG_WARN("I couldn't find parameter with name {}, therefore will not fix it", name);
+
+  MACH3LOG_WARN("I couldn't find parameter with name {}, therefore don't know if it fixed", name);
   return false;
 }
 

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -155,10 +155,15 @@ class ParameterHandlerBase {
   /// @brief Get name of covariance
   /// @ingroup ParameterHandlerGetters
   std::string GetName() const { return matrixName; }
-  /// @brief Get name of covariance
+  /// @brief Get name of parameter
   /// @param i Parameter index
   /// @ingroup ParameterHandlerGetters
   std::string GetParName(const int i) const {return _fNames[i];}
+
+  /// @brief Get index based on name
+  /// @ingroup ParameterHandlerGetters
+  int GetParIndex(const std::string& name) const;
+
   /// @brief Get fancy name of the Parameter
   /// @param i Parameter index
   /// @ingroup ParameterHandlerGetters

--- a/Parameters/ParameterHandlerGeneric.cpp
+++ b/Parameters/ParameterHandlerGeneric.cpp
@@ -619,21 +619,47 @@ void ParameterHandlerGeneric::CheckCorrectInitialisation() {
 
 // ********************************************
 // Function to set to prior parameters of a given group
-void ParameterHandlerGeneric::SetGroupOnlyParameters(const std::string& Group) {
+void ParameterHandlerGeneric::SetGroupOnlyParameters(const std::vector< std::string>& Groups) {
 // ********************************************
-  if(!pca) {
+  for(size_t i = 0; i < Groups.size(); i++){
+    SetGroupOnlyParameters(Groups[i]);
+  }
+}
+
+// ********************************************
+// Function to set to prior parameters of a given group
+void ParameterHandlerGeneric::SetGroupOnlyParameters(const std::string& Group, const std::vector<double>& Pars) {
+// ********************************************
+  // If empty, set the proposed to prior
+  if (Pars.empty()) {
     for (int i = 0; i < _fNumPar; i++) {
       if(IsParFromGroup(i, Group)) _fPropVal[i] = _fPreFitValue[i];
     }
-  } else {
-    MACH3LOG_ERROR("{} not implemented for PCA", __func__);
-    throw MaCh3Exception(__FILE__, __LINE__);
+  } else{
+    const size_t ExpectedSize = static_cast<size_t>(GetNumParFromGroup(Group));
+    if (Pars.size() != ExpectedSize) {
+      MACH3LOG_ERROR("Number of param in group {} is {}, while you passed {}", Group, ExpectedSize, Pars.size());
+      throw MaCh3Exception(__FILE__, __LINE__);
+    }
+    int Counter = 0;
+    for (int i = 0; i < _fNumPar; i++) {
+      // If belongs to group set value from parsed vector, otherwise use propose value
+      if(IsParFromGroup(i, Group)){
+        _fPropVal[i] = Pars[Counter];
+        Counter++;
+      }
+    }
+  }
+  // And if pca make the transfer
+  if (pca) {
+    PCAObj->TransferToPCA();
+    PCAObj->TransferToParam();
   }
 }
 
 // ********************************************
 // Checks if parameter belongs to a given group
-bool ParameterHandlerGeneric::IsParFromGroup(const int i, const std::string& Group) {
+bool ParameterHandlerGeneric::IsParFromGroup(const int i, const std::string& Group) const {
 // ********************************************
   std::string groupLower = Group;
   std::string paramGroupLower = _ParameterGroup[i];
@@ -643,6 +669,16 @@ bool ParameterHandlerGeneric::IsParFromGroup(const int i, const std::string& Gro
   std::transform(paramGroupLower.begin(), paramGroupLower.end(), paramGroupLower.begin(), ::tolower);
 
   return groupLower == paramGroupLower;
+}
+
+// ********************************************
+int ParameterHandlerGeneric::GetNumParFromGroup(const std::string& Group) const {
+// ********************************************
+  int Counter = 0;
+  for (int i = 0; i < _fNumPar; i++) {
+    if(IsParFromGroup(i, Group)) Counter++;
+  }
+  return Counter;
 }
 
 // ********************************************

--- a/Parameters/ParameterHandlerGeneric.h
+++ b/Parameters/ParameterHandlerGeneric.h
@@ -99,13 +99,23 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
     /// @param i parameter index
     /// @param Group name of group, like Xsec or Flux
     /// @return bool telling whether param is part of group
-    /// @ingroup ParameterHandlerSetters
-    bool IsParFromGroup(const int i, const std::string& Group);
+    /// @ingroup ParameterHandlerGetters
+    bool IsParFromGroup(const int i, const std::string& Group) const;
 
-    /// @brief KS Function to set to prior parameters of a given group
+    /// @brief KS: Check how many parameters are associated with given group
+    /// @ingroup ParameterHandlerGetters
+    int GetNumParFromGroup(const std::string& Group) const;
+
+    /// @brief KS Function to set to prior parameters of a given group or values from vector
     /// @param Group name of group, like Xsec or Flux
+    /// @param Pars Values which will overwrite proposed step
     /// @ingroup ParameterHandlerSetters
-    void SetGroupOnlyParameters(const std::string& Group);
+    /// @note this mimic functionality of @ParameterHandlerBase::SetParameters
+    void SetGroupOnlyParameters(const std::string& Group, const std::vector<double>& Pars = {});
+    /// @brief KS Function to set to prior parameters of a given groups or values from vector
+    /// @param Group vector of group names, like Xsec or Flux
+    /// @ingroup ParameterHandlerSetters
+    void SetGroupOnlyParameters(const std::vector<std::string>& Groups);
 
     /// @brief Dump Matrix to ROOT file, useful when we need to pass matrix info to another fitting group
     /// @param Name Name of TFile to which we save stuff


### PR DESCRIPTION
# Pull request description
As we expand number of uncertanties we need better way to control parmates from various groups (xsec, flux and osc in future)

## Changes or fixes
- Now we can easily bet parmater index using name
- SetGroupOnlyParameters also support setting values from vecto
- SetGroupOnlyParameters also can pass mutlple groups

## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
