### PR TITLE
tidy: Move remaining PCA Variables

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -2,8 +2,7 @@
 #include "regex"
 
 // ********************************************
-ParameterHandlerBase::ParameterHandlerBase(std::string name, std::string file, double threshold, int FirstPCA, int LastPCA) : inputFile(file), pca(false),
-eigen_threshold(threshold), FirstPCAdpar(FirstPCA), LastPCAdpar(LastPCA) {
+ParameterHandlerBase::ParameterHandlerBase(std::string name, std::string file, double threshold, int FirstPCA, int LastPCA) : inputFile(file), pca(false) {
 // ********************************************
   MACH3LOG_DEBUG("Constructing instance of ParameterHandler");
   if (threshold < 0 || threshold >= 1) {
@@ -17,10 +16,10 @@ eigen_threshold(threshold), FirstPCAdpar(FirstPCA), LastPCAdpar(LastPCA) {
   Init(name, file);
 
   // Call the innocent helper function
-  if (pca) ConstructPCA();
+  if (pca) ConstructPCA(threshold, FirstPCA, LastPCA);
 }
 // ********************************************
-ParameterHandlerBase::ParameterHandlerBase(const std::vector<std::string>& YAMLFile, std::string name, double threshold, int FirstPCA, int LastPCA) : inputFile(YAMLFile[0].c_str()), matrixName(name), pca(true), eigen_threshold(threshold), FirstPCAdpar(FirstPCA), LastPCAdpar(LastPCA) {
+ParameterHandlerBase::ParameterHandlerBase(const std::vector<std::string>& YAMLFile, std::string name, double threshold, int FirstPCA, int LastPCA) : inputFile(YAMLFile[0].c_str()), matrixName(name), pca(true) {
 // ********************************************
   MACH3LOG_INFO("Constructing instance of ParameterHandler using");
   for(unsigned int i = 0; i < YAMLFile.size(); i++)
@@ -39,7 +38,7 @@ ParameterHandlerBase::ParameterHandlerBase(const std::vector<std::string>& YAMLF
 
   Init(YAMLFile);
   // Call the innocent helper function
-  if (pca) ConstructPCA();
+  if (pca) ConstructPCA(threshold, FirstPCA, LastPCA);
 }
 
 // ********************************************
@@ -60,7 +59,7 @@ ParameterHandlerBase::~ParameterHandlerBase(){
 }
 
 // ********************************************
-void ParameterHandlerBase::ConstructPCA() {
+void ParameterHandlerBase::ConstructPCA(const double eigen_threshold, int FirstPCAdpar, int LastPCAdpar) {
 // ********************************************
   if(AdaptiveHandler) {
     MACH3LOG_ERROR("Adaption has been enabled and now trying to enable PCA. Right now both configuration don't work with each other");

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -322,8 +322,11 @@ class ParameterHandlerBase {
   bool IsParameterFixed(const std::string& name) const;
 
   /// @brief CW: Calculate eigen values, prepare transition matrices and remove param based on defined threshold
+  /// @param eigen_threshold PCA threshold from 0 to 1. Default is -1 and means no PCA
+  /// @param FirstPCAdpar First PCA parameter that will be decomposed.
+  /// @param LastPCAdpar First PCA parameter that will be decomposed.
   /// @see For more details, visit the [Wiki](https://github.com/mach3-software/MaCh3/wiki/03.-Eigen-Decomposition-%E2%80%90-PCA).
-  void ConstructPCA();
+  void ConstructPCA(const double eigen_threshold, int FirstPCAdpar, int LastPCAdpar);
 
   /// @brief is PCA, can use to query e.g. LLH scans
   inline bool IsPCA() const { return pca; }
@@ -444,15 +447,6 @@ protected:
   /// Tells to which samples object param should be applied
   std::vector<std::vector<std::string>> _fSampleNames;
 
-  /// perform PCA or not
-  bool pca;
-  /// CW: Threshold based on which we remove parameters in eigen base
-  double eigen_threshold;
-  /// Index of the first param that is being decomposed
-  int FirstPCAdpar;
-  /// Index of the last param that is being decomposed
-  int LastPCAdpar;
-
   /// Matrix which we use for step proposal before Cholesky decomposition (not actually used for step proposal)
   TMatrixDSym* throwMatrix;
   /// Matrix which we use for step proposal after Cholesky decomposition
@@ -460,6 +454,8 @@ protected:
   /// Throw matrix that is being used in the fit, much faster as TMatrixDSym cache miss
   double** throwMatrixCholDecomp;
 
+  /// perform PCA or not
+  bool pca;
   /// Are we using AMCMC?
   bool use_adaptive;
 


### PR DESCRIPTION
# Pull request description
Simply Move Remaining PCA variables into PCA handler

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
