### PR TITLE
bugfix: Reset Step Size when loading adapt matrix

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -1137,6 +1137,7 @@ void ParameterHandlerBase::InitialiseAdaption(const YAML::Node& adapt_manager){
 
   AdaptiveHandler->SetThrowMatrixFromFile(external_file_name, external_matrix_name, external_mean_name, use_adaptive);
   SetThrowMatrix(AdaptiveHandler->GetAdaptiveCovariance());
+  ResetIndivStepScale();
 
   MACH3LOG_INFO("Successfully Set External Throw Matrix Stored in {}", external_file_name);
 }


### PR DESCRIPTION
# Pull request description
After chatting with Abi let's try to reset step size when loading adapt.

We do reset step size when we enable adapt. However then when we load matrix step size is not rested i.e. adaption may not work as intended.

## Changes or fixes


## Examples



---

- [ ] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
