### PR TITLE
tidy: Use GetTitle instead of GetName for refering to data histograms

### DIFF
--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -1208,7 +1208,7 @@ void SampleHandlerFD::AddData(std::vector< std::vector <double> > &data) {
 }
 
 void SampleHandlerFD::AddData(TH1D* Data) {
-  MACH3LOG_INFO("Adding 1D data histogram: {} with {:.2f} events", Data->GetName(), Data->Integral());
+  MACH3LOG_INFO("Adding 1D data histogram: {} with {:.2f} events", Data->GetTitle(), Data->Integral());
   dathist2d = nullptr;
   dathist = Data;
   
@@ -1232,7 +1232,7 @@ void SampleHandlerFD::AddData(TH1D* Data) {
 }
 
 void SampleHandlerFD::AddData(TH2D* Data) {
-  MACH3LOG_INFO("Adding 2D data histogram: {} with {:.2f} events", Data->GetName(), Data->Integral());
+  MACH3LOG_INFO("Adding 2D data histogram: {} with {:.2f} events", Data->GetTitle(), Data->Integral());
   dathist2d = Data;
   dathist = nullptr;
 


### PR DESCRIPTION
# Pull request description

Use a safer `hist->GetTitle()` in the logger instead of  `hist->GetName()`  when displaying the logger of adding FD data. The latter can many a times be ambiguous name instead of the actual data histogram name. See attached image and output for reference to the issue. 

## Changes or fixes


## Examples
Previous implementation had ambiguity between the histogram names in the file and what was being displayed through GetName()

![image](https://github.com/user-attachments/assets/41ce7091-d2c2-499f-987b-17be9dc863a0)

versus

```
[JointFit.cpp][info] Added FHCnumuCC1pi_2024 data
[samplePDFFDBase.cpp][info] Adding 1D data histogram: numucc1pi_erec with 140.00 events
```


---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
