### PR TITLE
tidy: More helpfull yaml error messages

### DIFF
--- a/Manager/YamlHelper.h
+++ b/Manager/YamlHelper.h
@@ -264,10 +264,6 @@ inline std::string DemangleTypeName(const std::string& mangledName) {
 template<typename Type>
 Type Get(const YAML::Node& node, const std::string File, const int Line) {
 // **********************
-  if (!node) {
-    MACH3LOG_ERROR("Empty Yaml node");
-    throw MaCh3Exception(File , Line );
-  }
   try {
     // Attempt to convert the node to the expected type
     return node.as<Type>();
@@ -275,6 +271,21 @@ Type Get(const YAML::Node& node, const std::string File, const int Line) {
     const std::string nodeAsString = YAMLtoSTRING(node);
     MACH3LOG_ERROR("YAML type mismatch: {}", e.what());
     MACH3LOG_ERROR("While trying to access variable {}", nodeAsString);
+    throw MaCh3Exception(File , Line );
+  } catch (const YAML::InvalidNode& e) {
+    std::string key = "<unknown>";
+    const std::string msg = e.what();
+    const std::string search = "first invalid key: \"";
+    auto start = msg.find(search);
+    if (start != std::string::npos) {
+      start += search.length();
+      auto end = msg.find("\"", start);
+      if (end != std::string::npos) {
+        key = msg.substr(start, end - start);
+      }
+    }
+    MACH3LOG_ERROR("Invalid YAML node: {}", e.what());
+    MACH3LOG_ERROR("While trying to access key: {}", key);
     throw MaCh3Exception(File , Line );
   }
 }


### PR DESCRIPTION
# Pull request description
Basically Dan pointer out that error "empty yaml" isn;t very helpufll so this should imrpove htis

Sadly yaml don't store information back so I don't think we can fully trace path back wihtout changing how Get<> works

## Changes or fixes


## Examples
Before:
<img width="560" alt="before" src="https://github.com/user-attachments/assets/9065721e-279e-4be2-a718-3c22bceb4228" />

After:
<img width="547" alt="After" src="https://github.com/user-attachments/assets/b3ed5d7e-fda3-4d77-a753-60239dae36b9" />
<img width="575" alt="After2" src="https://github.com/user-attachments/assets/a6ab06a8-15b5-45a4-b4cb-9e4c702525c8" />


---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
