### PR TITLE
tidy: MaCh3 mode alternative constructor

### DIFF
--- a/Manager/MaCh3Modes.cpp
+++ b/Manager/MaCh3Modes.cpp
@@ -6,11 +6,21 @@ MaCh3Modes::MaCh3Modes(std::string const &filename) {
 // *******************
   // Load config
   YAML::Node config = M3OpenConfig(filename);
+  Initialise(config);
+}
 
-  std::string GetMaCh3ModeName(const int Index);
+// *******************
+MaCh3Modes::MaCh3Modes(const YAML::Node& config) {
+// *******************
+  Initialise(config);
+}
+
+// *******************
+void MaCh3Modes::Initialise(const YAML::Node& config) {
+// *******************
   NModes = 0;
   nCCModes = 0;
-  
+
   Title = config["Title"].as<std::string>();
   Generator = config["GeneratorName"].as<std::string>();
 
@@ -45,7 +55,7 @@ MaCh3Modes::MaCh3Modes(std::string const &filename) {
 }
 
 // *******************
-void MaCh3Modes::Print() {
+void MaCh3Modes::Print() const {
 // *******************
   MACH3LOG_INFO("Printing MaCh3 Modes Called: {}", Title);
 
@@ -53,9 +63,9 @@ void MaCh3Modes::Print() {
   MACH3LOG_INFO("{:<5} {:2} {:<20} {:2} {:<20} {:2} {:<30}", "#", "|", "Name", "|", "FancyName", "|", Generator+" Modes");
   MACH3LOG_INFO("------------------------------------------------------------------------");
   for(int i = 0; i < NModes; ++i) {
-    auto Name = fMode[i].Name;
-    auto FancyName = fMode[i].FancyName;
-    auto Values = fMode[i].GeneratorMaping;
+    auto Name = fMode.at(i).Name;
+    auto FancyName = fMode.at(i).FancyName;
+    auto Values = fMode.at(i).GeneratorMaping;
 
     std::string generatorModes;
     for (const int& element : Values) {
@@ -69,7 +79,7 @@ void MaCh3Modes::Print() {
   MACH3LOG_INFO("{:<10} {:2} {:<30}", Generator + " Modes", "|", "Name");
   MACH3LOG_INFO("--------------------------");
   for (size_t i = 0; i < ModeMap.size(); ++i) {
-    MACH3LOG_INFO("{:<10} {:2} {:<30}", i, "|", fMode[ModeMap[i]].Name);
+    MACH3LOG_INFO("{:<10} {:2} {:<30}", i, "|", fMode.at(ModeMap[i]).Name);
   }
   MACH3LOG_INFO("==========================");
 }
@@ -87,11 +97,11 @@ MaCh3Modes_t MaCh3Modes::EnsureModeNameRegistered(std::string const &name) {
 
 // *******************
 void MaCh3Modes::DeclareNewMode(std::string const &name,
-				std::string const &fancyname,
-				int PlotColor,
-				std::vector<int> const &GenMap,
-				bool IsNC,
-				std::string SplineSuffix) {
+                std::string const &fancyname,
+                int PlotColor,
+                std::vector<int> const &GenMap,
+                bool const IsNC,
+                std::string const &SplineSuffix) {
 // *******************
   MaCh3ModeInfo newinfo;
   newinfo.GeneratorMaping = GenMap;
@@ -135,7 +145,7 @@ void MaCh3Modes::PrepareMap() {
 }
 
 // *******************
-std::string MaCh3Modes::GetMaCh3ModeName(const int Index) {
+std::string MaCh3Modes::GetMaCh3ModeName(const int Index) const {
 // *******************
   if(Index < 0)
     MACH3LOG_CRITICAL("Mode you look for is smaller than 0 and equal to {}", Index);
@@ -144,13 +154,14 @@ std::string MaCh3Modes::GetMaCh3ModeName(const int Index) {
   if(Index > NModes)
   {
     MACH3LOG_DEBUG("Asking for mode {}, while I only have {}, returning {} mode", Index, NModes, fMode[NModes].Name);
-    return fMode[NModes].Name;
+    return fMode.at(NModes).Name;
   }
-  return fMode[Index].Name;
+  return fMode.at(Index).Name;
 }
 
 // *******************
-bool MaCh3Modes::IsMaCh3ModeNC(const int Index) {
+bool MaCh3Modes::IsMaCh3ModeNC(const int Index) const {
+// *******************
   if(Index < 0)
     MACH3LOG_CRITICAL("Mode you look for is smaller than 0 and equal to {}", Index);
   
@@ -158,15 +169,13 @@ bool MaCh3Modes::IsMaCh3ModeNC(const int Index) {
   if(Index > NModes)
   {
     MACH3LOG_DEBUG("Asking for mode {}, while I only have {}, returning {} mode", Index, NModes, fMode[NModes].Name);
-    return fMode[NModes].IsNC;
+    return fMode.at(NModes).IsNC;
   }
-
-  return fMode[Index].IsNC;
+  return fMode.at(Index).IsNC;
 }
-// *******************
 
 // *******************
-std::string MaCh3Modes::GetMaCh3ModeFancyName(const int Index) {
+std::string MaCh3Modes::GetMaCh3ModeFancyName(const int Index) const {
 // *******************
   // return UNKNOWN_BAD if out of boundary
   if(Index < 0)
@@ -175,16 +184,16 @@ std::string MaCh3Modes::GetMaCh3ModeFancyName(const int Index) {
   if(Index > NModes)
   {
     MACH3LOG_DEBUG("Asking for mode {}, while I only have {}, returning {} mode", Index, NModes, fMode[NModes].Name);
-    return fMode[NModes].FancyName;
+    return fMode.at(NModes).FancyName;
   }
-  return fMode[Index].FancyName;
+  return fMode.at(Index).FancyName;
 }
 
 // *******************
-MaCh3Modes_t MaCh3Modes::GetMode(const std::string& name) {
+MaCh3Modes_t MaCh3Modes::GetMode(const std::string& name) const {
 // *******************
   if (Mode.count(name)) {
-    return Mode[name];
+    return Mode.at(name);
   }
   MACH3LOG_DEBUG("Asking for mode {}, while I only have {}, returning {} mode", name, NModes, fMode[NModes].Name);
 
@@ -193,7 +202,7 @@ MaCh3Modes_t MaCh3Modes::GetMode(const std::string& name) {
 }
 
 // *******************
-MaCh3Modes_t MaCh3Modes::GetModeFromGenerator(const int Index) {
+MaCh3Modes_t MaCh3Modes::GetModeFromGenerator(const int Index) const {
 // *******************
   if(Index < 0)
     MACH3LOG_CRITICAL("Mode you look for is smaller than 0 and equal to {}", Index);
@@ -208,7 +217,7 @@ MaCh3Modes_t MaCh3Modes::GetModeFromGenerator(const int Index) {
 }
 
 // *******************
-int MaCh3Modes::GetMaCh3ModePlotColor(const int Index) {
+int MaCh3Modes::GetMaCh3ModePlotColor(const int Index) const {
 // *******************
   // return UNKNOWN_BAD if out of boundary
   if(Index < 0)
@@ -217,9 +226,9 @@ int MaCh3Modes::GetMaCh3ModePlotColor(const int Index) {
   if(Index > NModes)
   {
     MACH3LOG_DEBUG("Asking for mode {}, while I only have {}, returning {} mode", Index, NModes, fMode[NModes].PlotColor);
-    return fMode[NModes].PlotColor;
+    return fMode.at(NModes).PlotColor;
   }
-  return fMode[Index].PlotColor;
+  return fMode.at(Index).PlotColor;
 }
 
 // *******************

--- a/Manager/MaCh3Modes.h
+++ b/Manager/MaCh3Modes.h
@@ -40,46 +40,54 @@ struct MaCh3ModeInfo {
 /// @author Daniel Barrow
 class MaCh3Modes {
  public:
-  /// @brief KS: Initialise MaCh3 modes
+  /// @brief KS: Initialise MaCh3 modes using path to config
   MaCh3Modes(std::string const &filename);
+  /// @brief KS: Initialise MaCh3 modes using config
+  MaCh3Modes(const YAML::Node& config);
   /// @brief KS: Empty destructor
   virtual ~MaCh3Modes(){};
 
   /// @brief KS: Print info about initialised modes
-  void Print();
+  void Print() const;
 
   /// @brief KS: Get number of modes, keep in mind actual number is +1 greater due to unknown category
   inline int GetNModes() const {return NModes;}
   /// @brief KS: Get mode number based on name, if mode not known you will get UNKNOWN_BAD
-  MaCh3Modes_t GetMode(const std::string& name);
+  /// @name of MaCh3 mode
+  MaCh3Modes_t GetMode(const std::string& name) const;
   /// @brief KS: Get normal name of mode, if mode not known you will get UNKNOWN_BAD
-  std::string GetMaCh3ModeName(const int Index);
+  std::string GetMaCh3ModeName(const int Index) const;
   /// @brief KS: Get normal name of mode, if mode not known you will get UNKNOWN_BAD
-  int GetMaCh3ModePlotColor(const int Index);
+  int GetMaCh3ModePlotColor(const int Index) const;
   /// @brief KS: Get fancy name of mode, if mode not known you will get UNKNOWN_BAD
-  std::string GetMaCh3ModeFancyName(const int Index);
+  std::string GetMaCh3ModeFancyName(const int Index) const;
   /// @brief DB: Get IsNC (a check whether the given MaCh3 corresponds to a Neutral Current mode)
-  bool IsMaCh3ModeNC(const int Index);
+  bool IsMaCh3ModeNC(const int Index) const;
   /// @brief DB: Get binned spline mode suffic from MaCh3 Mode
   std::string GetSplineSuffixFromMaCh3Mode(const int Index);
   /// @brief KS: Get MaCh3 mode from generator mode
-  MaCh3Modes_t GetModeFromGenerator(const int Index);
+  MaCh3Modes_t GetModeFromGenerator(const int Index) const;
   /// @brief Get class name
   inline std::string GetName() const {return "MaCh3Modes";};
   /// @brief Return count of CC modes
   inline int GetNCCModes() const {return nCCModes;};
 
  private:
+  /// @brief KS: Initialise MaCh3 modes based on provided config
+  /// @param config YAML-based config used for class initialisation
+  inline void Initialise(const YAML::Node& config);
+
   /// @brief KS: Make sure we don't have two modes with the same name
+  /// @name of MaCh3 mode
   inline MaCh3Modes_t EnsureModeNameRegistered(std::string const &name);
 
   /// @brief KS: Add new mode
   inline void DeclareNewMode(std::string const &name,
-			     std::string const &fancyname,
-			     int PlotColor,
-			     std::vector<int> const &GenMap,
-			     bool IsNC,
-			     std::string SplineSuffix);
+                             std::string const &fancyname,
+                             int PlotColor,
+                             std::vector<int> const &GenMap,
+                             const bool IsNC,
+                             const std::string& SplineSuffix);
 
   /// @brief KS: Fill ModeMap
   inline void PrepareMap();


### PR DESCRIPTION
# Pull request description
Now you initialize MaCh3 mode using path to config, but now it also enable initializing using actual YAML file not path to YAML.

In addition, minor changes for `const `correctness
## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
