### PR TITLE
feat: Flexible Config getter from chain

### DIFF
--- a/Diagnostics/GetPenaltyTerm.cpp
+++ b/Diagnostics/GetPenaltyTerm.cpp
@@ -1,6 +1,7 @@
 // MaCh3 includes
 #include "Manager/Manager.h"
 #include "Samples/SampleStructs.h"
+#include "Parameters/ParameterHandlerUtils.h"
 
 _MaCh3_Safe_Include_Start_ //{
 // ROOT includes
@@ -44,7 +45,8 @@ void ReadXSecFile(const std::string& inputFile)
   TFile *TempFile = new TFile(inputFile.c_str(), "open");
 
   // Get the matrix
-  TMatrixDSym *XSecMatrix = TempFile->Get<TMatrixDSym>("CovarianceFolder/xsec_cov");
+  TDirectory* CovarianceFolder = TempFile->Get<TDirectory>("CovarianceFolder");
+  TMatrixDSym *XSecMatrix = M3::GetCovMatrixFromChain(CovarianceFolder);
 
   // Get the settings for the MCMC
   TMacro *Config = TempFile->Get<TMacro>("MaCh3_Config");

--- a/Fitters/MCMCProcessor.cpp
+++ b/Fitters/MCMCProcessor.cpp
@@ -2195,8 +2195,7 @@ void MCMCProcessor::FindInputFiles() {
     InputNotFound = true;
   }
 
-
-  TMacro *XsecConfig = CovarianceFolder->Get<TMacro>("Config_xsec_cov");
+  TMacro *XsecConfig = M3::GetConfigMacroFromChain(CovarianceFolder);
   if (XsecConfig == nullptr) {
     MACH3LOG_WARN("Didn't find Config_xsec_cov tree in MCMC file! {}", MCMCFile);
   } else {

--- a/Fitters/MCMCProcessor.h
+++ b/Fitters/MCMCProcessor.h
@@ -11,6 +11,7 @@
 // MaCh3 includes
 #include "Fitters/StatisticalUtils.h"
 #include "Samples/HistogramUtils.h"
+#include "Parameters/ParameterHandlerUtils.h"
 
 _MaCh3_Safe_Include_Start_ //{
 // ROOT includes

--- a/Parameters/ParameterHandlerUtils.h
+++ b/Parameters/ParameterHandlerUtils.h
@@ -407,7 +407,7 @@ inline TMacro* GetConfigMacroFromChain(TDirectory* CovarianceFolder) {
 inline TMatrixDSym* GetCovMatrixFromChain(TDirectory* TempFile) {
 // *************************************
   if (!TempFile) {
-    MACH3LOG_ERROR("Null TDirectory passed to GetXSecCovMatrix.");
+    MACH3LOG_ERROR("Null TDirectory passed to {}.", __func__);
     throw MaCh3Exception(__FILE__, __LINE__);
   }
 
@@ -429,10 +429,10 @@ inline TMatrixDSym* GetCovMatrixFromChain(TDirectory* TempFile) {
     MACH3LOG_INFO("Found single TMatrixDSym in directory: using it.");
     return foundMatrix;
   } else {
-    MACH3LOG_WARN("Found {} TMatrixDSym objects. Using hardcoded path: CovarianceFolder/xsec_cov.", matrixCount);
-    TMatrixDSym* fallback = TempFile->Get<TMatrixDSym>("CovarianceFolder/xsec_cov");
+    MACH3LOG_WARN("Found {} TMatrixDSym objects. Using hardcoded path: xsec_cov.", matrixCount);
+    TMatrixDSym* fallback = TempFile->Get<TMatrixDSym>("xsec_cov");
     if (!fallback) {
-      MACH3LOG_WARN("Fallback matrix 'CovarianceFolder/xsec_cov' not found.");
+      MACH3LOG_WARN("Fallback matrix 'xsec_cov' not found.");
     }
     return fallback;
   }

--- a/Parameters/ParameterHandlerUtils.h
+++ b/Parameters/ParameterHandlerUtils.h
@@ -376,7 +376,7 @@ inline TMacro* GetConfigMacroFromChain(TDirectory* CovarianceFolder) {
   TIter next(CovarianceFolder->GetListOfKeys());
   TKey* key;
   while ((key = dynamic_cast<TKey*>(next()))) {
-    if (strcmp(key->GetClassName(), "TMacro") == 0) {
+    if (std::string(key->GetClassName()) == "TMacro") {
       ++macroCount;
       if (macroCount == 1) {
         foundMacro = dynamic_cast<TMacro*>(key->ReadObj());
@@ -417,7 +417,8 @@ inline TMatrixDSym* GetCovMatrixFromChain(TDirectory* TempFile) {
   TIter next(TempFile->GetListOfKeys());
   TKey* key;
   while ((key = dynamic_cast<TKey*>(next()))) {
-    if (strcmp(key->GetClassName(), "TMatrixDSym") == 0) {
+    std::string className = key->GetClassName();
+    if (className.find("TMatrix") != std::string::npos) {
       ++matrixCount;
       if (matrixCount == 1) {
         foundMatrix = dynamic_cast<TMatrixDSym*>(key->ReadObj());

--- a/Parameters/ParameterHandlerUtils.h
+++ b/Parameters/ParameterHandlerUtils.h
@@ -21,6 +21,7 @@ _MaCh3_Safe_Include_Start_ //{
 #include "TMatrixDSymEigen.h"
 #include "TMatrixDEigen.h"
 #include "TDecompSVD.h"
+#include "TKey.h"
 _MaCh3_Safe_Include_End_ //}
 
 namespace M3
@@ -355,6 +356,86 @@ inline void MakeCorrelationMatrix(YAML::Node& root,
 
   outFile << YAMLString;
   outFile.close();
+}
+
+// *************************************
+/// @brief KS: We store configuration macros inside the chain.
+/// In the past, multiple configs were stored, which required error-prone hardcoding like "Config_xsec_cov".
+/// Therefore, this code maintains backward compatibility by checking the number of macros present and
+/// using a hardcoded name only if necessary.
+inline TMacro* GetConfigMacroFromChain(TDirectory* CovarianceFolder) {
+// *************************************
+  if (!CovarianceFolder) {
+    MACH3LOG_ERROR("Null TDirectory passed to {}", __func__);
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+
+  TMacro* foundMacro = nullptr;
+  int macroCount = 0;
+
+  TIter next(CovarianceFolder->GetListOfKeys());
+  TKey* key;
+  while ((key = dynamic_cast<TKey*>(next()))) {
+    if (strcmp(key->GetClassName(), "TMacro") == 0) {
+      ++macroCount;
+      if (macroCount == 1) {
+        foundMacro = dynamic_cast<TMacro*>(key->ReadObj());
+      }
+    }
+  }
+
+  if (macroCount == 1 && foundMacro) {
+    MACH3LOG_INFO("Found single TMacro in directory: using it.");
+    return foundMacro;
+  } else {
+    MACH3LOG_WARN("Found {} TMacro objects. Using hardcoded macro name: Config_xsec_cov.", macroCount);
+    TMacro* fallback = CovarianceFolder->Get<TMacro>("Config_xsec_cov");
+    if (!fallback) {
+      MACH3LOG_WARN("Fallback macro 'Config_xsec_cov' not found in directory.");
+    }
+    return fallback;
+  }
+}
+
+// *************************************
+/// @brief KS: Retrieve the cross-section covariance matrix from the given TDirectory.
+/// Historically, multiple covariance matrices could be stored, requiring fragile hardcoded paths like "CovarianceFolder/xsec_cov".
+/// This function maintains backward compatibility by:
+/// - Using the single matrix present if only one exists,
+/// - Otherwise falling back to the hardcoded path.
+/// This avoids error-prone assumptions while supporting both old and new formats.
+inline TMatrixDSym* GetCovMatrixFromChain(TDirectory* TempFile) {
+// *************************************
+  if (!TempFile) {
+    MACH3LOG_ERROR("Null TDirectory passed to GetXSecCovMatrix.");
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+
+  TMatrixDSym* foundMatrix = nullptr;
+  int matrixCount = 0;
+
+  TIter next(TempFile->GetListOfKeys());
+  TKey* key;
+  while ((key = dynamic_cast<TKey*>(next()))) {
+    if (strcmp(key->GetClassName(), "TMatrixDSym") == 0) {
+      ++matrixCount;
+      if (matrixCount == 1) {
+        foundMatrix = dynamic_cast<TMatrixDSym*>(key->ReadObj());
+      }
+    }
+  }
+
+  if (matrixCount == 1 && foundMatrix) {
+    MACH3LOG_INFO("Found single TMatrixDSym in directory: using it.");
+    return foundMatrix;
+  } else {
+    MACH3LOG_WARN("Found {} TMatrixDSym objects. Using hardcoded path: CovarianceFolder/xsec_cov.", matrixCount);
+    TMatrixDSym* fallback = TempFile->Get<TMatrixDSym>("CovarianceFolder/xsec_cov");
+    if (!fallback) {
+      MACH3LOG_WARN("Fallback matrix 'CovarianceFolder/xsec_cov' not found.");
+    }
+    return fallback;
+  }
 }
 
 }


### PR DESCRIPTION
# Pull request description
Old ways of having multiple matrices requeir us to hack matcis name to be xsec_cov etc. Since Core assumed such naming cnvention it forced experiemnt specyfic to obey.

This PR introduces new getter so if there is only one TMacro [coming from GenericHandler] only this will be taken. Otherwise code will use old school hardcdoing for backward compatibility.

## Changes or fixes


## Examples
<img width="558" alt="test" src="https://github.com/user-attachments/assets/acd179fc-359e-4fd4-b290-d5d79a697c97" />

[Test_drawCorr.pdf](https://github.com/user-attachments/files/20625881/Test_drawCorr.pdf)

![image](https://github.com/user-attachments/assets/2e4ce57b-b037-40b3-a95c-11c18df035fb)

[Test.root_PenaltyTerm.pdf](https://github.com/user-attachments/files/20626433/Test.root_PenaltyTerm.pdf)

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
