### PR TITLE
bugfix: Correctly set coefficents when making TSpline3 out of TSpline3_ref

### DIFF
--- a/Splines/SplineStructs.h
+++ b/Splines/SplineStructs.h
@@ -671,6 +671,10 @@ public:
     #else
     TSpline3 *spline = new TSpline3("Spline", XPos, YResp, nPoints);
     #endif
+    for (Int_t i = 0; i < nPoints; ++i) {
+      spline->SetPointCoeff(i, Par[i][0], Par[i][1], Par[i][2]);
+    }
+
     return spline;
   }
 


### PR DESCRIPTION
# Pull request description
ConstructTSpline3 was missinge setting of coefficents

You can see that it actually works here: https://github.com/mach3-software/MaCh3Tutorial/pull/152
## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
