### PR TITLE
tidy: unify wheter step is UInt or Int

### DIFF
--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -170,7 +170,7 @@ void FitterBase::PrepareOutput() {
     outTree->Branch("LogL", &logLCurr, "LogL/D");
     if(SaveProposal) outTree->Branch("LogLProp", &logLProp, "LogLProp/D");
     outTree->Branch("accProb", &accProb, "accProb/D");
-    outTree->Branch("step", &step, "step/I");
+    outTree->Branch("step", &step, "step/i");
     outTree->Branch("stepTime", &stepTime, "stepTime/D");
 
     // Store individual likelihood components
@@ -196,7 +196,7 @@ void FitterBase::PrepareOutput() {
   {
     outTree->Branch("LogL", &logLCurr, "LogL/D");
     outTree->Branch("accProb", &accProb, "accProb/D");
-    outTree->Branch("step", &step, "step/I");
+    outTree->Branch("step", &step, "step/i");
     outTree->Branch("stepTime", &stepTime, "stepTime/D");
   }
 

--- a/Fitters/MCMCProcessor.cpp
+++ b/Fitters/MCMCProcessor.cpp
@@ -1073,7 +1073,7 @@ void MCMCProcessor::CacheSteps() {
   clock.Start();
   
   ParStep = new double*[nDraw];
-  StepNumber = new int[nEntries];
+  StepNumber = new unsigned int[nEntries];
   
   hpost2D.resize(nDraw);
   for (int i = 0; i < nDraw; ++i) 
@@ -1084,13 +1084,13 @@ void MCMCProcessor::CacheSteps() {
     {
       ParStep[i][j] = -999.99;
       //KS: Set this only once
-      if(i == 0) StepNumber[j] = -999.99;
+      if(i == 0) StepNumber[j] = 0;
     }
   }
 
   // Set all the branches to off
   Chain->SetBranchStatus("*", false);
-  int stepBranch = 0;
+  unsigned int stepBranch = 0;
   double* ParValBranch = new double[nEntries]();
   // Turn on the branches which we want for parameters
   for (int i = 0; i < nDraw; ++i)
@@ -2462,7 +2462,7 @@ void MCMCProcessor::SetStepCut(const int Cuts) {
 // Make the step cut from an int
 void MCMCProcessor::CheckStepCut() const {
 // ***************
-  const int maxNsteps = Chain->GetMaximum("step");
+  const unsigned int maxNsteps = Chain->GetMaximum("step");
   if(BurnInCut > maxNsteps){
     MACH3LOG_ERROR("StepCut({}) is larger than highest value of step({})", BurnInCut, maxNsteps);
     throw MaCh3Exception(__FILE__ , __LINE__ );
@@ -3028,7 +3028,7 @@ void MCMCProcessor::PrepareDiagMCMC() {
   SampleValues = new double*[nEntries]();
   SystValues = new double*[nEntries]();
   AccProbValues = new double[nEntries]();
-  StepNumber = new int[nEntries]();
+  StepNumber = new unsigned int[nEntries]();
   for (int i = 0; i < nEntries; ++i) {
     SampleValues[i] = new double[nSamples]();
     SystValues[i] = new double[nSysts]();
@@ -3040,7 +3040,7 @@ void MCMCProcessor::PrepareDiagMCMC() {
       SystValues[i][j] = -999.99;
     }
     AccProbValues[i] = -999.99;
-    StepNumber[i] = -999.99;
+    StepNumber[i] = 0;
   }
 
   // Initialise the sums
@@ -4038,7 +4038,7 @@ void MCMCProcessor::GewekeDiagnostic() {
     std::vector<double> SpectralVarianceDown(nDraw, 0.0);
     std::vector<int> DenomCounterDown(nDraw, 0);
 
-    const int ThresholsCheck = Division*k*nSteps;
+    const unsigned int ThresholsCheck = Division*k*nSteps;
     //KS: First mean
     for (int j = 0; j < nDraw; ++j)
     {

--- a/Fitters/MCMCProcessor.h
+++ b/Fitters/MCMCProcessor.h
@@ -387,9 +387,9 @@ class MCMCProcessor {
     /// Cut used when making 1D Posterior distribution
     std::string Posterior1DCut;
     /// KS: Used only for SubOptimality
-    int UpperCut;
+    unsigned int UpperCut;
     /// Value of burn in cut
-    int BurnInCut;
+    unsigned int BurnInCut;
     /// Number of branches in a TTree
     int nBranches;
     /// KS: For merged chains number of entries will be different from nSteps
@@ -509,7 +509,7 @@ class MCMCProcessor {
     /// Array holding values for all parameters
     double** ParStep;
     /// Step number for step, important if chains were merged
-    int* StepNumber;
+    unsigned int* StepNumber;
 
     /// Number of bins
     int nBins;

--- a/Fitters/OscProcessor.cpp
+++ b/Fitters/OscProcessor.cpp
@@ -174,7 +174,7 @@ void OscProcessor::PerformJarlskogAnalysis() {
   TDirectory *JarlskogDir = OutputFile->mkdir("Jarlskog");
   JarlskogDir->cd();
 
-  int step = M3::_BAD_INT_;
+  unsigned int step = 0;
   Chain->SetBranchStatus("*", false);
 
   Chain->SetBranchStatus(Sin2Theta13Name.c_str(), true);

--- a/Fitters/PredictiveThrower.cpp
+++ b/Fitters/PredictiveThrower.cpp
@@ -326,7 +326,7 @@ void PredictiveThrower::ProduceToys() {
 
   TChain* PosteriorFile = new TChain("posteriors");
   PosteriorFile->Add(PosteriorFileName.c_str());
-  int Step = 0;
+  unsigned int Step = 0;
   PosteriorFile->SetBranchAddress("step", &Step);
 
   if (PosteriorFile->GetBranch("Weight")) {
@@ -341,11 +341,11 @@ void PredictiveThrower::ProduceToys() {
     systematics[s]->MatchMaCh3OutputBranches(PosteriorFile, branch_vals[s], branch_name[s]);
   }
   //Get the burn-in from the config
-  auto burn_in = Get<int>(fitMan->raw()["Predictive"]["BurnInSteps"], __FILE__, __LINE__);
+  auto burn_in = Get<unsigned int>(fitMan->raw()["Predictive"]["BurnInSteps"], __FILE__, __LINE__);
 
   //DL: Adding sanity check for chains shorter than burn in
   const unsigned int maxNsteps = static_cast<unsigned int>(PosteriorFile->GetMaximum("step"));
-  if(static_cast<unsigned int>(burn_in) >= maxNsteps)
+  if(burn_in >= maxNsteps)
   {
     MACH3LOG_ERROR("You are running on a chain shorter than burn in cut");
     MACH3LOG_ERROR("Maximal value of nSteps: {}, burn in cut {}", maxNsteps, burn_in);
@@ -362,7 +362,7 @@ void PredictiveThrower::ProduceToys() {
       MaCh3Utils::PrintProgressBar(i, Ntoys);
     }
     int entry = 0;
-    Step = -999;
+    Step = 0;
 
     //YSP: Ensures you get an entry from the mcmc even when burn_in is set to zero (Although not advised :p ).
     //Take 200k burn in steps, WP: Eb C in 1st peaky

--- a/Fitters/mcmc.cpp
+++ b/Fitters/mcmc.cpp
@@ -169,7 +169,7 @@ void mcmc::ProposeStep() {
     syst_llh_prop[s] = systematics[s]->GetLikelihood();
     llh += syst_llh_prop[s];
 
-#ifdef DEBUG
+    #ifdef DEBUG
     if (debug) debugFile << "LLH after " << systematics[s]->GetName() << " " << llh << std::endl;
     #endif
   }
@@ -199,7 +199,7 @@ void mcmc::ProposeStep() {
       // Get the sample likelihoods and add them
       sample_llh_prop[i] = samples[i]->GetLikelihood();
       llh += sample_llh_prop[i];
-#ifdef DEBUG
+      #ifdef DEBUG
       if (debug) debugFile << "LLH after sample " << i << " " << llh << std::endl;
       #endif
     }
@@ -244,14 +244,14 @@ void mcmc::StartFromPreviousFit(const std::string& FitName) {
   FitterBase::StartFromPreviousFit(FitName);
 
   // For MCMC we also need to set stepStart
-  TFile *infile = new TFile(FitName.c_str(), "READ");
+  TFile *infile = M3::Open(FitName, "READ", __FILE__, __LINE__);
   TTree *posts = infile->Get<TTree>("posteriors");
-  int step_val = -1;
+  unsigned int step_val = 0;
 
   posts->SetBranchAddress("step",&step_val);
   posts->GetEntry(posts->GetEntries()-1);
 
-  stepStart = step_val + 1;
+  stepStart = step_val;
   // KS: Also update number of steps if using adaption
   for(unsigned int i = 0; i < systematics.size(); ++i){
     if(systematics[i]->GetDoAdaption()){


### PR DESCRIPTION
# Pull request description
Within Fitter base step number was Unsinged Int however it was saved as int and whole processing was using int.

This is attempt to unify this

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
