### PR TITLE
feat: Add ability to temporarily disable flipping in delayed rejection

### DIFF
--- a/Fitters/DelayedMR2T2.h
+++ b/Fitters/DelayedMR2T2.h
@@ -97,4 +97,10 @@ class DelayedMR2T2 : public MR2T2 {
     bool delay_on_oob_only;
     /// Can delay with probability instead
     double delay_probability;
+
+    /// Continue flipping parameters on reject
+    bool flip_on_reject;
+    /// bool to store the INITIAL flip setting
+    std::vector<bool> initial_flip_setting;
+
 };

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -7,6 +7,8 @@ ParameterHandlerBase::ParameterHandlerBase(std::string name, std::string file, d
 // ********************************************
   MACH3LOG_DEBUG("Constructing instance of ParameterHandler");
   doSpecialStepProposal = false;
+  doFlipStepProposal = false;                      
+
   if (threshold < 0 || threshold >= 1) {
     MACH3LOG_INFO("NOTE: {} {}", name, file);
     MACH3LOG_INFO("Principal component analysis but given the threshold for the principal components to be less than 0, or greater than (or equal to) 1. This will not work");
@@ -307,6 +309,7 @@ void ParameterHandlerBase::EnableSpecialProposal(const YAML::Node& param, const 
 
   if (param["FlipParameter"]) {
     FlipEnabled = true;
+    doFlipStepProposal = true;
   }
 
   if (!CircEnabled && !FlipEnabled) {

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -308,6 +308,12 @@ class ParameterHandlerBase {
   /// @cite haario2001adaptive
   void UpdateAdaptiveCovariance();
 
+  /// @brief Check if we have any flip step proposal enabled
+  bool HasFlipStepProposal() const { return doFlipStepProposal; }
+
+  /// @brief enable/disable flips, used in Delayed Rejection
+  void EnableFlipStepProposal(bool enable) { doFlipStepProposal = enable; }
+
   /// @brief Accepted this step
   void AcceptStep() _noexcept_;
 
@@ -321,6 +327,7 @@ class ParameterHandlerBase {
   void ToggleFixParameter(const std::string& name);
   /// @brief Is parameter fixed or not
   /// @param i Parameter index
+
   bool IsParameterFixed(const int i) const {
     if (_fError[i] < 0) { return true; }
     else                { return false; }
@@ -422,6 +429,9 @@ protected:
 
   /// Check if any of special step proposal were enabled
   bool doSpecialStepProposal;
+
+  /// Specifically disable flips, used in Delayed Rejection
+  bool doFlipStepProposal;
 
   /// The input root file we read in
   const std::string inputFile;


### PR DESCRIPTION
# Pull request description
Add ability to flip on the first delayed step and then NO OTHER STEPS for that given delay. Allows for small adjustments to try and find a mode

## Changes or fixes
-> Add interface to disable flips to parameter handler base
-> Add method to restore flips to DelayedRejection

---

- [ ] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
