### PR TITLE
feat: Sanity Check for bound getting

### DIFF
--- a/Manager/YamlHelper.h
+++ b/Manager/YamlHelper.h
@@ -458,6 +458,10 @@ inline std::vector<double> ParseBounds(const YAML::Node& node, const std::string
     } else if (val.IsScalar()) {
       try {
         const double center = val.as<double>();
+        if (std::floor(center) != center) {
+          MACH3LOG_ERROR("Invalid center value in Bounds[0]: '{}'. Expected an integer (e.g., 0 or 1).", static_cast<std::string>(val.Scalar()));
+          throw MaCh3Exception(File, Line);
+        }
         bounds = {center - 0.5, center + 0.5};
       } catch (const YAML::BadConversion& e) {
         MACH3LOG_ERROR("Invalid value in Bounds[0]: '{}'. Expected a number.", static_cast<std::string>(val.Scalar()));


### PR DESCRIPTION
# Pull request description
We now support single bound in kienamtic cuts
`- iClass [13]`

but code may not work as expected if osmoen would pass 
`- iClass [12.5]`

This is pretty much what this PR does.
## Changes or fixes


## Examples
<img width="753" alt="test" src="https://github.com/user-attachments/assets/769b9dcb-8253-409f-be6b-d8d1c1104a1e" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
