### PR TITLE
feat: Binary search bin finding

### DIFF
--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -453,13 +453,9 @@ void SampleHandlerFD::FillArray() {
     }
     //DB - If we end up in this loop, the event has been shifted outside of its nominal bin, but is still within the allowed binning range
     else {
-      for (unsigned int iBin=0;iBin<(XBinEdges.size()-1);iBin++)
-      {
-        if (XVar >= XBinEdges[iBin] && XVar < XBinEdges[iBin+1]) {
-          XBinToFill = iBin;
-          break; // KS: Once found bin stop looping over remaining
-        }
-      }
+      // KS: Perform binary search to find correct bin. We already checked if isn't outside of bounds
+      XBinToFill = static_cast<int>(std::distance(XBinEdges.begin(),
+                                                  std::upper_bound(XBinEdges.begin(), XBinEdges.end(), XVar)) - 1);
     }
 
     //DB Fill relevant part of thread array
@@ -595,11 +591,9 @@ void SampleHandlerFD::FillArray_MP()  {
       }
       //DB - If we end up in this loop, the event has been shifted outside of its nominal bin, but is still within the allowed binning range
       else {
-        for(unsigned int iBin=0;iBin<(XBinEdges.size()-1);iBin++) {
-          if (XVar >= XBinEdges[iBin] && XVar < XBinEdges[iBin+1]) {
-            XBinToFill = iBin;
-          }
-        }
+        // KS: Perform binary search to find correct bin. We already checked if isn't outside of bounds
+        XBinToFill = static_cast<int>(std::distance(XBinEdges.begin(),
+                                                    std::upper_bound(XBinEdges.begin(), XBinEdges.end(), XVar)) - 1);
       }
 
       //ETA - we can probably remove this final if check on the -1?


### PR DESCRIPTION
# Pull request description
Previously we simply looped over all bins to find bin after migration. This was SLOOOW. Now let's use binary search to find correct bin.

## Changes or fixes


## Examples
Based on below example new code is magnituted faster and give same results
![image](https://github.com/user-attachments/assets/4c6731a3-6c5c-4ea5-a0d5-90cfcac01e8f)

For test I used 100000 bins to see difference which is much more than what we use but it was easiest to show diffrence.
Below is full code I used for debuging

```
#include <iostream>
#include <vector>
#include <chrono>
#include <algorithm>
#include "TRandom3.h"

int main() {
  const unsigned int nBins = 100000;
  std::vector<double> XBinEdges;
  XBinEdges.reserve(nBins + 1);

  // Uniform binning from 0 to nBins (bin width = 1)
  for (unsigned int i = 0; i <= nBins; ++i) {
    XBinEdges.push_back(static_cast<double>(i));
  }

  // Use TRandom3 to generate a value uniformly within the bin range
  TRandom3 rng(0); // seed = 0
  double XVar = rng.Uniform(XBinEdges.front(), XBinEdges.back());

  // ----------------------------------------
  // Linear search method
  // ----------------------------------------
  int XBinToFill_linear = -1;
  auto start_linear = std::chrono::high_resolution_clock::now();
  for (unsigned int iBin = 0; iBin < XBinEdges.size() - 1; ++iBin) {
    if (XVar >= XBinEdges[iBin] && XVar < XBinEdges[iBin + 1]) {
      XBinToFill_linear = iBin;
      break;
    }
  }
  auto end_linear = std::chrono::high_resolution_clock::now();
  auto duration_linear = std::chrono::duration_cast<std::chrono::nanoseconds>(end_linear - start_linear).count();

  // ----------------------------------------
  // Binary search with std::upper_bound
  // ----------------------------------------
  int XBinToFill_binary = -1;
  auto start_binary = std::chrono::high_resolution_clock::now();
  auto it = std::upper_bound(XBinEdges.begin(), XBinEdges.end(), XVar);
  XBinToFill_binary = static_cast<int>(std::distance(XBinEdges.begin(), it)) - 1;
  auto end_binary = std::chrono::high_resolution_clock::now();
  auto duration_binary = std::chrono::duration_cast<std::chrono::nanoseconds>(end_binary - start_binary).count();

  // ----------------------------------------
  // Output results
  // ----------------------------------------
  std::cout << "Random XVar: " << XVar << "\n";
  std::cout << "[Linear search]    Bin: " << XBinToFill_linear << ", Time: " << duration_linear << " ns\n";
  std::cout << "[Binary search]    Bin: " << XBinToFill_binary << ", Time: " << duration_binary << " ns\n";

  return 0;
}
```

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
