### PR TITLE
feat: Average Autocorrelation plotting

### DIFF
--- a/Diagnostics/PlotMCMCDiag.cpp
+++ b/Diagnostics/PlotMCMCDiag.cpp
@@ -237,7 +237,7 @@ std::pair<TGraph *, TGraph *> CreateMinMaxBand(TH1D *hist, Color_t color)
     return {minGraph, maxGraph};
 }
 
-std::pair<TGraph *, TGraph *> CalculateMinMaxBand(const std::vector<TH1D *> &histograms, Color_t color)
+TGraph* CalculateMinMaxBand(const std::vector<TH1D *> &histograms, Color_t color)
 {
     if (histograms.empty())
     {
@@ -259,7 +259,6 @@ std::pair<TGraph *, TGraph *> CalculateMinMaxBand(const std::vector<TH1D *> &his
         }
     }
 
-    TGraph *minGraph = new TGraph(nBins, x.data(), ymin.data());
 
     // Create a band using TGraphAsymmErrors for the shaded region
     TGraphAsymmErrors *band = new TGraphAsymmErrors(nBins);
@@ -272,7 +271,7 @@ std::pair<TGraph *, TGraph *> CalculateMinMaxBand(const std::vector<TH1D *> &his
     band->SetFillColorAlpha(color, float(0.2));
     band->SetLineWidth(1);
 
-    return {band, minGraph}; // Return band and min graph (min graph can be used for legend)
+    return band; // Return band and min graph (min graph can be used for legend)
 }
 
 
@@ -414,7 +413,7 @@ void CompareAverageAC(const std::vector<std::vector<TH1D *>> &histograms,
         auto colour = static_cast<Color_t>(TColor::GetColorPalette(static_cast<Int_t>(i*nb/histograms.size())));
 
         {
-          auto [band, min_graph] = CalculateMinMaxBand(histograms[i], colour);
+          auto band = CalculateMinMaxBand(histograms[i], colour);
           band->SetLineWidth(0);
           band->SetTitle("Average Auto Correlation");
           band->GetXaxis()->SetTitle("lag");


### PR DESCRIPTION
# Pull request description
Add utilities to compare the average auto-correlation for multiple files to PlotDiag code.

## Changes or fixes
Add plot of average(autocorrelation) over ALL non-fixed parameters in a fit. Can be compared. By default overlays the full range of auto-correlation values and the 1-sigma error.

## Examples
Single plot
![image](https://github.com/user-attachments/assets/9626d756-bb80-4b17-968f-7c09a59e7127)

Multi-plot
![image](https://github.com/user-attachments/assets/76e996e5-d3e6-4189-9eb7-87fd27fd1a84)


---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
