### PR TITLE
tidy: Stop Saving Adatpive So often

### DIFF
--- a/.github/workflows/CIValidations.yml
+++ b/.github/workflows/CIValidations.yml
@@ -22,49 +22,32 @@ jobs:
       matrix:
         include:
           - name: Reweight Validations
-            test_1: ./CIValidations/SplineValidations
-            test_2: ./CIValidations/SamplePDFValidations
-            test_3: ./CIValidations/NuOscillatorInterfaceValidations
-            test_4: ./CIValidations/LLHValidation
-            test_5: ./bin/KinemDistributionTutorial TutorialConfigs/FitterConfig.yaml
-            test_6: ./CIValidations/PredictiveValidations
-            test_7: empty
-            test_8: empty
-            test_9: empty
-
-          - name: Covariance Validations
-            test_1: ./CIValidations/CovarianceValidations
-            test_2: ./CIValidations/MaCh3ModeValidations
-            test_3: ./CIValidations/pValueValidations 
-            test_4: ./CIValidations/SigmaVarValidations
-            test_5: ./CIValidations/UnitTests/manager_tests
-            test_6: ./CIValidations/UnitTests/histogram_tests
-            test_7: ./CIValidations/UnitTests/statistical_tests
-            test_8: empty
-            test_9: empty
-
-          - name: Fitter Validations
-            test_1: ./CIValidations/FitterValidations
-            test_2: ./bin/ProcessMCMC bin/TutorialDiagConfig.yaml MCMC_Test.root
-            test_3: ./bin/DiagMCMC MCMC_Test.root bin/TutorialDiagConfig.yaml
-            test_4: ./bin/RHat 10 MCMC_Test.root MCMC_Test.root MCMC_Test.root MCMC_Test.root
-            test_5: ./bin/CombineMaCh3Chains -o MergedChain.root MCMC_Test.root MCMC_Test.root MCMC_Test.root MCMC_Test.root
-            test_6: ./bin/GetPenaltyTerm MCMC_Test.root bin/TutorialDiagConfig.yaml
-            test_7: ./bin/MatrixPlotter bin/TutorialDiagConfig.yaml MCMC_Test_drawCorr.root
-            test_8: bin/GetPostfitParamPlots MCMC_Test_drawCorr.root
-            test_9: bin/PlotLLH MCMC_Test.root
-            test_10: bin/PlotMCMCDiag MCMC_Test_MCMC_Diag.root "test_plot_1" MCMC_Test_MCMC_Diag.root "test_plot_2"
-
-          - name: NuMCMC Tools Validations
-            test_1: ./CIValidations/NuMCMCvalidations.sh
+            test_1: MaCh3CLI --ReweightValidations
             test_2: empty
             test_3: empty
             test_4: empty
             test_5: empty
-            test_6: empty
-            test_7: empty
-            test_8: empty
-            test_9: empty
+
+          - name: Covariance Validations
+            test_1: MaCh3CLI --CovarianceValidations
+            test_2: empty
+            test_3: empty
+            test_4: empty
+            test_5: empty
+
+          - name: Fitter Validations
+            test_1: MaCh3CLI --FitterValidations
+            test_2: empty
+            test_3: empty
+            test_4: empty
+            test_5: empty
+
+          - name: NuMCMC Tools Validations
+            test_1: MaCh3CLI --NuMCMCToolsValidations
+            test_2: empty
+            test_3: empty
+            test_4: empty
+            test_5: empty
 
     container:
       image: ghcr.io/mach3-software/mach3:alma9latest
@@ -124,34 +107,4 @@ jobs:
             echo " "
             echo "Performing test 5"
             ${{ matrix.test_5 }}
-        fi
-
-        if [[ "${{ matrix.test_6 }}" != "empty" ]]; then
-            echo " "
-            echo "Performing  test 6"
-            ${{ matrix.test_6 }}
-        fi
-
-        if [[ "${{ matrix.test_7 }}" != "empty" ]]; then
-            echo " "
-            echo "Performing  test 7"
-            ${{ matrix.test_7 }}
-        fi
-
-        if [[ "${{ matrix.test_8 }}" != "empty" ]]; then
-            echo " "
-            echo "Performing  test 8"
-            ${{ matrix.test_8 }}
-        fi
-
-        if [[ "${{ matrix.test_9 }}" != "empty" ]]; then
-            echo " "
-            echo "Performing  test 9"
-            ${{ matrix.test_9 }}
-        fi
-
-        if [[ "${{ matrix.test_10 }}" != "empty" ]]; then
-            echo " "
-            echo "Performing  test 10"
-            ${{ matrix.test_10 }}
         fi

--- a/Parameters/AdaptiveMCMCHandler.cpp
+++ b/Parameters/AdaptiveMCMCHandler.cpp
@@ -69,7 +69,7 @@ bool AdaptiveMCMCHandler::InitFromConfig(const YAML::Node& adapt_manager, const 
   start_adaptive_update = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["StartUpdate"], 0);
   end_adaptive_update   = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["EndUpdate"], 10000);
   adaptive_update_step  = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["UpdateStep"], 100);
-  adaptive_save_n_iterations  = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["SaveNIterations"], 1);
+  adaptive_save_n_iterations  = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["SaveNIterations"], 1.0e+20);
   output_file_name = GetFromManager<std::string>(adapt_manager["AdaptionOptions"]["Settings"]["OutputFileName"], "");
 
   // We also want to check for "blocks" by default all parameters "know" about each other

--- a/Parameters/AdaptiveMCMCHandler.cpp
+++ b/Parameters/AdaptiveMCMCHandler.cpp
@@ -141,8 +141,12 @@ void AdaptiveMCMCHandler::SetAdaptiveBlocks(const std::vector<std::vector<int>>&
 void AdaptiveMCMCHandler::SaveAdaptiveToFile(const std::string &outFileName,
                                              const std::string &systematicName, bool is_final) {
 // ********************************************
-  if(adaptive_save_n_iterations < 0) return;
-  if (((total_steps - start_adaptive_throw) / adaptive_update_step) % adaptive_save_n_iterations == 0 || is_final) {
+  // Skip saving if adaptive_save_n_iterations is negative,
+  // unless this is the final iteration (is_final overrides the condition)
+  if (adaptive_save_n_iterations < 0 && !is_final) return;
+  if (is_final ||
+    (adaptive_save_n_iterations > 0 &&
+    ((total_steps - start_adaptive_throw) / adaptive_update_step) % adaptive_save_n_iterations == 0)) {
 
     TFile *outFile = new TFile(outFileName.c_str(), "UPDATE");
     if (outFile->IsZombie()) {

--- a/Parameters/AdaptiveMCMCHandler.cpp
+++ b/Parameters/AdaptiveMCMCHandler.cpp
@@ -69,7 +69,7 @@ bool AdaptiveMCMCHandler::InitFromConfig(const YAML::Node& adapt_manager, const 
   start_adaptive_update = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["StartUpdate"], 0);
   end_adaptive_update   = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["EndUpdate"], 10000);
   adaptive_update_step  = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["UpdateStep"], 100);
-  adaptive_save_n_iterations  = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["SaveNIterations"], 1.0e+20);
+  adaptive_save_n_iterations  = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["SaveNIterations"], -1);
   output_file_name = GetFromManager<std::string>(adapt_manager["AdaptionOptions"]["Settings"]["OutputFileName"], "");
 
   // We also want to check for "blocks" by default all parameters "know" about each other
@@ -141,6 +141,7 @@ void AdaptiveMCMCHandler::SetAdaptiveBlocks(const std::vector<std::vector<int>>&
 void AdaptiveMCMCHandler::SaveAdaptiveToFile(const std::string &outFileName,
                                              const std::string &systematicName, bool is_final) {
 // ********************************************
+  if(adaptive_save_n_iterations < 0) return;
   if (((total_steps - start_adaptive_throw) / adaptive_update_step) % adaptive_save_n_iterations == 0 || is_final) {
 
     TFile *outFile = new TFile(outFileName.c_str(), "UPDATE");

--- a/Parameters/AdaptiveMCMCHandler.h
+++ b/Parameters/AdaptiveMCMCHandler.h
@@ -73,6 +73,7 @@ class AdaptiveMCMCHandler{
   }
 
   /// @brief Get the current values of the parameters
+  /// @ingroup ParameterHandlerGetters
   int GetNumParams() const {
     return static_cast<int>(_fCurrVal->size());
   }
@@ -89,6 +90,7 @@ class AdaptiveMCMCHandler{
   double CurrVal(const int par_index);
 
   /// @brief Get Total Number of Steps
+  /// @ingroup ParameterHandlerGetters
   int GetTotalSteps() const {
     return total_steps;
   }
@@ -104,6 +106,7 @@ class AdaptiveMCMCHandler{
   }
 
   /// @brief Increase by one number of total steps
+  /// @ingroup ParameterHandlerGetters
   TMatrixDSym* GetAdaptiveCovariance() const {
     return adaptive_covariance;
   }


### PR DESCRIPTION
# Pull request description
Becasue `adaptive_save_n_iterations  `by deafult was 1 it was saving adaptive matrix every time udpate adaptive was called.

In addition use MaCh3CLI for bots

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
