### PR TITLE
feat: Wrapper around Open to safegarud from missconfigured paths

### DIFF
--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -43,7 +43,7 @@ FitterBase::FitterBase(manager * const man) : fitMan(man) {
   //ROOT::EnableImplicitMT();
   #endif
   // Set the output file
-  outputFile = M3::Open(outfile, "RECREATE");
+  outputFile = M3::Open(outfile, "RECREATE", __FILE__, __LINE__);
   outputFile->cd();
   // Set output tree
   outTree = new TTree("posteriors", "Posterior_Distributions");

--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -43,7 +43,7 @@ FitterBase::FitterBase(manager * const man) : fitMan(man) {
   //ROOT::EnableImplicitMT();
   #endif
   // Set the output file
-  outputFile = new TFile(outfile.c_str(), "RECREATE");
+  outputFile = M3::Open(outfile, "RECREATE");
   outputFile->cd();
   // Set output tree
   outTree = new TTree("posteriors", "Posterior_Distributions");

--- a/Fitters/StatisticalUtils.cpp
+++ b/Fitters/StatisticalUtils.cpp
@@ -493,12 +493,7 @@ void ThinningMCMC(const std::string& FilePath, const int ThinningCut) {
     MACH3LOG_WARN("Error: system call to copy file failed with code {}", ret);
   }
 
-  TFile *inFile = TFile::Open(TempFilePath.c_str(), "UPDATE");
-  if (!inFile || inFile->IsZombie()) {
-    MACH3LOG_ERROR("Error opening file: {}", TempFilePath);
-    throw MaCh3Exception(__FILE__, __LINE__);
-  }
-
+  TFile *inFile = M3::Open(TempFilePath, "RECREATE", __FILE__, __LINE__);
   TTree *inTree = inFile->Get<TTree>("posteriors");
   if (!inTree) {
     MACH3LOG_ERROR("Error: TTree 'posteriors' not found in file.");

--- a/Samples/HistogramUtils.cpp
+++ b/Samples/HistogramUtils.cpp
@@ -603,3 +603,24 @@ double CalculateEnu(double PLep, double costh, double Eb, bool neutrino){
 
   return Enu;
 }
+
+
+namespace M3 {
+// **************************************************************************
+TFile* Open(const std::string& Name, const std::string& Type) {
+// **************************************************************************
+  TFile* OutFile = new TFile(Name.c_str(), Type.c_str());
+
+  // Check if the file is successfully opened and usable
+  if (OutFile->IsZombie()) {
+    MACH3LOG_ERROR("Failed to open file: {}", Name);
+    if (Type == "RECREATE") {
+      MACH3LOG_ERROR("Check if directory exist");
+    }
+    delete OutFile;
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+  return OutFile;
+}
+
+} //end M3

--- a/Samples/HistogramUtils.cpp
+++ b/Samples/HistogramUtils.cpp
@@ -607,7 +607,7 @@ double CalculateEnu(double PLep, double costh, double Eb, bool neutrino){
 
 namespace M3 {
 // **************************************************************************
-TFile* Open(const std::string& Name, const std::string& Type) {
+TFile* Open(const std::string& Name, const std::string& Type, const std::string& File, const int Line) {
 // **************************************************************************
   TFile* OutFile = new TFile(Name.c_str(), Type.c_str());
 
@@ -618,7 +618,7 @@ TFile* Open(const std::string& Name, const std::string& Type) {
       MACH3LOG_ERROR("Check if directory exist");
     }
     delete OutFile;
-    throw MaCh3Exception(__FILE__, __LINE__);
+    throw MaCh3Exception(File, Line);
   }
   return OutFile;
 }

--- a/Samples/HistogramUtils.h
+++ b/Samples/HistogramUtils.h
@@ -144,4 +144,16 @@ std::unique_ptr<ObjectType> Clone(const ObjectType* obj, const std::string& name
 
   return Hist;
 }
-}
+
+
+/// @brief Opens a ROOT file with the given name and mode.
+///
+/// This function wraps ROOT’s `TFile` constructor and checks whether the file was opened
+/// successfully and give some useful debugging information
+///
+/// @param Name The name or path of the file to open.
+/// @param Type The file open mode (e.g., "READ", "RECREATE", "UPDATE").
+/// @return Pointer to the opened ROOT file.
+TFile* Open(const std::string& Name, const std::string& Type);
+
+} //end M3

--- a/Samples/HistogramUtils.h
+++ b/Samples/HistogramUtils.h
@@ -154,6 +154,6 @@ std::unique_ptr<ObjectType> Clone(const ObjectType* obj, const std::string& name
 /// @param Name The name or path of the file to open.
 /// @param Type The file open mode (e.g., "READ", "RECREATE", "UPDATE").
 /// @return Pointer to the opened ROOT file.
-TFile* Open(const std::string& Name, const std::string& Type);
+TFile* Open(const std::string& Name, const std::string& Type, const std::string& File, const int Line);
 
 } //end M3


### PR DESCRIPTION
# Pull request description
Dan suggested that if one puts wrong file name for example foldr which do not exist MaCh3 will not stop and run whole chain. Which will leave user wondering where chain is...

This wrapper is mean to fix this. I will udpate other parts of the code to use this wrapper in future.

## Changes or fixes


## Examples
<img width="482" alt="error" src="https://github.com/user-attachments/assets/4d8cce83-81d3-47cf-9faa-d5c68bb2da79" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
