### PR TITLE
feat: Use STL over TMath

### DIFF
--- a/Fitters/mcmc.cpp
+++ b/Fitters/mcmc.cpp
@@ -38,11 +38,11 @@ void mcmc::CheckStep() {
   accProb = 0.0;
 
   // Calculate acceptance probability
-  if (anneal) accProb = TMath::Min(1.,TMath::Exp( -(logLProp-logLCurr) / (TMath::Exp(-step/AnnealTemp)))); 
-  else accProb = TMath::Min(1., TMath::Exp(logLCurr-logLProp));
+  if (anneal) accProb = std::min(1., std::exp( -(logLProp-logLCurr) / (std::exp(-step/AnnealTemp))));
+  else accProb = std::min(1., std::exp(logLCurr-logLProp));
 
   // Get the random number
-  double fRandom = random->Rndm();
+  const double fRandom = random->Rndm();
 
   // Do the accept/reject
   if (fRandom <= accProb) {
@@ -94,7 +94,8 @@ void mcmc::RunMCMC() {
   logLCurr = logLProp;
 
   // Begin MCMC
-  for (step = stepStart; step < stepStart+chainLength; ++step)
+  const auto StepEnd = stepStart + chainLength;
+  for (step = stepStart; step < StepEnd; ++step)
   {
     stepClock->Start();
     // Set the initial rejection to false

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -753,7 +753,7 @@ M3::float_t SampleHandlerFD::CalcWeightNorm(const FarDetectorCoreInfo* MCEvent) 
     xsecw *= static_cast<M3::float_t>(*(MCEvent->xsec_norm_pointers[iParam]));
 #pragma GCC diagnostic pop
     #ifdef DEBUG
-    if (TMath::IsNaN(xsecw)) MACH3LOG_WARN("iParam= {} xsecweight=nan from norms", iParam);
+    if (std::isnan(xsecw)) MACH3LOG_WARN("iParam= {} xsecweight=nan from norms", iParam);
     #endif
   }
   return xsecw;


### PR DESCRIPTION
# Pull request description
Simple use STL over TMath. Funnily enoug TMath was calling some STL fucntions already so this is to reduce relliance on ROOT rather than any perfomace.

Also now stepStart + chainLength is calcuated once and set const. Previously it tehccinally could be calculated every iteration unless compiler was smart enough to figure out this on it's own. Even if it is faster impact would be negligilbe so I didn't test it.

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
