### PR TITLE
bugfix: Store correct syst/sample likelihoods when saving steps in MCMC

### DIFF
--- a/Fitters/mcmc.cpp
+++ b/Fitters/mcmc.cpp
@@ -208,7 +208,7 @@ void mcmc::ProposeStep() {
   } else {
     for (size_t i = 0; i < samples.size(); ++i) {
       // Set the sample_llh[i] to be madly high also to signify a step out of bounds
-      sample_llh[i] = M3::_LARGE_LOGL_;
+      sample_llh_prop[i] = M3::_LARGE_LOGL_;
       #ifdef DEBUG
       if (debug) debugFile << "LLH after REJECT sample " << i << " " << llh << std::endl;
       #endif

--- a/Fitters/mcmc.cpp
+++ b/Fitters/mcmc.cpp
@@ -90,6 +90,11 @@ void mcmc::RunMCMC() {
   // Remove obsolete memory and make other checks before fit starts
   SanitiseInputs();
 
+  // Setup penalty term likelihood for proposed step
+  syst_llh_prop = syst_llh;
+  // Setup sample likelihood for proposed step
+  sample_llh_prop = sample_llh;
+
   // Reconfigure the samples, systematics and oscillation for first weight
   // ProposeStep sets logLProp
   ProposeStep();
@@ -97,11 +102,6 @@ void mcmc::RunMCMC() {
   // Accept the first step to set logLCurr: this shouldn't affect the MCMC because we ignore the first N steps in burn-in
   logLCurr = logLProp;
 
-  // Setup penalty term likelihood for proposed step
-  syst_llh_prop = syst_llh;
-  
-  // Setup sample likelihood for proposed step
-  sample_llh_prop = sample_llh;
 
 
   // KS: Make sure we don't hit limits when using very long

--- a/Fitters/mcmc.h
+++ b/Fitters/mcmc.h
@@ -44,5 +44,11 @@ class mcmc : public FitterBase {
   bool anneal;
   /// simulated annealing temperature
   double AnnealTemp;
+
+  /// Penalty term for proposed step
+  std::vector<double> syst_llh_prop;
+
+  /// Sample likelihood for proposed step
+  std::vector<double> sample_llh_prop;
 };
 


### PR DESCRIPTION
# Pull request description
MaCh3 was storing proposed sample/systematic likelihoods in syst/sample_llh. This means that, when saving steps to chain, each step's individual likelihoods were those of the last proposed step. This results in weirdness like systematic LLHs showing loads of out of bounds steps.

## Changes or fixes
- Add separate sample/systematic likelihood vectors for proposed step
- Swap to usual vector when step saved

## Examples
Now Xsec likelihoods look more reasonable:
<img width="856" height="501" alt="image" src="https://github.com/user-attachments/assets/af1d62b8-0756-4ba0-a636-b566f2ab9450" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
