### PR TITLE
feat: Parameter throwing in PCA

### DIFF
--- a/Parameters/PCAHandler.h
+++ b/Parameters/PCAHandler.h
@@ -60,6 +60,16 @@ class PCAHandler{
   /// @brief Transfer param values from PCA base to normal base
   void TransferToParam();
 
+  /// @brief Throw the parameters according to the covariance matrix. This shouldn't be used in MCMC code ase it can break Detailed Balance;
+  void ThrowParameters(const std::vector<std::unique_ptr<TRandom3>>& random_number,
+                       double** throwMatrixCholDecomp,
+                       double* randParams,
+                       double* corr_throw,
+                       const std::vector<double>& fPreFitValue,
+                       const std::vector<double>& fLowBound,
+                       const std::vector<double>& fUpBound,
+                       int _fNumPar);
+
   /// @brief Accepted this step
   void AcceptStep() _noexcept_;
   /// @brief Use Cholesky throw matrix for better step proposal
@@ -144,6 +154,13 @@ class PCAHandler{
   /// @brief Get current parameter value using PCA
   /// @param i Parameter index
   /// @ingroup ParameterHandlerGetters
+  double GetPreFitValuePCA(const int i) const {
+    return _fPreFitValuePCA[i];
+  }
+
+  /// @brief Get current parameter value using PCA
+  /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
   double GetParCurrPCA(const int i) const {
     return _fParCurrPCA(i);
   }
@@ -165,6 +182,13 @@ class PCAHandler{
     return eigen_values_master;
   }
 
+  /// @brief Check if parameter in PCA base is decomposed or not
+  /// @param i Parameter index
+  /// @ingroup ParameterHandlerGetters
+  bool IsParameterDecomposed(const int i) const {
+    if(isDecomposedPCA[i] >= 0) return false;
+    else return true;
+  }
 
   #ifdef DEBUG_PCA
   /// @brief KS: Let's dump all useful matrices to properly validate PCA


### PR DESCRIPTION
# Pull request description
By having ability to throw parmaters in PCA base we can for example evalaute how much PCA would bias our results wihtout having to run fit. This fucnitonalit is moslty used in prior/posterior predictive.

## Changes or fixes
- Fix minor bug in PCA randomiz which resulted in ranomd number not being filled.

## Examples
Throws in PCA base
![image](https://github.com/user-attachments/assets/59557db1-9040-4d86-9d03-5be3af7d8b51)
Throws in normal base
![image](https://github.com/user-attachments/assets/a3ed5419-555f-4cf3-a969-0099179dbe78)

and for other param in PCA
![image](https://github.com/user-attachments/assets/a19b373c-6359-4165-955e-3dda0eceb1ae)
normal Base
![image](https://github.com/user-attachments/assets/b93aff08-97f7-435d-8abb-3971fe1e4674)

So PCA throwing both conserves mean and RMS of distrubtion

---

- [X] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
