### PR TITLE
feat: LogL calculations for low MC predictinos and 0 MC predictions limits, GetTestStatLLH optimization

### DIFF
--- a/Manager/Core.h
+++ b/Manager/Core.h
@@ -69,6 +69,9 @@ namespace M3 {
   /// Large Likelihood is used it parameter go out of physical boundary, this indicates in MCMC that such step should be removed
   constexpr static const double _LARGE_LOGL_ = 1234567890.0;
 
+  /// MC prediction lower bound in bin to identify problematic binning definitions and handle LogL calculation
+  constexpr static const double _LOW_MC_BOUND_ = .00001;
+
   /// Default value for spline knot capping, default mean not capping is being applied
   constexpr static const double DefSplineKnotUpBound = 9999;
   /// Default value for spline knot capping, default mean not capping is being applied

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -17,18 +17,15 @@ SampleHandlerBase::~SampleHandlerBase() {
 // Poisson likelihood calc for data and MC event rates
 double SampleHandlerBase::GetTestStatLLH(const double data, const double mc) const {
 // ***************************************************************************
-  // Need some MC
-  if(mc == 0) return 0.;
+  // Return mc if there are no data, returns 0 for data == 0 && mc == 0  
+  if(data == 0) return mc;
 
-  double negLogL = 0;
-  if(mc > 0 && data > 0)
-  {
-    //http://hyperphysics.phy-astr.gsu.edu/hbase/math/stirling.html
-    negLogL += (mc - data + data * std::log(data/mc));
-  }
-  else if(mc > 0 && data == 0) negLogL += mc;
-  
-  return negLogL; 
+  // If there are some data, but the prediction falls below the mc bound => return Poisson LogL for the low mc bound
+  if(mc < M3::_LOW_MC_BOUND_) return (M3::_LOW_MC_BOUND_ - data + data * std::log(data/M3::_LOW_MC_BOUND_));
+
+  // otherwise just return usual Poisson LogL using Stirling's approximation
+  // http://hyperphysics.phy-astr.gsu.edu/hbase/math/stirling.html
+  return (mc - data + data * std::log(data/mc));
 }
 
 // *************************

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -23,7 +23,7 @@ double SampleHandlerBase::GetTestStatLLH(const double data, const double mc) con
   // If there are some data, but the prediction falls below the MC bound => return Poisson LogL for the low MC bound
   if ( mc < M3::_LOW_MC_BOUND_ ) {
     if ( data > M3::_LOW_MC_BOUND_ ) return ( M3::_LOW_MC_BOUND_ - data + data * std::log( data/M3::_LOW_MC_BOUND_ ) );
-    else if ( data > mc ) return 0.;
+    else if ( data >= mc ) return 0.;
   }
   
   // Otherwise, just return usual Poisson LogL using Stirling's approximation
@@ -52,7 +52,7 @@ double SampleHandlerBase::GetTestStatLLH(const double data, const double mc, con
       // If MC falls below the low MC bound, use low MC bound for newmc
       if ( mc < M3::_LOW_MC_BOUND_ ) {
         if ( data > M3::_LOW_MC_BOUND_ ) newmc = M3::_LOW_MC_BOUND_;
-        else if ( data > mc ) return 0.;
+        else if ( data >= mc ) return 0.;
       }
         
       // Barlow-Beeston uses fractional uncertainty on MC, so sqrt(sum[w^2])/mc
@@ -102,7 +102,7 @@ double SampleHandlerBase::GetTestStatLLH(const double data, const double mc, con
       // If MC falls below the low MC bound, use low MC bound for newmc
       if ( mc < M3::_LOW_MC_BOUND_ ) {
         if ( data > M3::_LOW_MC_BOUND_ ) newmc = M3::_LOW_MC_BOUND_;
-        else if ( data > mc ) return 0.;
+        else if ( data >= mc ) return 0.;
       }
       
       //the so-called effective count
@@ -149,8 +149,8 @@ double SampleHandlerBase::GetTestStatLLH(const double data, const double mc, con
 
       // Check whether the stat is more than Poisson-like bound for low mc (mc < data)
       // TN: I believe this might get some extra optimization
-      if ( mc < data ) {
-        if ( data < M3::_LOW_MC_BOUND_ ) return 0.;
+      if ( mc <= data ) {
+        if ( data <= M3::_LOW_MC_BOUND_ ) return 0.;
         const double poisson = GetTestStatLLH(data, M3::_LOW_MC_BOUND_);
         if ( stat > poisson ) return poisson;
       }
@@ -169,7 +169,7 @@ double SampleHandlerBase::GetTestStatLLH(const double data, const double mc, con
       // If MC is lower than the low MC bound, return the test-stat at the bound
       if ( mc < M3::_LOW_MC_BOUND_ ) {
         if ( data > M3::_LOW_MC_BOUND_ ) return ( data - M3::_LOW_MC_BOUND_ ) * ( data - M3::_LOW_MC_BOUND_ ) / ( 2. * M3::_LOW_MC_BOUND_ ); 
-        else if ( data > mc ) return 0.;
+        else if ( data >= mc ) return 0.;
       }
       
       // Return the Pearson metric

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -69,7 +69,7 @@ double SampleHandlerBase::GetTestStatLLH(const double data, const double mc, con
        // With data, test-stat shall return LogL for newMC*beta which includes the low MC bound
       if ( data > 0 ) {
         newmc *= beta;
-        double stat = newmc - data + data * std::log(data/newmc);
+        stat = newmc - data + data * std::log(data/newmc);
       }
 
       // Now, MC stat penalty

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -88,7 +88,7 @@ double SampleHandlerBase::GetTestStatLLH(const double data, const double mc, con
       //https://github.com/scikit-hep/iminuit/blob/059d06b00cae097ebf340b218b4eb57357111df8/src/iminuit/cost.py#L274-L300
       
       // If w2 == 0 for any reason, return Poisson LogL
-      if ( w2 == 0 ) return getTestStatLLH(data,mc);
+      if ( w2 == 0 ) return GetTestStatLLH(data,mc);
       
       // The MC can be changed
       double newmc = mc;
@@ -128,7 +128,7 @@ double SampleHandlerBase::GetTestStatLLH(const double data, const double mc, con
 
       // If there is 0 MC uncertainty, or the MC is less than low MC bound while having some data
       // => Return Poisson(data, mc)
-      if ( w2 == 0 || ( mc < M3::_LOW_MC_BOUND_ && data > 0 ) ) return getTestStatLLH(data,mc);
+      if ( w2 == 0 || ( mc < M3::_LOW_MC_BOUND_ && data > 0 ) ) return GetTestStatLLH(data,mc);
       
       // Auxiliary variables
       const long double b = mc/w2;
@@ -140,7 +140,7 @@ double SampleHandlerBase::GetTestStatLLH(const double data, const double mc, con
       // Check whether the stat is more than Poisson-like bound for low mc (mc < data)
       // TN: I believe there must be a better way to check, whether mc is near its bound
       if ( mc < data ) {
-        const double poisson = getTestStatLLH(data, M3::_LOW_MC_BOUND_);
+        const double poisson = GetTestStatLLH(data, M3::_LOW_MC_BOUND_);
         if ( stat > poisson ) return poisson;
       }
 
@@ -164,7 +164,7 @@ double SampleHandlerBase::GetTestStatLLH(const double data, const double mc, con
     break;
     case (kPoisson):
     {
-      //Just call getTestStatLLH which doesn't take in weights
+      //Just call GetTestStatLLH which doesn't take in weights
       //and is a Poisson likelihood comparison.
       return GetTestStatLLH(data, mc);
     }

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -64,11 +64,13 @@ double SampleHandlerBase::GetTestStatLLH(const double data, const double mc, con
       // Solve for the positive beta
       const double beta = (-1*temp+sqrt(temp2))/2.;
 
-      // With data, test-stat shall return LogL for newMC*beta which has the low MC bound
-      newmc *= beta;
-      double stat = newmc - data + data * std::log(data/newmc);
       // If there are no data, test-stat shall return only MC*beta
-      if (data == 0) stat = mc*beta;
+      double stat = mc*beta;
+       // With data, test-stat shall return LogL for newMC*beta which includes the low MC bound
+      if (data > 0) {
+        newmc *= beta;
+        double stat = newmc - data + data * std::log(data/newmc);
+      }
 
       // Now, MC stat penalty
       // The penalty from MC statistics using Conways approach (https://cds.cern.ch/record/1333496?)

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -94,7 +94,7 @@ double SampleHandlerBase::GetTestStatLLH(const double data, const double mc, con
       double newmc = mc;
       
       // If MC falls below the low MC bound, use low MC bound for newmc
-      if ( mc < M3::_LOW_MC_BOUND_ ) newmc = M3::_LOW_MC_BOUND_;
+      if ( mc < M3::_LOW_MC_BOUND_ && data > 0 ) newmc = M3::_LOW_MC_BOUND_;
       
       //the so-called effective count
       const double k = newmc*newmc / w2;

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -140,7 +140,7 @@ double SampleHandlerBase::GetTestStatLLH(const double data, const double mc, con
       // Check whether the stat is more than Poisson-like bound for low mc (mc < data)
       // TN: I believe there must be a better way to check, whether mc is near its bound
       if ( mc < data ) {
-        const double poisson = getTestStatLLH_test(data, M3::_LOW_MC_BOUND_);
+        const double poisson = getTestStatLLH(data, M3::_LOW_MC_BOUND_);
         if ( stat > poisson ) return poisson;
       }
 

--- a/Samples/SampleHandlerBase.h
+++ b/Samples/SampleHandlerBase.h
@@ -79,7 +79,15 @@ class SampleHandlerBase
   /// @param mc is mc
   /// @ingroup SampleHandlerGetters
   double GetTestStatLLH(double data, double mc) const;
-  /// @brief Calculate test statistic for a single bin. Calculation depends on setting of fTestStatistic
+  /// @brief Calculate test statistic for a single bin. Calculation depends on setting of fTestStatistic. Data and mc -> 0 cut-offs are defined in M3::_LOW_MC_BOUND_.
+  /// @details Implemented fTestStatistic are kPoisson (with Stirling's approx.), kBarlowBeeston (arXiv:1103.0354), kDembinskiAbdelmotteleb (arXiv:2206.12346), kIceCube (arxiv:1901.04645), and kPearson.
+  /// Test statistics require mc > 0, therefore low mc and data values are treated with cut-offs based on M3::_LOW_MC_BOUND_ = .00001 by default.
+  /// For kPoisson, kBarlowBeeston, kDembinskiAbdelmotteleb, kPearson:
+  /// data > _LOW_MC_BOUND_ & mc <= _LOW_MC_BOUND_: returns GetTestStatLLH(data, _LOW_MC_BOUND_, w2), with Poisson(data,_LOW_MC_BOUND_) limit for mc->0, w2->0.
+  /// mc < data <= _LOW_MC_BOUND_: returns 0 (as if any data <= _LOW_MC_BOUND_ were effectively consistent with 0 data count), with a limit of 0 for mc->0.
+  /// data = 0: returns mc (or mc/2. for kPearson), with a limit of 0 for mc->0.
+  /// For kIceCube:
+  /// mc < data returns the lower of IceCube(data,mc,w2) and Poisson(data,mc) penalties, with a Poisson(data,_LOW_MC_BOUND_) limit for mc->0, w2->0.
   /// @param data is data
   /// @param mc is mc
   /// @param w2 is is Sum(w_{i}^2) (sum of weights squared), which is sigma^2_{MC stats}


### PR DESCRIPTION
# Pull request description

The changes in this pull request introduce a low MC (1e-5 = _\_LOW\_MC\_BOUND\__) cut-off to deal with low &rarr; 0 MC predictions for test statistics -LogL calculation (```GetTestStatLLH()```) as discussed in the meeting https://indico.global/event/14742/ .

### Intentions
The main intent is to make the test statistics to return "reasonable" LogL numbers for low MC predictions and eventually construct a "reasonable" limit for 0 MC. 0 MC predictions have clear physics motivation, but they are not allowed -- obviously --  for rigorous test statistics.  
Given data _d >= 0_ and prediction _MC >= 0_, we shall consider the test statistic is well-behaved, if:  

1. It never returns _-LogL(d,MC)_ lower than _-LogL(d,d)_, even if _MC &rarr; 0_ or MC stat error _w<sup>2</sup> &rarr; 0_.
2. It is a monotonically decreasing function for _MC<d_ and monotonically increasing for _MC>d_.
3. _-LogL(d,MC)_ has a (local) minimum for only one value of _MC_ if  _d > \_LOW\_MC\_BOUND\__.
4. If _MC <=  \_LOW\_MC\_BOUND\__ and _d > 0_, it approaches the _MC = 0_ limit for _MC &rarr; 0_, _i.e._ it saturates for _MC <  \_LOW\_MC\_BOUND\__.
5. It reasonably scales with data, _i.e._ _-LogL(d<sub>1</sub>,MC) <= -LogL(d<sub>2</sub>,MC)_ if _d<sub>1</sub> < d<sub>2</sub>_ for _MC < d<sub>1</sub>_ and _-LogL(d<sub>1</sub>,MC) >= -LogL(d<sub>2</sub>,MC)_ for _MC > d<sub>2</sub>_.

Current implementation returning 0 at _MC=0_ fails 2., 3., 4., and for IceCube test-stat even 1. (as the global minimum will always correspond to _MC = 0_). 

## Changes or fixes

### New low MC behavior for Poisson, Barlow-Beeston, Dembinski-Abdelmotteleb, and Pearson test statistics

**1.** **Case _MC >  \_LOW\_MC\_BOUND\__ and _d >  \_LOW\_MC\_BOUND\__:** There is no change in the return value of ```GetTestStatLLH()```.
**2.** **_MC <=  \_LOW\_MC\_BOUND\__ and _d >  \_LOW\_MC\_BOUND\__:** ```GetTestStatLLH()``` returns ```GetTestStatLLH(d,_LOW_MC_BOUND_,w2)``` to produce a limit of _Poisson(d,\_LOW\_MC\_BOUND\_)_ (or _Pearson_) for _MC &rarr; 0_ and/or _w<sup>2</sup> &rarr; 0_.
**3.** **_MC < d <=  \_LOW\_MC\_BOUND\__:** For data counts below the _\_LOW\_MC\_BOUND\__ (Asimov studies, exposure studies, etc.), ```GetTestStatLLH()``` returns 0 for _d > MC_, constituting a fiction that any measurement below  _\_LOW\_MC\_BOUND\__ is effectively the same as 0 measurement. For _d < MC_, this returns the given test statistics (as before).
**4.** **Special _d = 0_ case:** ```GetTestStatLLH()``` returns _MC_ (or _MC/2_ or "stat-corrected" _MC_) limiting at 0 for _MC &rarr; 0_ and _w<sup>2</sup> &rarr; 0_.

See Examples.

### Special treatment of IceCube test statistic for low MC

I haven't come up with a reasonable limit of IceCube test statistic for _w<sup>2</sup> &rarr; 0_ (including the case _MC &rarr; 0_) that would nicely scale with _d_. Generally, IceCube test statistic does not have a minimum of 0, that is _-LogL(d,MC=d) != 0_. Heuristically, I have chosen the _w<sup>2</sup> &rarr; 0_ and _MC &rarr; 0_ limit to be _Poisson(d,\_LOW\_MC\_BOUND\_)_, independent of _w<sup>2</sup>_. The main motivation is the current implementation of Poisson-like return value for _w<sup>2</sup>=0_. In summary, for _MC <= d_, whenever _IceCube(d,MC,w<sup>2</sup>)_ surpasses _Poisson(data,\_LOW\_MC\_BOUND\_)_, the return value is _Poisson(data,\_LOW\_MC\_BOUND\_)_.  This means, the low MC cut-off depends on the data value.

However, as the minimum value of _IceCube(d,MC,w<sup>2</sup>)_ is not 0 and depends on _d_ and _w<sup>2</sup>_, it might happen for _d << 1_ that the Poisson-like limit is lower than the IceCube minimum. For such cases ```GetTestStat()``` drops to _Poisson(data,\_LOW\_MC\_BOUND\_)_ for any _MC <= d_. I.e., IceCube test statistic does not fulfill the 3. and 5. requirement of well-behaved test statistics above. One solution is to subtract the minimum _IceCube(d,d,w<sup>2</sup>)_ from the test statistic calculation to have 0 as minimum, but that seems to be a computationally expensive overkill, given the differences of the order of _1e-1_ and lower between the Poisson-like limit and the IceCube minimum (see examples).  

For _d < \_LOW\_MC\_BOUND\__, ```GetTestStatLLH()``` returns 0 for _d < MC_ (similar to other statistics).

See Examples.

### Some optimization efforts

As the low MC cut-off requires some extra computing time (extra condition), I have also tried to optimize the structure of ```GetTestStatLLH()``` function to be less affected in terms of speed. The main focus was given to the implementation of the standard Poisson LogL function. See Examples for speed comparisons.

## Examples

The calculations documented below were performed for data _d_ = 0, 1e-7, 1e-6, 1e-5, 1e-4, 1e-3, 1..10, while _MC_ varied for 0 and from 1e-8 to 1e3 (10 values for each power of 10). One-bin MC statistic was set to 50, the _w<sup>2</sup>_ was recalculated according to the value of tested _MC_ prediction.   

For each value of _d_ and _MC_ ```GetTestStatLLH()``` function was invoked 1e7 times to obtain an average real time of the -LogL calculation, using isolated computing resources 4 CPU threads and keeping similar conditions while the original and proposed versions were invoked. The ratio is to accommodate for varying running conditions and thread management when varying _d_ and _MC_.

In conclusion, Poisson calculation gets a minor appreciable speed-up about 5% for _d>0_. Barlow-Beeston calculations get a bit worse than previously on average, while IceCube and Pearson calculations get a small slow-down of about 3%.

Details and _MC = 0_ case to check the _MC &rarr; 0_ limit in the attached data files.

### Poisson
**Data file:** [Poisson.txt](https://github.com/user-attachments/files/20834937/Poisson.txt)
![Poisson_Speed](https://github.com/user-attachments/assets/3f14e113-bce2-4a54-a534-8555289d057e)
![Poisson_LogL](https://github.com/user-attachments/assets/091f5d04-ca9f-48e8-a0be-ef6f36b67f0d)

### Barlow-Beeston
**Data file:** [Barlow-Beeston.txt](https://github.com/user-attachments/files/20834957/Barlow-Beeston.txt)
![Barlow-Beeston_Speed](https://github.com/user-attachments/assets/0063da67-8d84-4149-8d4b-f5e94078a45a)
![Barlow-Beeston_LogL](https://github.com/user-attachments/assets/ac8e2be3-5f69-4381-9544-18d4ede0506f)

### Dembinski-Abdelmotteleb
**Data file:** [Dembinski-Abdelmotteleb.txt](https://github.com/user-attachments/files/20834969/Dembinski-Abdelmotteleb.txt)
![Dembinski-Abdelmotteleb_Speed](https://github.com/user-attachments/assets/25fc89d0-3887-4845-a2e4-7ce15d5e2aea)
![Dembinski-Abdelmotteleb_LogL](https://github.com/user-attachments/assets/92c4a0d1-21e3-4f38-96b6-733028420d74)

### IceCube
**Data file:** [IceCube.txt](https://github.com/user-attachments/files/20834974/IceCube.txt)
![IceCube_Speed](https://github.com/user-attachments/assets/c8b9e22e-211d-445f-abb9-78f2448a5a4c)
![IceCube_LogL](https://github.com/user-attachments/assets/53e446c7-65f8-40f3-ad83-f7cce2c730a9)

### Pearson
**Data file:** [Pearson.txt](https://github.com/user-attachments/files/20834988/Pearson.txt)
![Pearson_Speed](https://github.com/user-attachments/assets/d2479295-7ea4-4b43-9b1d-49b517ba743d)
![Pearson_LogL](https://github.com/user-attachments/assets/e20de854-6267-4f01-b463-866061f412ae)

## Extra considerations

- Ideally, this shall be tested also while invoked from the more complex Sample->GetLikelihood() routines.
- It might be interesting to study data dependent MC prediction cut-offs (similar to the proposed IceCube), instead of hard MC cut-offs. E.g., the cut-off might be constructed as a fraction of data value _MC < d*1e-5_. This might be better for low _d_ behavior of the return value, but needs some extra considerations for higher _d_ that gets cut off at otherwise reasonable values (e.g. below MC prediction 1 for data = 10000) depending on the analysis.
- This update does not include any messaging or warnings concerning low MC predictions. This was also discussed and will be prepared based on the final version of the MC cut-off behavior, once merged. This will require separate development branch and MR.

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
