### PR TITLE
tidy: Tweak how we change whether fixed param

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -602,7 +602,7 @@ void ParameterHandlerBase::Randomize() _noexcept_ {
     #endif
     for (int i = 0; i < _fNumPar; ++i) {
       // If parameter isn't fixed
-      if (_fError[i] > 0.0) {
+      if (!IsParameterFixed(i) > 0.0) {
         randParams[i] = random_number[M3::GetThreadIndex()]->Gaus(0, 1);
         // If parameter IS fixed
       } else {
@@ -640,7 +640,7 @@ void ParameterHandlerBase::CorrelateSteps() _noexcept_ {
     #pragma omp parallel for
     #endif
     for (int i = 0; i < _fNumPar; ++i) {
-      if (_fError[i] > 0.) {
+      if (!IsParameterFixed(i) > 0.) {
         _fPropVal[i] = _fCurrVal[i] + corr_throw[i]*_fGlobalStepScale*_fIndivStepScale[i];
       }
     }
@@ -696,7 +696,7 @@ void ParameterHandlerBase::ThrowParProp(const double mag) {
     M3::MatrixVectorMulti(corr_throw, throwMatrixCholDecomp, randParams, _fNumPar);
     // Number of sigmas we throw
     for (int i = 0; i < _fNumPar; i++) {
-      if (_fError[i] > 0.)
+      if (!IsParameterFixed(i) > 0.)
         _fPropVal[i] = _fCurrVal[i] + corr_throw[i]*mag;
     }
   } else {
@@ -715,7 +715,7 @@ void ParameterHandlerBase::ThrowParCurr(const double mag) {
     // The number of sigmas to throw
     // Should probably have this as a default parameter input to the function instead
     for (int i = 0; i < _fNumPar; i++) {
-      if (_fError[i] > 0.){
+      if (!IsParameterFixed(i) > 0.){
         _fCurrVal[i] = corr_throw[i]*mag;
       }
     }

--- a/Samples/OscillationHandler.cpp
+++ b/Samples/OscillationHandler.cpp
@@ -59,7 +59,7 @@ void OscillationHandler::Evaluate() {
   for (size_t iPar = 0; iPar < OscParams.size(); ++iPar) {
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wuseless-cast"
-    OscVec[iPar] = M3::float_t(*OscParams[iPar]);
+    OscVec[iPar] = static_cast<M3::float_t>(*OscParams[iPar]);
     #pragma GCC diagnostic pop
   }
 

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -309,15 +309,15 @@ void SampleHandlerFD::SetupSampleBinning(){
   MACH3LOG_INFO("Setting up Sample Binning");
   TString histname1d = (XVarStr).c_str();
   TString histname2d = (XVarStr+"_"+YVarStr).c_str();
-  TString histtitle = "";
+  TString histtitle = GetTitle();
 
   //The binning here is arbitrary, now we get info from cfg so the
   //set1DBinning and set2Dbinning calls below will make the binning
   //to be what we actually want
-  _hPDF1D   = new TH1D("h"+histname1d+SampleTitle,histtitle, 1, 0, 1);
-  dathist   = new TH1D("d"+histname1d+SampleTitle,histtitle, 1, 0, 1);
-  _hPDF2D   = new TH2D("h"+histname2d+SampleTitle,histtitle, 1, 0, 1, 1, 0, 1);
-  dathist2d = new TH2D("d"+histname2d+SampleTitle,histtitle, 1, 0, 1, 1, 0, 1);
+  _hPDF1D   = new TH1D("h" + histname1d + GetTitle(),histtitle, 1, 0, 1);
+  dathist   = new TH1D("d" + histname1d + GetTitle(),histtitle, 1, 0, 1);
+  _hPDF2D   = new TH2D("h" + histname2d + GetTitle(),histtitle, 1, 0, 1, 1, 0, 1);
+  dathist2d = new TH2D("d" + histname2d + GetTitle(),histtitle, 1, 0, 1, 1, 0, 1);
 
   _hPDF1D->GetXaxis()->SetTitle(XVarStr.c_str());
   dathist->GetXaxis()->SetTitle(XVarStr.c_str());
@@ -715,7 +715,12 @@ void SampleHandlerFD::ApplyShifts(int iEvent) {
   // Given a sample and event, apply the shifts to the event based on the vector of functional parameter enums
   // First reset shifted array back to nominal values
   resetShifts(iEvent);
-  for (int fpEnum : funcParsGrid[iEvent]) {
+
+  const std::vector<int>& fpEnums = funcParsGrid[iEvent];
+  const std::size_t nShifts = fpEnums.size();
+
+  for (std::size_t i = 0; i < nShifts; ++i) {
+    const int fpEnum = fpEnums[i];
     FunctionalParameter *fp = funcParsMap[static_cast<std::size_t>(fpEnum)];
     // if (fp->funcPtr) {
     //   (*fp->funcPtr)(fp->valuePtr, iEvent);


### PR DESCRIPTION
# Pull request description


## Changes or fixes
- if (_fError[i] > 0.) { -> if (!IsParameterFixed(i)) {
- In apply shifts use old school loop as on average compiler can better optimise them [In test noticed minor imrpovment]

## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
