### PR TITLE
feat: Smear Contours

### DIFF
--- a/Diagnostics/CMakeLists.txt
+++ b/Diagnostics/CMakeLists.txt
@@ -8,6 +8,7 @@ foreach(app
     ProcessMCMC
     CombineMaCh3Chains
     PlotMCMCDiag
+    SmearChain
     )
     add_executable(${app} ${app}.cpp)
     add_dependencies(DiagApps ${app})

--- a/Diagnostics/CombineMaCh3Chains.cpp
+++ b/Diagnostics/CombineMaCh3Chains.cpp
@@ -272,7 +272,7 @@ void CombineChain()
   outputFile->cd();
 
   // EM: Write out the version and config files to the combined file
-  std::vector<std::string> configNames = {"MaCh3_Config", "Reweight_Config"};
+  std::vector<std::string> configNames = {"MaCh3_Config", "Reweight_Config", "Smearing_Config"};
   for (std::size_t i = 0; i < configNames.size(); ++i) {
     const std::string& name = configNames[i];
     TMacro* macro = prevFile->Get<TMacro>(name.c_str());

--- a/Diagnostics/README.md
+++ b/Diagnostics/README.md
@@ -1,5 +1,5 @@
 # Diagnostic
-**ProcessMCMC** - The main app you want to use for analysing the ND280 chain. It prints posterior distribution after burn-in the cut. Moreover, you can compare two/three different chains. There are a few options you can modify easily inside the app like selection, burn-in cut, and whether to plot xse+flux or only flux. Other functionality
+**ProcessMCMC** - The main app you want to use for analysing the ND280 chain. It prints posterior distribution after burn-in the cut. Moreover, you can compare two/three different chains. There are a few options you can modify easily inside the app like selection, burn-in cut, and whether to plot xsec+flux or only flux. Other functionality
 <ol>
 <li> Produce a covariance matrix with multithreading (which requires lots of RAM due to caching) </li>
 <li> Violin plots </li>
@@ -9,6 +9,7 @@
 <li> Study covariance matrix stability </li>
 </ol>
 
+You can find more options [here](https://github.com/mach3-software/MaCh3/wiki/09.-Bayesian-Analysis,-Plotting-and-MCMC-Processor).
 **GetPenaltyTerm** - Since xsec and flux and ND spline systematic are treated as the same systematic object we cannot just take log_xsec, hence we need this script, use `GetFluxPenaltyTerm MCMCChain.root config`. Parameters of relevance are loaded via config, thus you can study any combination you want. Time needed increases with number of sets :(
 
 **DiagMCMC** - Perform MCMC diagnostic like autocorrelation or trace plots.
@@ -37,3 +38,6 @@ CombineMaCh3Chains [-h] [-c [0-9]] [-f] [-o <output file>] file1.root [file2.roo
 -h print usage message and exit
 
 *Output file* (optional) name of the combined file. If not specified, will just use *file1.root*, the first in the list of files, same as *hadd*.
+
+
+**SmearChain** - Allows you to smear contour. For example after performing sets of study one finds out that used sets of uncertainty doesn't fully cover analysis need. Then one can smear additionally contour.

--- a/Diagnostics/SmearChain.cpp
+++ b/Diagnostics/SmearChain.cpp
@@ -1,0 +1,40 @@
+#include "Fitters/MCMCProcessor.h"
+
+#include "Manager/Manager.h"
+
+/// @brief Main function  creating MCMCProcessor and calling Smear Chain
+/// @param inputFile MCMC Chain
+/// @param config Config file with settings
+void DiagMCMC(const std::string& inputFile, const std::string& config)
+{
+  MACH3LOG_INFO("File for study: {}", inputFile);
+
+  YAML::Node Settings = M3OpenConfig(config);
+
+  // Make the processor
+  auto Processor = std::make_unique<MCMCProcessor>(inputFile);
+  Processor->SetOutputSuffix("_Smear_MCMC");
+  Processor->Initialise();
+
+  const auto& Smear = Settings["SmearChain"];
+  std::vector<std::string> Names = Smear["Smear"][0].as<std::vector<std::string>>();
+  std::vector<double> ErrorValue = Smear["Smear"][1].as<std::vector<double>>();
+
+  bool SaveUnsmearedBranch = GetFromManager<bool>(Smear["SaveUnsmearedBranch"], false);
+  Processor->SmearChain(Names, ErrorValue, SaveUnsmearedBranch);
+}
+
+int main(int argc, char *argv[]) {
+  SetMaCh3LoggerFormat();
+  if (argc != 3)
+  {
+    MACH3LOG_ERROR("How to use: {} MCMC_Output.root config", argv[0]);
+    throw MaCh3Exception(__FILE__ , __LINE__ );
+  }
+  MACH3LOG_INFO("Producing single fit output");
+  std::string filename = argv[1];
+  std::string config = argv[2];
+  DiagMCMC(filename, config);
+
+  return 0;
+}

--- a/Fitters/MCMCProcessor.h
+++ b/Fitters/MCMCProcessor.h
@@ -179,6 +179,15 @@ class MCMCProcessor {
                        const std::vector<double>& NewCentral,
                        const std::vector<double>& NewError);
     
+
+    /// @brief Smear chain contours
+    /// @param Names Parameter names for which we do smearing
+    /// @param Error Error based on which we smear
+    /// @param SaveBranch Whether we save unsmeared branch or not
+    void SmearChain(const std::vector<std::string>& Names,
+                    const std::vector<double>& NewCentral,
+                    const bool& SaveBranch);
+
     /// @brief Make .gif of parameter evolution
     /// @param Names Parameter names for which we do .gif
     /// @param NIntervals Number of intervals for a gif


### PR DESCRIPTION
# Pull request description
In T2K analyses, we often have to smear chain after fake data studies.
This functionality has been now implemented in MaCh3 Core with addition of meta-data

## Changes or fixes


## Examples
<img width="1429" height="1374" alt="image" src="https://github.com/user-attachments/assets/f0234462-6202-490b-bdaa-4429147a988a" />
<img width="1420" height="1346" alt="image" src="https://github.com/user-attachments/assets/c78ad18d-1a2d-49b7-bca0-e6f5735837b0" />
Meta data example
<img width="1191" height="558" alt="image" src="https://github.com/user-attachments/assets/67814f04-03ef-4ccb-a253-051a2cf64dab" />
example of unsmeared branches
<img width="1172" height="772" alt="image" src="https://github.com/user-attachments/assets/9bc454b7-a921-45a8-af81-1e0a104107f8" />


---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
