### PR TITLE
tidy: Bin Edeges no longer per event and add FindXBin

### DIFF
--- a/Samples/FarDetectorCoreInfoStruct.h
+++ b/Samples/FarDetectorCoreInfoStruct.h
@@ -69,18 +69,10 @@ struct FarDetectorCoreInfo {
 
   //M3::float_t total_w  = M3::_BAD_INT_;
 
-  //std::vector<int> XBin;
-  //std::vector<int> YBin;
   int NomXBin = -1;
   int NomYBin = -1;
 
   bool isNC = false;
-
-  // histo pdf bins
-  double rw_lower_xbinedge = -1;       ///< lower to check if Eb has moved the erec bin
-  double rw_lower_lower_xbinedge = -1; ///< lower to check if Eb has moved the erec bin
-  double rw_upper_xbinedge = -1;       ///< upper to check if Eb has moved the erec bin
-  double rw_upper_upper_xbinedge = -1; ///< upper to check if Eb has moved the erec bin
 
   const double* mode = &M3::Unity_D;
 };

--- a/Samples/SampleStructs.h
+++ b/Samples/SampleStructs.h
@@ -177,6 +177,42 @@ struct SampleBinningInfo {
   size_t nXBins = M3::_BAD_INT_;
   /// Number of Y axis bins in the histogram used for likelihood calculation
   size_t nYBins = M3::_BAD_INT_;
+
+  /// lower to check if Eb has moved the erec bin
+  double rw_lower_xbinedge = -1;
+  /// lower to check if Eb has moved the erec bin
+  double rw_lower_lower_xbinedge = -1;
+  /// upper to check if Eb has moved the erec bin
+  double rw_upper_xbinedge = -1;
+  /// upper to check if Eb has moved the erec bin
+  double rw_upper_upper_xbinedge = -1;
+
+  /// @brief DB Find the relevant bin in the PDF for each event
+  int FindXBin(const double XVar, const int NomXBin) const {
+    //DB Check to see if momentum shift has moved bins
+    //DB - First, check to see if the event is still in the nominal bin
+    if (XVar < rw_upper_xbinedge && XVar >= rw_lower_xbinedge) {
+      return NomXBin;
+    }
+    //DB - Second, check to see if the event is outside of the binning range and skip event if it is
+    else if (XVar < XBinEdges[0] || XVar >= XBinEdges[nXBins]) {
+      return -1;
+    }
+    //DB - Thirdly, check the adjacent bins first as Eb+CC+EScale shifts aren't likely to move an Erec more than 1bin width
+    //Shifted down one bin from the event bin at nominal
+    else if (XVar < rw_lower_xbinedge && XVar >= rw_lower_lower_xbinedge) {
+      return NomXBin-1;
+    }
+    //Shifted up one bin from the event bin at nominal
+    else if (XVar < rw_upper_upper_xbinedge && XVar >= rw_upper_xbinedge) {
+      return NomXBin+1;
+    }
+    //DB - If we end up in this loop, the event has been shifted outside of its nominal bin, but is still within the allowed binning range
+    else {
+      // KS: Perform binary search to find correct bin. We already checked if isn't outside of bounds
+      return static_cast<int>(std::distance(XBinEdges.begin(), std::upper_bound(XBinEdges.begin(), XBinEdges.end(), XVar)) - 1);
+    }
+  }
 };
 
 

--- a/Samples/SampleStructs.h
+++ b/Samples/SampleStructs.h
@@ -179,32 +179,32 @@ struct SampleBinningInfo {
   size_t nYBins = M3::_BAD_INT_;
 
   /// lower to check if Eb has moved the erec bin
-  double rw_lower_xbinedge = -1;
+  std::vector<double> rw_lower_xbinedge;
   /// lower to check if Eb has moved the erec bin
-  double rw_lower_lower_xbinedge = -1;
+  std::vector<double> rw_lower_lower_xbinedge;
   /// upper to check if Eb has moved the erec bin
-  double rw_upper_xbinedge = -1;
+  std::vector<double> rw_upper_xbinedge;
   /// upper to check if Eb has moved the erec bin
-  double rw_upper_upper_xbinedge = -1;
+  std::vector<double> rw_upper_upper_xbinedge;
 
   /// @brief DB Find the relevant bin in the PDF for each event
   int FindXBin(const double XVar, const int NomXBin) const {
     //DB Check to see if momentum shift has moved bins
-    //DB - First, check to see if the event is still in the nominal bin
-    if (XVar < rw_upper_xbinedge && XVar >= rw_lower_xbinedge) {
-      return NomXBin;
-    }
-    //DB - Second, check to see if the event is outside of the binning range and skip event if it is
-    else if (XVar < XBinEdges[0] || XVar >= XBinEdges[nXBins]) {
+    //DB - First , check to see if the event is outside of the binning range and skip event if it is
+     if (XVar < XBinEdges[0] || XVar >= XBinEdges[nXBins]) {
       return -1;
+    }
+    //DB - Second, check to see if the event is still in the nominal bin
+    else if (XVar < rw_upper_xbinedge[NomXBin] && XVar >= rw_lower_xbinedge[NomXBin]) {
+      return NomXBin;
     }
     //DB - Thirdly, check the adjacent bins first as Eb+CC+EScale shifts aren't likely to move an Erec more than 1bin width
     //Shifted down one bin from the event bin at nominal
-    else if (XVar < rw_lower_xbinedge && XVar >= rw_lower_lower_xbinedge) {
+    else if (XVar < rw_lower_xbinedge[NomXBin] && XVar >= rw_lower_lower_xbinedge[NomXBin]) {
       return NomXBin-1;
     }
     //Shifted up one bin from the event bin at nominal
-    else if (XVar < rw_upper_upper_xbinedge && XVar >= rw_upper_xbinedge) {
+    else if (XVar < rw_upper_upper_xbinedge[NomXBin] && XVar >= rw_upper_xbinedge[NomXBin]) {
       return NomXBin+1;
     }
     //DB - If we end up in this loop, the event has been shifted outside of its nominal bin, but is still within the allowed binning range


### PR DESCRIPTION
# Pull request description
Previously bin edges were per event which is waste of RAM.
In addition refactored bin finding for X which make code much neater

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
