### PR TITLE
feat: Enforce Same Binning for posterior compasion

### DIFF
--- a/Diagnostics/DiagMCMC.cpp
+++ b/Diagnostics/DiagMCMC.cpp
@@ -17,6 +17,7 @@ void DiagMCMC(const std::string& inputFile, const std::string& config)
   //KS:Turn off plotting detector and some other setting
   Processor->SetExcludedTypes(GetFromManager<std::vector<std::string>>(Settings["DiagMCMC"]["ExcludedTypes"], {}));
   Processor->SetExcludedNames(GetFromManager<std::vector<std::string>>(Settings["DiagMCMC"]["ExcludedNames"], {}));
+  Processor->SetExcludedGroups(GetFromManager<std::vector<std::string>>(Settings["DiagMCMC"]["ExcludedGroups"], {}));
   Processor->SetPlotRelativeToPrior(GetFromManager<bool>(Settings["DiagMCMC"]["PlotRelativeToPrior"], false));
   //KS: Use 20 batches for batched means
   Processor->SetnBatches(GetFromManager<int>(Settings["DiagMCMC"]["nBatches"], 20));

--- a/Diagnostics/ProcessMCMC.cpp
+++ b/Diagnostics/ProcessMCMC.cpp
@@ -89,6 +89,8 @@ void ProcessMCMC(const std::string& inputFile)
 
   Processor->SetExcludedTypes(GetFromManager<std::vector<std::string>>(Settings["ExcludedTypes"], {}));
   Processor->SetExcludedNames(GetFromManager<std::vector<std::string>>(Settings["ExcludedNames"], {}));
+  Processor->SetExcludedGroups(GetFromManager<std::vector<std::string>>(Settings["ExcludedGroups"], {}));
+
   //Apply additional cuts to 1D posterior
   Processor->SetPosterior1DCut(GetFromManager<std::string>(Settings["Posterior1DCut"], ""));
 
@@ -193,6 +195,7 @@ void MultipleProcessMCMC()
 
     Processor[ik]->SetExcludedTypes(GetFromManager<std::vector<std::string>>(Settings["ExcludedTypes"], {}));
     Processor[ik]->SetExcludedNames(GetFromManager<std::vector<std::string>>(Settings["ExcludedNames"], {}));
+    Processor[ik]->SetExcludedGroups(GetFromManager<std::vector<std::string>>(Settings["ExcludedGroups"], {}));
 
     //Apply additional cuts to 1D posterior
     Processor[ik]->SetPosterior1DCut(GetFromManager<std::string>(Settings["Posterior1DCut"], ""));
@@ -211,11 +214,37 @@ void MultipleProcessMCMC()
       Processor[ik]->SetEntries(Get<int>(Settings["MaxEntries"], __FILE__, __LINE__));
     }
   }
+
+  Processor[0]->MakePostfit();
+  Processor[0]->DrawPostfit();
+  // Get edges from first histogram to ensure all params use same binning
+  std::map<std::string, std::pair<double, double>> ParamEdges;
+  for(int i = 0; i < Processor[0]->GetNParams(); ++i) {
+    // Get the histogram for the i-th parameter
+    TH1D* hist = Processor[0]->GetHpost(i);
+    if (!hist) {
+      MACH3LOG_DEBUG("Histogram for parameter {} is null.", i);
+      continue;
+    }
+
+    // Get the parameter name (title of the histogram)
+    std::string paramName = hist->GetTitle();
+
+    // Get the axis limits (edges)
+    TAxis* axis = hist->GetXaxis();
+    double xmin = axis->GetXmin();
+    double xmax = axis->GetXmax();
+
+    MACH3LOG_DEBUG("Adding bin edges for {} equal to {:.4f}, {:.4f}",paramName, xmin, xmax);
+    // Insert into the map
+    ParamEdges[paramName] = std::make_pair(xmin, xmax);
+  }
+
   //KS: Multithreading here is very tempting but there are some issues with root that need to be resovled :(
-  for (int ik = 0; ik < nFiles; ik++)
+  for (int ik = 1; ik < nFiles; ik++)
   {
     // Make the postfit
-    Processor[ik]->MakePostfit();
+    Processor[ik]->MakePostfit(ParamEdges);
     Processor[ik]->DrawPostfit();
   }
 
@@ -227,7 +256,7 @@ void MultipleProcessMCMC()
   Posterior->SetBottomMargin(0.1f);
   Posterior->SetTopMargin(0.05f);
   Posterior->SetRightMargin(0.03f);
-  Posterior->SetLeftMargin(0.10f);
+  Posterior->SetLeftMargin(0.15f);
 
   FileNames[0] = FileNames[0].substr(0, FileNames[0].find(".root")-1);
   TString canvasname = FileNames[0];
@@ -252,7 +281,7 @@ void MultipleProcessMCMC()
     std::vector<std::unique_ptr<TH1D>> hpost(nFiles);
     std::vector<std::unique_ptr<TLine>> hpd(nFiles);
     hpost[0] = M3::Clone(Processor[0]->GetHpost(i));
-
+    hpost[0]->GetYaxis()->SetTitle("Posterior Density");
     bool Skip = false;
     for (int ik = 1 ; ik < nFiles;  ik++)
     {
@@ -280,7 +309,7 @@ void MultipleProcessMCMC()
       hpost[ik]->SetLineWidth(2);
 
       // Area normalise the distributions
-      hpost[ik]->Scale(1./hpost[ik]->Integral(), "width");
+      hpost[ik]->Scale(1./hpost[ik]->Integral());
     }
     TString Title;
     double Prior = 1.0;
@@ -295,7 +324,7 @@ void MultipleProcessMCMC()
     Asimov->SetLineStyle(kDashed);
 
     // Make a nice little TLegend
-    auto leg = std::make_unique<TLegend>(0.12, 0.7, 0.6, 0.97);
+    auto leg = std::make_unique<TLegend>(0.20, 0.7, 0.6, 0.97);
     leg->SetTextSize(0.03f);
     leg->SetFillColor(0);
     leg->SetFillStyle(0);
@@ -638,8 +667,8 @@ void KolmogorovSmirnovTest(const std::vector<std::unique_ptr<MCMCProcessor>>& Pr
                            const std::unique_ptr<TCanvas>& Posterior,
                            const TString& canvasname)
 {
-  const Color_t CumulativeColor[] = {kBlue-1, kRed, kGreen+2};
-  const Style_t CumulativeStyle[] = {kSolid, kDashed, kDotted};
+  constexpr Color_t CumulativeColor[] = {kBlue-1, kRed, kGreen+2};
+  constexpr Style_t CumulativeStyle[] = {kSolid, kDashed, kDotted};
 
   for(int i = 0; i < Processor[0]->GetNParams(); ++i) 
   {

--- a/Fitters/MCMCProcessor.h
+++ b/Fitters/MCMCProcessor.h
@@ -69,7 +69,7 @@ class MCMCProcessor {
     /// @brief Scan chain, what parameters we have and load information from covariance matrices
     void Initialise();
     /// @brief Make 1D projection for each parameter and prepare structure
-    void MakePostfit();
+    void MakePostfit(const std::map<std::string, std::pair<double, double>>& Edges = {});
     /// @brief Calculate covariance by making 2D projection of each combination of parameters
     void MakeCovariance();
     /// @brief KS:By caching each step we use multithreading
@@ -293,6 +293,7 @@ class MCMCProcessor {
     /// @param Batches Vector with parameters type names we want to exclude
     inline void SetExcludedTypes(std::vector<std::string> Name){ExcludedTypes = Name; };
     inline void SetExcludedNames(std::vector<std::string> Name){ExcludedNames = Name; };
+    inline void SetExcludedGroups(std::vector<std::string> Name){ExcludedGroups = Name; };
 
     /// @brief Set value of Nbatches used for batched mean, this need to be done earlier as batches are made when reading tree
     /// @param Batches Number of batches, default is 20
@@ -431,7 +432,8 @@ class MCMCProcessor {
     std::vector<TString> BranchNames;
     std::vector<std::string> ExcludedTypes;
     std::vector<std::string> ExcludedNames;
-    
+    std::vector<std::string> ExcludedGroups;
+
     /// Is the ith parameter varied
     std::vector<bool> IamVaried;
     /// Name of parameters which we are going to analyse


### PR DESCRIPTION
# Pull request description
MCMC Processor doesn't hardcore binning therefore when we compare histograms binning is tiny bit different.

Dan pointed out this causing issues when trying to carefully compare Osc parameters. Dan suggested solution.

Now Second and Third Processor are using same binning as was found within First One.

In addition add ability to exclude param groups

## Changes or fixes


## Examples
Now it correclty sets binning
<img width="574" height="613" alt="debug" src="https://github.com/user-attachments/assets/42042580-b56f-401c-ae74-93c62b89b4c0" />
[Plots.pdf](https://github.com/user-attachments/files/21940152/Plots.pdf)

Now it correctly skip groups
![Excluding](https://github.com/user-attachments/assets/2f04a41c-ec6d-44b8-9643-676eb1a72434)

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
