### PR TITLE
tidy: Unify default values in MCMC Processor

### DIFF
--- a/Diagnostics/ProcessMCMC.cpp
+++ b/Diagnostics/ProcessMCMC.cpp
@@ -155,8 +155,8 @@ void ProcessMCMC(const std::string& inputFile)
                                      GetFromManager<std::vector<short int>>(Settings["CredibleRegionStyle"], {2, 1, 3}),
                                      GetFromManager<std::vector<short int>>(Settings["CredibleRegionColor"], {413, 406, 416}),
                                      GetFromManager<bool>(Settings["CredibleInSigmas"], false), 
-				     GetFromManager<bool>(Settings["Draw2DPosterior"], true),
-				     GetFromManager<bool>(Settings["DrawBestFit"], true));
+                                     GetFromManager<bool>(Settings["Draw2DPosterior"], true),
+                                     GetFromManager<bool>(Settings["DrawBestFit"], true));
     }
     if(GetFromManager<bool>(Settings["GetTrianglePlot"], true)) GetTrianglePlot(Processor.get());
 
@@ -255,7 +255,7 @@ void MultipleProcessMCMC()
     {
       // KS: If somehow this chain doesn't given params we skip it
       const int Index = Processor[ik]->GetParamIndexFromName(hpost[0]->GetTitle());
-      if(Index == _UNDEF_)
+      if(Index == M3::_BAD_INT_)
       {
         Skip = true;
         break;
@@ -347,7 +347,7 @@ void MultipleProcessMCMC()
   Posterior->Print(canvasname);
 }
 
-// KS: Calculate Bayes factor for a given hypothesis, most informative are those related to osc params. However, it make relative easy interpretation for switch dials
+/// @brief KS: Calculate Bayes factor for a given hypothesis, most informative are those related to osc params. However, it make relative easy interpretation for switch dials
 void CalcBayesFactor(MCMCProcessor* Processor)
 {
   YAML::Node card_yaml = M3OpenConfig(config.c_str());
@@ -520,13 +520,13 @@ void DiagnoseCovarianceMatrix(MCMCProcessor* Processor, const std::string& input
       {
         if( std::fabs (CovarianceDiff->GetBinContent(j, i)) < 1.e-5 && std::fabs (CovariancePreviousHist->GetBinContent(j, i)) < 1.e-5)
         {
-          CovarianceDiff->SetBinContent(j, i, _UNDEF_);
-          CovariancePreviousHist->SetBinContent(j, i, _UNDEF_);
+          CovarianceDiff->SetBinContent(j, i, M3::_BAD_DOUBLE_);
+          CovariancePreviousHist->SetBinContent(j, i, M3::_BAD_DOUBLE_);
         }
         if( std::fabs (CorrelationDiff->GetBinContent(j, i)) < 1.e-5 && std::fabs (CorrelationPreviousHist->GetBinContent(j, i)) < 1.e-5)
         {
-          CorrelationDiff->SetBinContent(j, i, _UNDEF_);
-          CorrelationPreviousHist->SetBinContent(j, i, _UNDEF_);
+          CorrelationDiff->SetBinContent(j, i, M3::_BAD_DOUBLE_);
+          CorrelationPreviousHist->SetBinContent(j, i, M3::_BAD_DOUBLE_);
         }
       }
     }
@@ -637,7 +637,7 @@ TH2D* TMatrixIntoTH2D(TMatrixDSym* Matrix, const std::string& title)
   return hMatrix;
 }
 
-//KS: Perform KS test to check if two posteriors for the same parameter came from the same distribution
+// KS: Perform KS test to check if two posteriors for the same parameter came from the same distribution
 void KolmogorovSmirnovTest(const std::vector<std::unique_ptr<MCMCProcessor>>& Processor,
                            const std::unique_ptr<TCanvas>& Posterior,
                            const TString& canvasname)
@@ -665,7 +665,7 @@ void KolmogorovSmirnovTest(const std::vector<std::unique_ptr<MCMCProcessor>>& Pr
       {
         // KS: If somehow this chain doesn't given params we skip it
         Index = Processor[ik]->GetParamIndexFromName(hpost[0]->GetTitle());
-        if(Index == _UNDEF_)
+        if(Index == M3::_BAD_INT_)
         {
           Skip = true;
           break;

--- a/Fitters/MCMCProcessor.cpp
+++ b/Fitters/MCMCProcessor.cpp
@@ -60,7 +60,7 @@ MCMCProcessor::MCMCProcessor(const std::string &InputFile) :
 
   nDraw = 0;
   nEntries = 0;
-  UpperCut = _UNDEF_;
+  UpperCut = M3::_BAD_INT_;
   nSteps = 0;
   nBatches = 0;
   AutoCorrLag = 0;
@@ -931,7 +931,7 @@ void MCMCProcessor::MakeCovariance() {
   // Check that the diagonal entries have been filled
   // i.e. MakePostfit() has been called
   for (int i = 0; i < nDraw; ++i) {
-    if ((*Covariance)(i,i) == _UNDEF_) {
+    if ((*Covariance)(i,i) == M3::_BAD_DOUBLE_) {
       HaveMadeDiagonal = false;
       MACH3LOG_INFO("Have not run diagonal elements in covariance, will do so now by calling MakePostfit()");
       break;
@@ -1148,7 +1148,7 @@ void MCMCProcessor::MakeCovariance_MP(bool Mute) {
   // Check that the diagonal entries have been filled
   // i.e. MakePostfit() has been called
   for (int i = 0; i < nDraw; ++i) {
-    if ((*Covariance)(i,i) == _UNDEF_) {
+    if ((*Covariance)(i,i) == M3::_BAD_DOUBLE_) {
       HaveMadeDiagonal = false;
       MACH3LOG_WARN("Have not run diagonal elements in covariance, will do so now by calling MakePostfit()");
       break;
@@ -1678,7 +1678,7 @@ void MCMCProcessor::MakeTrianglePlot(const std::vector<std::string>& ParNames,
   for(int j = 0; j < nParamPlot; ++j)
   {
     int ParamNo = GetParamIndexFromName(ParNames[j]);
-    if(ParamNo == _UNDEF_)
+    if(ParamNo == M3::_BAD_INT_)
     {
       MACH3LOG_WARN("Couldn't find param {}. Will not plot Triangle plot", ParNames[j]);
       return;
@@ -2060,18 +2060,18 @@ void MCMCProcessor::SetupOutput() {
   #endif
   for (int i = 0; i < nDraw; ++i)
   {
-    (*Central_Value)(i) = _UNDEF_;
-    (*Means)(i) = _UNDEF_;
-    (*Errors)(i) = _UNDEF_;
-    (*Means_Gauss)(i) = _UNDEF_;
-    (*Errors_Gauss)(i) = _UNDEF_;
-    (*Means_HPD)(i) = _UNDEF_;
-    (*Errors_HPD)(i) = _UNDEF_;
-    (*Errors_HPD_Positive)(i) = _UNDEF_;
-    (*Errors_HPD_Negative)(i) = _UNDEF_;
+    (*Central_Value)(i) = M3::_BAD_DOUBLE_;
+    (*Means)(i) = M3::_BAD_DOUBLE_;
+    (*Errors)(i) = M3::_BAD_DOUBLE_;
+    (*Means_Gauss)(i) = M3::_BAD_DOUBLE_;
+    (*Errors_Gauss)(i) = M3::_BAD_DOUBLE_;
+    (*Means_HPD)(i) = M3::_BAD_DOUBLE_;
+    (*Errors_HPD)(i) = M3::_BAD_DOUBLE_;
+    (*Errors_HPD_Positive)(i) = M3::_BAD_DOUBLE_;
+    (*Errors_HPD_Negative)(i) = M3::_BAD_DOUBLE_;
     for (int j = 0; j < nDraw; ++j) {
-      (*Covariance)(i, j) = _UNDEF_;
-      (*Correlation)(i, j) = _UNDEF_;
+      (*Covariance)(i, j) = M3::_BAD_DOUBLE_;
+      (*Correlation)(i, j) = M3::_BAD_DOUBLE_;
     }
   }
   hpost.resize(nDraw);
@@ -2425,7 +2425,7 @@ void MCMCProcessor::SetStepCut(const int Cuts) {
 void MCMCProcessor::GetNthParameter(const int param, double &Prior, double &PriorError, TString &Title) const {
 // **************************
   ParameterEnum ParType = ParamType[param];
-  int ParamNo = _UNDEF_;
+  int ParamNo = M3::_BAD_INT_;
   ParamNo = param - ParamTypeStartPos[ParType];
 
   Prior = ParamCentral[ParType][ParamNo];
@@ -2437,7 +2437,7 @@ void MCMCProcessor::GetNthParameter(const int param, double &Prior, double &Prio
 // Find Param Index based on name
 int MCMCProcessor::GetParamIndexFromName(const std::string& Name){
 // **************************
-  int ParamNo = _UNDEF_;
+  int ParamNo = M3::_BAD_INT_;
   for (int i = 0; i < nDraw; ++i)
   {
     TString Title = "";
@@ -2493,7 +2493,7 @@ void MCMCProcessor::GetPolarPlot(const std::vector<std::string>& ParNames){
   {
     //KS: First we need to find parameter number based on name
     int ParamNo = GetParamIndexFromName(ParNames[k]);
-    if(ParamNo == _UNDEF_)
+    if(ParamNo == M3::_BAD_INT_)
     {
       MACH3LOG_WARN("Couldn't find param {}. Will not calculate Polar Plot", ParNames[k]);
       continue;
@@ -2559,7 +2559,7 @@ void MCMCProcessor::GetBayesFactor(const std::vector<std::string>& ParNames,
   {
     //KS: First we need to find parameter number based on name
     int ParamNo = GetParamIndexFromName(ParNames[k]);
-    if(ParamNo == _UNDEF_)
+    if(ParamNo == M3::_BAD_INT_)
     {
       MACH3LOG_WARN("Couldn't find param {}. Will not calculate Bayes Factor", ParNames[k]);
       continue;
@@ -2619,7 +2619,7 @@ void MCMCProcessor::GetSavageDickey(const std::vector<std::string>& ParNames,
   {
     //KS: First we need to find parameter number based on name
     int ParamNo = GetParamIndexFromName(ParNames[k]);
-    if(ParamNo == _UNDEF_)
+    if(ParamNo == M3::_BAD_INT_)
     {
       MACH3LOG_WARN("Couldn't find param {}. Will not calculate SavageDickey", ParNames[k]);
       continue;
@@ -2755,7 +2755,7 @@ void MCMCProcessor::ReweightPrior(const std::vector<std::string>& Names,
   {
     //KS: First we need to find parameter number based on name
     int ParamNo = GetParamIndexFromName(Names[k]);
-    if(ParamNo == _UNDEF_)
+    if(ParamNo == M3::_BAD_INT_)
     {
       MACH3LOG_WARN("Couldn't find param {}. Can't reweight Prior", Names[k]);
       return;
@@ -2855,7 +2855,7 @@ void MCMCProcessor::ParameterEvolution(const std::vector<std::string>& Names,
   {
     //KS: First we need to find parameter number based on name
     int ParamNo = GetParamIndexFromName(Names[k]);
-    if(ParamNo == _UNDEF_)
+    if(ParamNo == M3::_BAD_INT_)
     {
       MACH3LOG_WARN("Couldn't find param {}. Can't reweight Prior", Names[k]);
       continue;
@@ -3556,8 +3556,8 @@ void MCMCProcessor::CalculateESS(const int nLags, const std::vector<std::vector<
   //KS: Calculate ESS and MCMC efficiency for each parameter
   for (int j = 0; j < nDraw; ++j)
   {
-    (*EffectiveSampleSize)(j) = _UNDEF_;
-    (*SamplingEfficiency)(j) = _UNDEF_;
+    (*EffectiveSampleSize)(j) = M3::_BAD_DOUBLE_;
+    (*SamplingEfficiency)(j) = M3::_BAD_DOUBLE_;
     TempDenominator[j] = 0.;
     //KS: Firs sum over all Calculated autocorrelations
     for (int k = 0; k < nLags; ++k)

--- a/Fitters/MCMCProcessor.h
+++ b/Fitters/MCMCProcessor.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#ifndef _UNDEF_
-#define _UNDEF_ 1234567890
-#endif
-
 // C++ includes
 #include <complex>
 #include <cstdio>
@@ -112,8 +108,8 @@ class MCMCProcessor {
                              const std::vector<Style_t>& CredibleRegionStyle = {kDashed, kSolid, kDotted},
                              const std::vector<Color_t>& CredibleRegionColor = {kGreen-3, kGreen-10, kGreen},
                              const bool CredibleInSigmas = false,
-			     const bool Draw2DPosterior = true,
-			     const bool DrawBestFit = true
+                             const bool Draw2DPosterior = true,
+                             const bool DrawBestFit = true
                              );
     /// @brief Make fancy triangle plot for selected parameters
     /// @param CredibleIntervals Vector with values of credible intervals, must be in descending order

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -1146,6 +1146,11 @@ TH1* SampleHandlerFD::GetDataHist(const int Dimension) {
 }
 
 void SampleHandlerFD::AddData(std::vector<double> &data) {
+  if (dathist == nullptr) {
+    MACH3LOG_ERROR("Data hist hasn't been initialised yet");
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+
   dathist2d = nullptr;
   dathist->Reset();
 
@@ -1171,6 +1176,11 @@ void SampleHandlerFD::AddData(std::vector<double> &data) {
 }
 
 void SampleHandlerFD::AddData(std::vector< std::vector <double> > &data) {
+  if (dathist2d == nullptr) {
+    MACH3LOG_ERROR("Data hist hasn't been initialised yet");
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+
   dathist = nullptr;
   dathist2d->Reset();
 
@@ -1202,6 +1212,9 @@ void SampleHandlerFD::AddData(std::vector< std::vector <double> > &data) {
 
 void SampleHandlerFD::AddData(TH1D* Data) {
   MACH3LOG_INFO("Adding 1D data histogram: {} with {:.2f} events", Data->GetTitle(), Data->Integral());
+  if (dathist != nullptr) {
+    delete dathist;
+  }
   dathist2d = nullptr;
   dathist = static_cast<TH1D*>(Data->Clone());
 
@@ -1226,6 +1239,9 @@ void SampleHandlerFD::AddData(TH1D* Data) {
 
 void SampleHandlerFD::AddData(TH2D* Data) {
   MACH3LOG_INFO("Adding 2D data histogram: {} with {:.2f} events", Data->GetTitle(), Data->Integral());
+  if (dathist2d != nullptr) {
+    delete dathist2d;
+  }
   dathist2d = static_cast<TH2D*>(Data->Clone());
   dathist = nullptr;
 


### PR DESCRIPTION
# Pull request description
MCMC Processor was using _undef_ while rest of MaCh3 is using bad double/int.
This PR attempts to unify how we set default values

## Changes or fixes
- Remove potentail memroy leak if add data would be called twice

## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
