### PR TITLE
tidy: Ensure Circular Bounds are within Physic bounds

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -321,6 +321,14 @@ void ParameterHandlerBase::EnableSpecialProposal(const YAML::Node& param, const 
                   GetParFancyName(Index),
                   CircularBoundsValues.back().first,
                   CircularBoundsValues.back().second);
+    // KS: Make sure circular bounds are within physical bounds. If we are outside of physics bound MCMC will never explore such phase space region
+    if (CircularBoundsValues.back().first < _fLowBound.at(Index) || CircularBoundsValues.back().second > _fUpBound.at(Index)) {
+      MACH3LOG_ERROR("Circular bounds [{}, {}] for parameter {} exceed physical bounds [{}, {}]",
+                     CircularBoundsValues.back().first, CircularBoundsValues.back().second,
+                     GetParFancyName(Index),
+                     _fLowBound.at(Index), _fUpBound.at(Index));
+      throw MaCh3Exception(__FILE__, __LINE__);
+    }
   }
 
   if (FlipEnabled) {


### PR DESCRIPTION
# Pull request description
If Circular Bounds would not be beyond physical bounds then MCMC would not propelry explore phase space

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
