### PR TITLE
bugfix: Fix W2 resetting to 0 at every step

### DIFF
--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -630,7 +630,7 @@ void SampleHandlerFD::ResetHistograms() {
     #endif
     for (size_t xBin = 0; xBin < nXBins; ++xBin) {
       SampleHandlerFD_array[yBin][xBin] = 0.;
-      SampleHandlerFD_array_w2[yBin][xBin] = 0.;
+      if(FirstTimeW2) SampleHandlerFD_array_w2[yBin][xBin] = 0.;
     }
   }
 } // end function


### PR DESCRIPTION
# Pull request description
Fixed a minor bug at FD where the w2 array was being reset to 0 at every step, instead of it having to do so only in the first step.

This stopped FD samples from making use of a different test statistic like Barlow-Beeston as w2 was 0 all the time.

Thanks Kamil for spotting this!

## Changes or fixes


## Examples



---

- [ ] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
