### PR TITLE
feat: Do not apply special proposal for fixed params

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -296,6 +296,12 @@ void ParameterHandlerBase::Init(const std::vector<std::string>& YAMLFile) {
 // ********************************************
 void ParameterHandlerBase::EnableSpecialProposal(const YAML::Node& param, const int Index){
 // ********************************************
+  // If parameter is fixed do not enable special proposal to avoid situation where we switch mass ordering for example if it is fixed
+  if(IsParameterFixed(Index)) {
+    MACH3LOG_DEBUG("Parameter {} is fixed, therefore will not apply Special proposal", GetParName(Index));
+    return;
+  }
+
   doSpecialStepProposal = true;
 
   bool CircEnabled = false;

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -920,6 +920,36 @@ void ParameterHandlerBase::ToggleFixParameter(const int i) {
   } else {
     PCAObj->ToggleFixParameter(i, _fNames);
   }
+
+  RemoveSpecialProposal(i);
+}
+
+// ********************************************
+// Remove special proposal for fixed parameters
+void ParameterHandlerBase::RemoveSpecialProposal(const int i) {
+// ********************************************
+  /// @todo if me add class or simple struct holding this info it could make this function simplified
+  for (size_t idx = 0; idx < FlipParameterIndex.size(); ++idx) {
+    if (FlipParameterIndex[idx] == i) {
+      FlipParameterIndex.erase(FlipParameterIndex.begin() + idx);
+      FlipParameterPoint.erase(FlipParameterPoint.begin() + idx);
+      MACH3LOG_DEBUG("Removed flip symmetry for parameter {}.", i);
+      break;
+    }
+  }
+
+  for (size_t idx = 0; idx < CircularBoundsIndex.size(); ++idx) {
+    if (CircularBoundsIndex[idx] == i) {
+      CircularBoundsIndex.erase(CircularBoundsIndex.begin() + idx);
+      CircularBoundsValues.erase(CircularBoundsValues.begin() + idx);
+      MACH3LOG_DEBUG("Removed circular bounds for parameter {}.", i);
+      break;
+    }
+  }
+
+  // Sanity check that sizes matter
+  assert(FlipParameterIndex.size() == FlipParameterPoint.size());
+  assert(CircularBoundsIndex.size() == CircularBoundsValues.size());
 }
 
 // ********************************************

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -314,7 +314,8 @@ class ParameterHandlerBase {
   /// @brief Fix parameter at prior values
   /// @param name Name of parameter you want to fix
   void ToggleFixParameter(const std::string& name);
-
+  /// @brief Remove Special Propsoals for param
+  void RemoveSpecialProposal(const int i);
   /// @brief Is parameter fixed or not
   /// @param i Parameter index
   bool IsParameterFixed(const int i) const {

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -314,8 +314,6 @@ class ParameterHandlerBase {
   /// @brief Fix parameter at prior values
   /// @param name Name of parameter you want to fix
   void ToggleFixParameter(const std::string& name);
-  /// @brief Remove Special Propsoals for param
-  void RemoveSpecialProposal(const int i);
   /// @brief Is parameter fixed or not
   /// @param i Parameter index
   bool IsParameterFixed(const int i) const {


### PR DESCRIPTION
# Pull request description
Dan raised issue that even if we fixed param code might still apply special proposal like flipping.
Just to be completly safe turn off speical proposal for fixed params

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
