### PR TITLE
feat: Use break when doing bin fidning

### DIFF
--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -457,6 +457,7 @@ void SampleHandlerFD::FillArray() {
       {
         if (XVar >= XBinEdges[iBin] && XVar < XBinEdges[iBin+1]) {
           XBinToFill = iBin;
+          break; // KS: Once found bin stop looping over remaining
         }
       }
     }


### PR DESCRIPTION
# Pull request description
This algorithm should be improved in future. But the very least we can do is to break loop once we found bin...

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
