### PR TITLE
tidy: Avoid doing ==xsec_cov in FitterBase

### DIFF
--- a/Fitters/mcmc.cpp
+++ b/Fitters/mcmc.cpp
@@ -208,10 +208,7 @@ void mcmc::PrintProgress() {
   MACH3LOG_INFO("Accepted/Total steps: {}/{} = {:.2f}", accCount, step - stepStart, static_cast<double>(accCount) / static_cast<double>(step - stepStart));
 
   for (ParameterHandlerBase *cov : systematics) {
-    if (cov->GetName() == "xsec_cov") {
-      MACH3LOG_INFO("Cross-section parameters: ");
-      cov->PrintNominalCurrProp();
-    }
+    cov->PrintNominalCurrProp();
   }
   #ifdef DEBUG
   if (debug) {


### PR DESCRIPTION
# Pull request description
In the past only xsec_cov had fancy name. Now as we unify more and more Covariance Objects this is no longer true.

And "name ==xsec_cov" is very cofnusing for new users.

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
