### PR TITLE
tidy: Set minimal allowed standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,9 @@ find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++ PATHS ENV PATH NO_DEFAULT_PA
 include(MaCh3Dependencies)
 
 ############################  C++ Compiler  ####################################
+set(CXX_MINIMAL_STANDARD 14)
 if (NOT DEFINED CMAKE_CXX_STANDARD OR "${CMAKE_CXX_STANDARD} " STREQUAL " ")
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD ${CXX_MINIMAL_STANDARD})
   cmessage(STATUS "Set default CXX standard: \"${CMAKE_CXX_STANDARD}\"")
 endif()
 
@@ -67,6 +68,9 @@ if(DEFINED ROOT_CXX_STANDARD AND NOT ROOT_CXX_STANDARD EQUAL CMAKE_CXX_STANDARD)
   cmessage(STATUS "Set CXX standard due to ROOT: \"${ROOT_CXX_STANDARD}\"")
 endif()
 cmessage(STATUS "CMAKE_CXX_STANDARD: \"${CMAKE_CXX_STANDARD}\"")
+if (CMAKE_CXX_STANDARD LESS CXX_MINIMAL_STANDARD)
+  cmessage(FATAL_ERROR "Set CXX standard is lower than the minimal working standard: ${CXX_MINIMAL_STANDARD}")
+endif()
 set(MACH3_CXX_STANDARD ${CMAKE_CXX_STANDARD})
 set_property(GLOBAL PROPERTY MACH3_CXX_STANDARD "${MACH3_CXX_STANDARD}")
 

--- a/Fitters/StatisticalUtils.cpp
+++ b/Fitters/StatisticalUtils.cpp
@@ -486,17 +486,20 @@ double FisherCombinedPValue(const std::vector<double>& pvalues) {
 // ********************
 void ThinningMCMC(const std::string& FilePath, const int ThinningCut) {
 // ********************
-  // Define the path for the temporary thinned file
-  std::string TempFilePath = "Thinned_" + FilePath;
+  std::string FilePathNowRoot = FilePath;
+  if (FilePath.size() >= 5 && FilePath.substr(FilePath.size() - 5) == ".root") {
+    FilePathNowRoot = FilePath.substr(0, FilePath.size() - 5);
+  }
+  std::string TempFilePath = FilePathNowRoot + "_thinned.root";
   int ret = system(("cp " + FilePath + " " + TempFilePath).c_str());
   if (ret != 0) {
-    MACH3LOG_WARN("Error: system call to copy file failed with code {}", ret);
+    MACH3LOG_WARN("System call to copy file failed with code {}", ret);
   }
 
   TFile *inFile = M3::Open(TempFilePath, "RECREATE", __FILE__, __LINE__);
   TTree *inTree = inFile->Get<TTree>("posteriors");
   if (!inTree) {
-    MACH3LOG_ERROR("Error: TTree 'posteriors' not found in file.");
+    MACH3LOG_ERROR("TTree 'posteriors' not found in file.");
     inFile->ls();
     inFile->Close();
     throw MaCh3Exception(__FILE__, __LINE__);

--- a/Plotting/MatrixPlotter.cpp
+++ b/Plotting/MatrixPlotter.cpp
@@ -8,7 +8,7 @@
 
 TH2D* GetSubMatrix(TH2D *MatrixFull, const std::string& Title, const std::vector<std::string>& Params)
 {
-  std::vector<int> ParamIndex(Params.size(), -999);
+  std::vector<int> ParamIndex(Params.size(), M3::_BAD_INT_);
 
   for(size_t i = 0; i < Params.size(); i++)
   {
@@ -24,11 +24,11 @@ TH2D* GetSubMatrix(TH2D *MatrixFull, const std::string& Title, const std::vector
 
   for(size_t i = 0; i < Params.size(); i++)
   {
-    if(ParamIndex[i] == -999 )
+    if(ParamIndex[i] == M3::_BAD_INT_)
       MACH3LOG_ERROR("Didn't find param {} in matrix within {} sub-block", Params[i], Title);
   }
 
-  auto new_end = std::remove(ParamIndex.begin(), ParamIndex.end(), -999);
+  auto new_end = std::remove(ParamIndex.begin(), ParamIndex.end(), M3::_BAD_INT_);
   ParamIndex.erase(new_end, ParamIndex.end());
 
   TH2D* Hist = new TH2D(Title.c_str(), Title.c_str(), ParamIndex.size(), 0, ParamIndex.size(), ParamIndex.size(), 0, ParamIndex.size());
@@ -81,15 +81,10 @@ void SetupInfo(const std::string& Config, std::vector<std::string>& Title, std::
   }
 }
 
-void PlotMatrix(std::string Config, std::string File)
+void PlotMatrix(const std::string& Config, const std::string& File)
 {
   // Open the ROOT file
-  TFile *file = TFile::Open(File.c_str());
-  if (!file || file->IsZombie()) {
-    MACH3LOG_ERROR("Error opening file");
-    throw MaCh3Exception(__FILE__ , __LINE__ );
-  }
-
+  TFile *file = M3::Open(File, "UPDATE", __FILE__, __LINE__);
   TH2D *MatrixFull = nullptr;
   file->GetObject("Correlation_plot", MatrixFull);
 
@@ -113,7 +108,7 @@ void PlotMatrix(std::string Config, std::string File)
   gStyle->SetPaintTextFormat("4.1f");
 
   // Make pretty Correlation colors (red to blue)
-  const int NRGBs = 5;
+  constexpr int NRGBs = 5;
   TColor::InitializeColors();
   Double_t stops[NRGBs] = { 0.00, 0.25, 0.50, 0.75, 1.00 };
   Double_t red[NRGBs]   = { 0.00, 0.25, 1.00, 1.00, 0.50 };
@@ -152,7 +147,7 @@ void PlotMatrix(std::string Config, std::string File)
 void CompareMatrices(std::string Config, std::string File1, std::string Title1, std::string File2, std::string Title2)
 {
   // Open the ROOT file
-  const int NFiles = 2;
+  constexpr int NFiles = 2;
   TFile *file[NFiles];
   file[0] = TFile::Open(File1.c_str());
   file[1] = TFile::Open(File2.c_str());
@@ -171,10 +166,9 @@ void CompareMatrices(std::string Config, std::string File1, std::string Title1, 
   MatrixPlot->SetTopMargin(0.1);
   MatrixPlot->SetRightMargin(0.15);
   MatrixPlot->SetLeftMargin(0.15);
-
   gStyle->SetOptTitle(1);
 
-  //KS: Fancy colots
+  //KS: Fancy colors
   const int NRGBs = 10;
   TColor::InitializeColors();
   Double_t stops[NRGBs] = { 0.00, 0.10, 0.25, 0.35, 0.50, 0.60, 0.65, 0.75, 0.90, 1.00 };
@@ -228,7 +222,7 @@ int main(int argc, char *argv[])
 
   if (argc != 3 && argc != 6)
   {
-    MACH3LOG_INFO("How to use: {} MCMC_Processor_Output.root config", argv[0]);
+    MACH3LOG_INFO("How to use: {} config.yaml MCMC_Processor_Output.root", argv[0]);
     throw MaCh3Exception(__FILE__ , __LINE__ );
   }
 
@@ -246,4 +240,3 @@ int main(int argc, char *argv[])
   MACH3LOG_INFO("Finished plotting matrices");
   return 0;
 }
-

--- a/README.md
+++ b/README.md
@@ -174,9 +174,10 @@ Most of external libraries are being handled through [CPM](https://github.com/cp
 
 Based on several test here are recommended version:
 ```bash
-  GCC: >= 8.5 [lower versions may work]
+  GCC:   >= 8.5   [lower versions may work]
+  C++:   >= 14
   CMake: >= 3.14
-  ROOT: >= 6.18
+  ROOT:  >= 6.18
 ```
 ### Supported operational systems
 | Name        | Status |


### PR DESCRIPTION
# Pull request description


## Changes or fixes
- Hank noticed we do not set minimum standard so now cmake will throw error if standard is too small
- Dom noticed thinning path will be wrong if we use path with folder
- Tweak Matrix Plotter docuemtnaion

## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
