### PR TITLE
tidy: Removal of oboslete stuff and micro optimisation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 # CMake version check
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
-project(MaCh3 VERSION 2.2.0 LANGUAGES CXX)
+project(MaCh3 VERSION 2.2.1 LANGUAGES CXX)
 set(MaCh3_VERSION ${PROJECT_VERSION})
 
 option(MaCh3_PYTHON_ENABLED "Whether to build MaCh3 python bindings" OFF)

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -166,7 +166,6 @@ void SampleHandlerFD::ReadSampleConfig()
 
   //Now grab the selection cuts from the manager
   for ( auto const &SelectionCuts : SampleManager->raw()["SelectionCuts"]) {
-    SelectionStr.push_back(SelectionCuts["KinematicStr"].as<std::string>());
     auto TempBoundsVec = GetBounds(SelectionCuts["Bounds"]);
     KinematicCut CutObj;
     CutObj.LowerBound = TempBoundsVec[0];
@@ -357,9 +356,10 @@ void SampleHandlerFD::SetupSampleBinning(){
 // ************************************************
 bool SampleHandlerFD::IsEventSelected(const int iEvent) {
 // ************************************************
-  for (unsigned int iSelection=0;iSelection < Selection.size() ;iSelection++) {
-    const double Val = ReturnKinematicParameter(Selection[iSelection].ParamToCutOnIt, iEvent);
-    if ((Val < Selection[iSelection].LowerBound) || (Val >= Selection[iSelection].UpperBound)) {
+  for (unsigned int iSelection = 0; iSelection < Selection.size(); ++iSelection) {
+    const auto& Cut = Selection[iSelection];
+    const double Val = ReturnKinematicParameter(Cut.ParamToCutOnIt, iEvent);
+    if ((Val < Cut.LowerBound) || (Val >= Cut.UpperBound)) {
       return false;
     }
   }
@@ -516,7 +516,7 @@ void SampleHandlerFD::FillArray_MP() {
 
     const unsigned int NumberOfEvents = GetNEvents();
     #pragma omp for
-    for (unsigned int iEvent = 0; iEvent < NumberOfEvents; iEvent++) {
+    for (unsigned int iEvent = 0; iEvent < NumberOfEvents; ++iEvent) {
       //ETA - generic functions to apply shifts to kinematic variables
       // Apply this before IsEventSelected is called.
       ApplyShifts(iEvent);
@@ -726,12 +726,13 @@ void SampleHandlerFD::ApplyShifts(int iEvent) {
 M3::float_t SampleHandlerFD::CalcWeightSpline(const FarDetectorCoreInfo* MCEvent) const {
 // ***************************************************************************
   M3::float_t spline_weight = 1.0;
+  const int nSplines = static_cast<int>(MCEvent->xsec_spline_pointers.size());
   //DB Xsec syst
   //Loop over stored spline pointers
   #ifdef MULTITHREAD
   #pragma omp simd
   #endif
-  for (size_t iSpline = 0; iSpline < MCEvent->xsec_spline_pointers.size(); ++iSpline) {
+  for (int iSpline = 0; iSpline < nSplines; ++iSpline) {
     spline_weight *= *(MCEvent->xsec_spline_pointers[iSpline]);
   }
   return spline_weight;
@@ -742,11 +743,12 @@ M3::float_t SampleHandlerFD::CalcWeightSpline(const FarDetectorCoreInfo* MCEvent
 M3::float_t SampleHandlerFD::CalcWeightNorm(const FarDetectorCoreInfo* MCEvent) const {
 // ***************************************************************************
   M3::float_t xsecw = 1.0;
+  const int nNorms = static_cast<int>(MCEvent->xsec_norm_pointers.size());
   //Loop over stored normalisation and function pointers
   #ifdef MULTITHREAD
   #pragma omp simd
   #endif
-  for (size_t iParam = 0; iParam < MCEvent->xsec_norm_pointers.size(); ++iParam)
+  for (int iParam = 0; iParam < nNorms; ++iParam)
   {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuseless-cast"
@@ -947,26 +949,6 @@ void SampleHandlerFD::Set1DBinning(size_t nbins, double* boundaries)
   FindNominalBinAndEdges1D();
 }
 
-void SampleHandlerFD::Set1DBinning(size_t nbins, double low, double high)
-{
-  _hPDF1D->Reset();
-  _hPDF1D->SetBins(static_cast<int>(nbins),low,high);
-  dathist->SetBins(static_cast<int>(nbins),low,high);
-
-  Binning.YBinEdges = std::vector<double>(2);
-  Binning.YBinEdges[0] = -1e8;
-  Binning.YBinEdges[1] = 1e8;
-
-  _hPDF2D->Reset();
-  _hPDF2D->SetBins(static_cast<int>(nbins),low,high,1,Binning.YBinEdges[0],Binning.YBinEdges[1]);
-  dathist2d->SetBins(static_cast<int>(nbins),low,high,1,Binning.YBinEdges[0],Binning.YBinEdges[1]);
-
-  //Set the number of X and Y bins now
-  SetupReweightArrays(Binning.XBinEdges.size() - 1, Binning.YBinEdges.size() - 1);
-
-  FindNominalBinAndEdges1D();
-}
-
 void SampleHandlerFD::FindNominalBinAndEdges1D() {
   for(unsigned int event_i = 0; event_i < GetNEvents(); event_i++){
     //Set x_var and y_var values based on XVarStr and YVarStr
@@ -1028,22 +1010,6 @@ void SampleHandlerFD::Set2DBinning(size_t nbins1, double* boundaries1, size_t nb
   _hPDF2D->SetBins(static_cast<int>(nbins1),boundaries1,static_cast<int>(nbins2),boundaries2);
   dathist2d->SetBins(static_cast<int>(nbins1),boundaries1,static_cast<int>(nbins2),boundaries2);
   
-  //Set the number of X and Y bins now
-  SetupReweightArrays(Binning.XBinEdges.size() - 1, Binning.YBinEdges.size() - 1);
-
-  FindNominalBinAndEdges2D();
-}
-
-void SampleHandlerFD::Set2DBinning(size_t nbins1, double low1, double high1, size_t nbins2, double low2, double high2)
-{
-  _hPDF1D->Reset();
-  _hPDF1D->SetBins(static_cast<int>(nbins1),low1,high1);
-  dathist->SetBins(static_cast<int>(nbins1),low1,high1);
-
-  _hPDF2D->Reset();
-  _hPDF2D->SetBins(static_cast<int>(nbins1),low1,high1,static_cast<int>(nbins2),low2,high2);
-  dathist2d->SetBins(static_cast<int>(nbins1),low1,high1,static_cast<int>(nbins2),low2,high2);
-
   //Set the number of X and Y bins now
   SetupReweightArrays(Binning.XBinEdges.size() - 1, Binning.YBinEdges.size() - 1);
 
@@ -1377,13 +1343,14 @@ std::string SampleHandlerFD::GetSampleName(int iSample) const {
 
 M3::float_t SampleHandlerFD::GetEventWeight(const int iEntry) const {
   M3::float_t totalweight = 1.0;
+  const int nParams = static_cast<int>(MCSamples[iEntry].total_weight_pointers.size());
   #ifdef MULTITHREAD
   #pragma omp simd
   #endif
-  for (size_t iParam = 0; iParam < MCSamples[iEntry].total_weight_pointers.size(); ++iParam) {
+  for (int iParam = 0; iParam < nParams; ++iParam) {
     totalweight *= *(MCSamples[iEntry].total_weight_pointers[iParam]);
   }
-  
+
   return totalweight;
 }
 
@@ -1498,7 +1465,7 @@ void SampleHandlerFD::InitialiseSplineObject() {
   }
 
   //Keep a track of the spline variables
-  SplineVarNames.push_back("TrueNeutrinoEnergy");
+  std::vector<std::string> SplineVarNames = {"TrueNeutrinoEnergy"};
   if(XVarStr.length() > 0){
     SplineVarNames.push_back(XVarStr);
   }
@@ -1548,8 +1515,9 @@ TH1* SampleHandlerFD::Get1DVarHist(const std::string& ProjectionVar_Str, const s
     _h1DVar = new TH1D("", "", int(xBinEdges.size())-1, xBinEdges.data());
   }
   
-  if (IsSubEventVarString(ProjectionVar_Str)) Fill1DSubEventHist(_h1DVar, ProjectionVar_Str, SubEventSelectionVec, WeightStyle);
-  else {
+  if (IsSubEventVarString(ProjectionVar_Str)) {
+    Fill1DSubEventHist(_h1DVar, ProjectionVar_Str, SubEventSelectionVec, WeightStyle);
+  } else {
     //DB Grab the associated enum with the argument string
     int ProjectionVar_Int = ReturnKinematicParameterFromString(ProjectionVar_Str);
 

--- a/Samples/SampleHandlerFD.h
+++ b/Samples/SampleHandlerFD.h
@@ -172,6 +172,8 @@ public:
   /// @brief Contains all your binned splines and handles the setup and the returning of weights from spline evaluations
   std::shared_ptr<OscillationHandler> Oscillator;
   //===============================================================================
+  /// @brief Finds the binned spline that an event should apply to and stored them in a
+  /// a vector for easy evaluation in the fillArray() function.
   void FillSplineBins();
 
   //Functions which find the nominal bin and bin edges
@@ -184,24 +186,12 @@ public:
   /// @param nbins number of total bins
   /// @param boundaries the bin edges e.g. 0, 0.1, 0.2, 0.3 
   void Set1DBinning(size_t nbins, double* boundaries);
-  /// @brief set the binning used for likelihood calculation using uniform binning
-  /// @param nbins number of total bins
-  /// @param low lower bound of the binning
-  /// @param high upper bound of the binning
-  void Set1DBinning(size_t nbins, double low, double high);
   /// @brief set the binning for 2D sample used for the likelihood calculation
   /// @param nbins1 number of bins in axis 1 (the x-axis)
   /// @param nbins2 number of bins in axis 2 (the y-axis)
   /// @param boundaries1 the bin boundaries used in axis 1 (the x-axis)
   /// @param boundaries2 the bin boundaries used in axis 2 (the y-axis)
   void Set2DBinning(size_t nbins1, double* boundaries1, size_t nbins2, double* boundaries2);
-  /// @brief set the binning for 2D sample used for the likelihood calculation
-  /// @param nbins1 number of bins in axis 1 (the x-axis)
-  /// @param low1 lower bound of binning in axis 1 (the x-axis)
-  /// @param high1 upper bound of binning in axis 1 (the x-axis)
-  /// @param nbins2 number of bins in axis 2 (the y-axis)
-  /// @param low2 lower bound of binning in axis 2 (the y-axis)
-  void Set2DBinning(size_t nbins1, double low1, double high1, size_t nbins2, double low2, double high2);
   /// @brief set the binning for 1D sample used for the likelihood calculation
   /// @param XVec vector containing the binning in axis 1 (the x-axis)
   void Set1DBinning(std::vector<double> &XVec) {Set1DBinning(XVec.size()-1, XVec.data());};
@@ -216,7 +206,6 @@ public:
 
   /// @brief the strings associated with the variables used for the binning e.g. "RecoNeutrinoEnergy"
   std::string XVarStr, YVarStr;
-  std::vector<std::string> SplineVarNames;
   //===============================================================================
 
   // ----- Functional Parameters -----
@@ -226,7 +215,7 @@ public:
   void RegisterIndividualFunctionalParameter(const std::string& fpName, int fpEnum, FuncParFuncType fpFunc);
   /// @brief HH - a experiment-specific function where the maps to actual functions are set up
   virtual void RegisterFunctionalParameters() = 0;
-  /// @brief Update the functional parameter values to the latest propsed values. Needs to be called before every new reweight so is called in fillArray 
+  /// @brief Update the functional parameter values to the latest proposed values. Needs to be called before every new reweight so is called in fillArray
   virtual void PrepFunctionalParameters(){};
   /// @brief ETA - generic function applying shifts
   virtual void ApplyShifts(int iEvent);
@@ -350,8 +339,6 @@ public:
   /// @brief What gets pulled from config options, these are constant after loading in
   /// this is of length 3: 0th index is the value, 1st is lower bound, 2nd is upper bound
   std::vector< KinematicCut > StoredSelection;
-  /// @brief the strings grabbed from the sample config specifying the selections
-  std::vector< std::string > SelectionStr;
   /// @brief a way to store selection cuts which you may push back in the get1DVar functions
   /// most of the time this is just the same as StoredSelection
   std::vector< KinematicCut > Selection;


### PR DESCRIPTION
# Pull request description
tl:dr Tidy and crackpot speed ideas

## Changes or fixes
- SelectionStr wasn't used anywhere, we do store ParamToCutOnIt  so we can always revert it using map
-  SplineVarNames  only used during setup so no point having it class member
- removed not used Set2DBinning and Set1DBinning
- some hyper optimisation like caching size of vector whcih helps compiler optimsie entires [and using int not size which is smaller] or storing reference to Selection which helps caching

## Examples
In my few trials there is a few percent increase. Nothing major but "Tesco: every little helps"
![image](https://github.com/user-attachments/assets/b7d0accd-41b9-42ed-9adc-06c376a14dae)



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
