### PR TITLE
bugfix: Stop segfault in Plot LLH

### DIFF
--- a/Manager/MaCh3Logger.h
+++ b/Manager/MaCh3Logger.h
@@ -17,6 +17,8 @@ _MaCh3_Safe_Include_End_ //}
 
 /// @file MaCh3Logger.h
 /// @brief KS: Based on this https://github.com/gabime/spdlog/blob/a2b4262090fd3f005c2315dcb5be2f0f1774a005/include/spdlog/spdlog.h#L284
+/// @note can read more about spdlog [here](https://github.com/gabime/spdlog/wiki)
+/// @author Kamil Skwarczynski
 
 #define MACH3LOG_TRACE SPDLOG_TRACE
 #define MACH3LOG_DEBUG SPDLOG_DEBUG

--- a/Manager/YamlHelper.h
+++ b/Manager/YamlHelper.h
@@ -23,6 +23,7 @@ _MaCh3_Safe_Include_End_ //}
 
 /// @file YamlHelper.h
 /// @brief Utility functions for handling YAML nodes
+/// @note you can read more about Yaml: [here](https://codedocs.xyz/jbeder/yaml-cpp/index.html)
 /// @author Kamil Skwarczynski
 /// @author Luke Pickering
 

--- a/Parameters/AdaptiveMCMCHandler.cpp
+++ b/Parameters/AdaptiveMCMCHandler.cpp
@@ -191,7 +191,7 @@ void AdaptiveMCMCHandler::SetThrowMatrixFromFile(const std::string& matrix_file_
 // ********************************************
   // Lets you set the throw matrix externally
   // Open file
-  std::unique_ptr<TFile>matrix_file(new TFile(matrix_file_name.c_str()));
+  auto matrix_file = std::make_unique<TFile>(matrix_file_name.c_str());
   use_adaptive = true;
 
   if(matrix_file->IsZombie()){

--- a/Plotting/plottingUtils/inputManager.h
+++ b/Plotting/plottingUtils/inputManager.h
@@ -239,8 +239,6 @@ public:
     {
       file.Close();
     }
-
-    _fileVec.clear();
   }
 
   // NO COPYING!


### PR DESCRIPTION
# Pull request description
PlotLLH had segfault when comparing two files.

Plot LLH relies on ROOT memory management (should be fixed...), if two histograms with same name (one for each file) were being deleted then ROOT was deleting single histogram twice...

## Changes or fixes


## Examples
[LLHScan_Total.pdf](https://github.com/user-attachments/files/22370485/LLHScan_Total.pdf)
[LLHScan_Sample.pdf](https://github.com/user-attachments/files/22370487/LLHScan_Sample.pdf)
[LLHScan_Penalty.pdf](https://github.com/user-attachments/files/22370489/LLHScan_Penalty.pdf)

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
