### PR TITLE
tidy: Wildcard sanitizer

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -1276,6 +1276,13 @@ bool ParameterHandlerBase::AppliesToSample(const int SystIndex, const std::strin
   // Make a copy and to lower case to not be case sensitive
   std::string SampleNameCopy = SampleName;
   std::transform(SampleNameCopy.begin(), SampleNameCopy.end(), SampleNameCopy.begin(), ::tolower);
+
+  // Check for unsupported wildcards in SampleNameCopy
+  if (SampleNameCopy.find('*') != std::string::npos) {
+    MACH3LOG_ERROR("Wildcards ('*') are not supported in sample name: '{}'", SampleName);
+    throw MaCh3Exception(__FILE__ , __LINE__ );
+  }
+
   bool Applies = false;
 
   for (size_t i = 0; i < _fSampleNames[SystIndex].size(); i++) {


### PR DESCRIPTION
# Pull request description
To solve confusion widlards are supported on parmater side i.e. parmater can be applied to wildarc sample.
Sample should not have this widlcard feature otheriwse things would get convluted.

This came during dsicusision with Dan. Now error should be clear with error.
## Changes or fixes


## Examples
<img width="594" alt="example" src="https://github.com/user-attachments/assets/df13f444-6b68-4150-ad50-1670092ab36e" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
