### PR TITLE
tidy: More verbose GPU Printer

### DIFF
--- a/Fitters/gpuMCMCProcessorUtils.cu
+++ b/Fitters/gpuMCMCProcessorUtils.cu
@@ -21,7 +21,6 @@ static int h_nEntries = -1;
 // *******************************************
 /// KS: Initialiser, here we allocate memory for variables and copy constants
 __host__ void InitGPU_AutoCorr(
-// *******************************************
                           float **ParStep_gpu,
                           float **NumeratorSum_gpu,
                           float **ParamSums_gpu,
@@ -30,7 +29,7 @@ __host__ void InitGPU_AutoCorr(
                           int n_Entries,
                           int n_Pars,
                           const int n_Lags) {
-
+// *******************************************
   // Write to the global statics (h_* denotes host stored variable)
   h_nDraws = n_Pars;
   h_nLag = n_Lags;
@@ -63,8 +62,8 @@ __host__ void InitGPU_AutoCorr(
   cudaMalloc((void **) ParStep_gpu, h_nDraws*h_nEntries*sizeof(float*));
   CudaCheckError();
 
-  printf(" Allocated in total %f MB for autocorrelations calculations on GPU\n", double(sizeof(float)*(h_nLag*h_nDraws+h_nLag*h_nDraws+h_nDraws+h_nDraws*h_nEntries))/1.E6);
-
+  printf(" Allocated in total %f MB for autocorrelations calculations on GPU\n",
+         static_cast<double>(sizeof(float) * (h_nLag * h_nDraws + h_nLag * h_nDraws + h_nDraws + h_nDraws * h_nEntries)) / 1.0e6);
 }
 
 // ******************************************************
@@ -74,7 +73,6 @@ __host__ void InitGPU_AutoCorr(
 // ******************************************************
 /// KS: Copy necessary variables from CPU to GPU
 __host__ void CopyToGPU_AutoCorr(
-// ******************************************************
                             float *ParStep_cpu,
                             float *NumeratorSum_cpu,
                             float *ParamSums_cpu,
@@ -84,7 +82,7 @@ __host__ void CopyToGPU_AutoCorr(
                             float *NumeratorSum_gpu,
                             float *ParamSums_gpu,
                             float *DenomSum_gpu) {
-
+// ******************************************************
   //store value of parameter for each step
   cudaMemcpy(ParStep_gpu, ParStep_cpu, h_nDraws*h_nEntries*sizeof(float), cudaMemcpyHostToDevice);
   CudaCheckError();
@@ -115,7 +113,6 @@ __global__ void EvalOnGPU_AutoCorr(
     float*  NumeratorSum_gpu,
     float*  DenomSum_gpu) {
 //*********************************************************
-
   const unsigned int CurrentLagNum = (blockIdx.x * blockDim.x + threadIdx.x);
 
   //KS: Accessing shared memory is much much faster than global memory hence we use shared memory for calculation and then write to global memory
@@ -168,7 +165,6 @@ __host__ void RunGPU_AutoCorr(
     float*  NumeratorSum_cpu,
     float*  DenomSum_cpu) {
 // *****************************************
-
   dim3 block_size;
   dim3 grid_size;
 
@@ -210,5 +206,4 @@ __host__ void CleanupGPU_AutoCorr(
   cudaFree(DenomSum_gpu);
 
   printf(" Cleared memory at GPU, I am free \n");
-  return;
 }

--- a/Manager/Monitor.cpp
+++ b/Manager/Monitor.cpp
@@ -153,6 +153,12 @@ void GetGPUInfo(){
   MACH3LOG_INFO("Driver Version: {}", TerminalToString("nvidia-smi --query-gpu=driver_version --format=csv,noheader"));
   // Print N GPU thread
   MACH3LOG_INFO("Currently used GPU has: {} threads", GetNumGPUThreads());
+  // Print L2 cache
+  MACH3LOG_INFO("Currently used GPU has: {} KB L2 cache", GetL2CacheSize() / 1024);
+  // Shared memory info
+  MACH3LOG_INFO("Max shared memory per block: {} KB", GetSharedMemoryPerBlock() / 1024);
+  // Print 1D texture size
+  MACH3LOG_INFO("Max 1D texture size: {}", GetMaxTexture1DSize());
 #endif
 }
 

--- a/Manager/gpuUtils.cuh
+++ b/Manager/gpuUtils.cuh
@@ -74,3 +74,18 @@ void SetDevice(const int deviceId);
 /// @param Device The ID of the device. Defaults to 0.
 /// @return The number of GPU threads.
 int GetNumGPUThreads(const int Device = 0);
+
+/// @brief KS: Get L2 cache size (in bytes) for the specified GPU device.
+/// @param device The ID of the device. Defaults to 0.
+/// @return The size of the L2 cache in bytes
+size_t GetL2CacheSize(const int device = 0);
+
+/// @brief KS: Get the maximum size for 1D textures on the specified GPU device.
+/// @param device The ID of the device. Defaults to 0.
+/// @return The maximum 1D texture size supported by the device
+size_t GetMaxTexture1DSize(const int device = 0);
+
+/// @brief KS: Returns the maximum shared memory per block for a given GPU device.
+/// @param device CUDA device ID (default = 0)
+/// @return Maximum shared memory per block in bytes
+size_t GetSharedMemoryPerBlock(const int device = 0);

--- a/Splines/gpuSplineUtils.cu
+++ b/Splines/gpuSplineUtils.cu
@@ -159,10 +159,14 @@ __host__ void SMonolithGPU::InitGPU_SplineMonolith(
 #endif
   
   // Print allocation info to user
-  printf("Allocated %i entries for paramNo and nKnots arrays, size = %f MB\n", n_splines, double(sizeof(short int)*n_splines+sizeof(unsigned int)*n_splines)/1.E6);
-  printf("Allocated %i entries for x coeff arrays, size = %f MB\n", Eve_size, double(sizeof(float)*Eve_size)/1.E6);
-  printf("Allocated %i entries for {ybcd} coeff arrays, size = %f MB\n", _nCoeff_*total_nknots, double(sizeof(float)*_nCoeff_*total_nknots)/1.E6);
-  printf("Allocated %i entries for TF1 coefficient arrays, size = %f MB\n", _nTF1Coeff_*n_tf1, double(sizeof(float)*_nTF1Coeff_*n_tf1)/1.E6);
+  printf("Allocated %i entries for paramNo and nKnots arrays, size = %f MB\n",
+         n_splines, static_cast<double>(sizeof(short int) * n_splines + sizeof(unsigned int) * n_splines) / 1.0e6);
+  printf("Allocated %i entries for x coeff arrays, size = %f MB\n",
+         Eve_size, static_cast<double>(sizeof(float) * Eve_size) / 1.0e6);
+  printf("Allocated %i entries for {ybcd} coeff arrays, size = %f MB\n",
+         _nCoeff_ * total_nknots, static_cast<double>(sizeof(float) * _nCoeff_ * total_nknots) / 1.0e6);
+  printf("Allocated %i entries for TF1 coefficient arrays, size = %f MB\n",
+         _nTF1Coeff_ * n_tf1, static_cast<double>(sizeof(float) * _nTF1Coeff_ * n_tf1) / 1.0e6);
 
   //KS: Ask CUDA about memory usage
   checkGpuMem();
@@ -182,7 +186,6 @@ __host__ void SMonolithGPU::InitGPU_Segments(short int **segment) {
 // Allocate memory for spline segments
 __host__ void SMonolithGPU::InitGPU_Vals(float **vals) {
 // *******************************************
-
   //KS: Rather than allocate memory in standard way this fancy cuda tool allows to pin host memory which make memory transfer faster
   cudaMallocHost((void **) vals, _N_SPLINES_*sizeof(float));
   CudaCheckError();
@@ -217,7 +220,7 @@ __host__ void SMonolithGPU::CopyToGPU_SplineMonolith(
     printf("Number of splines not equal to %i, GPU code for event-by-event splines will fail\n", _N_SPLINES_);
     printf("n_params = %i\n", n_params);
     printf("%s : %i\n", __FILE__, __LINE__);
-    exit(-1);
+    throw;
   }
 
   // Write to the global statics (h_* denotes host stored variable)
@@ -264,7 +267,7 @@ __host__ void SMonolithGPU::CopyToGPU_SplineMonolith(
   texDesc_coeff_x.readMode = cudaReadModeElementType;
 
   // Create texture object
-  cudaCreateTextureObject(&text_coeff_x, &resDesc_coeff_x, &texDesc_coeff_x, NULL);
+  cudaCreateTextureObject(&text_coeff_x, &resDesc_coeff_x, &texDesc_coeff_x, nullptr);
   CudaCheckError();
 
   // Also copy the parameter number for each spline onto the GPU; i.e. what spline parameter are we calculating right now
@@ -304,7 +307,7 @@ __host__ void SMonolithGPU::CopyToGPU_SplineMonolith(
   texDesc_nParamPerEvent.readMode = cudaReadModeElementType;
 
   //Finally create texture object
-  cudaCreateTextureObject(&text_nParamPerEvent, &resDesc_nParamPerEvent, &texDesc_nParamPerEvent, NULL);
+  cudaCreateTextureObject(&text_nParamPerEvent, &resDesc_nParamPerEvent, &texDesc_nParamPerEvent, nullptr);
   CudaCheckError();
 
   // Now TF1
@@ -326,9 +329,8 @@ __host__ void SMonolithGPU::CopyToGPU_SplineMonolith(
   texDesc_nParamPerEvent_tf1.readMode = cudaReadModeElementType;
 
   //Finally create texture object
-  cudaCreateTextureObject(&text_nParamPerEvent_TF1, &resDesc_nParamPerEvent_tf1, &texDesc_nParamPerEvent_tf1, NULL);
+  cudaCreateTextureObject(&text_nParamPerEvent_TF1, &resDesc_nParamPerEvent_tf1, &texDesc_nParamPerEvent_tf1, nullptr);
   CudaCheckError();
-
   #endif
 }
 
@@ -468,7 +470,6 @@ __host__ void SMonolithGPU::RunGPU_SplineMonolith(
     const unsigned int h_n_splines,
     const unsigned int h_n_tf1) {
 // *****************************************
-
   dim3 block_size;
   dim3 grid_size;
 
@@ -579,7 +580,6 @@ __host__ void SMonolithGPU::CleanupGPU_SplineMonolith(
   cudaFreeHost(cpu_total_weights);
   cpu_total_weights = nullptr;
 #endif
-  return;
 }
 
 // *******************************************
@@ -591,6 +591,4 @@ __host__ void SMonolithGPU::CleanupGPU_Segments(short int *segment, float *vals)
 
   segment = nullptr;
   vals = nullptr;
-
-  return;
 }


### PR DESCRIPTION
# Pull request description
Most changes are use of static cast or removal of not needed return.

Main feature is expansion of printing GPU info so we can get info about texture memory L2 cache etc

## Changes or fixes


## Examples
<img width="419" alt="example" src="https://github.com/user-attachments/assets/8d1ad26f-e891-4f98-b43f-926a82953c72" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
