### PR TITLE
small fix for FD and ND cov grabbing so it's (less) hard-coded

### DIFF
--- a/Fitters/MCMCProcessor.h
+++ b/Fitters/MCMCProcessor.h
@@ -371,8 +371,10 @@ class MCMCProcessor {
     std::string MCMCFile;
     /// Output file suffix useful when running over same file with different settings
     std::string OutputSuffix;
-    /// Covariance matrix name position
+    /// Covariance matrix file name position
     std::vector<std::vector<std::string>> CovPos;
+    /// Covariance matrix name position
+    std::vector<std::vector<std::string>> CovNamePos;
     /// Covariance matrix config
     std::vector<YAML::Node> CovConfig;
 


### PR DESCRIPTION
# Pull request description
small change to MCMCProcessor to read in the the Cov name from the yaml. Also small change from TMatrixDSym to TMatrixD which is needed to process the T2K FD matrix.

## Changes or fixes
- Read cov name from the yaml stored in the chain

## Examples
- MCMCProcessor will read name from FDCovName.


---

- [ ] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
