### PR TITLE
feat: Speedy Cholesky decomposition

### DIFF
--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -213,9 +213,6 @@ class ParameterHandlerBase {
   /// @brief Get matrix used for step proposal
   /// @ingroup ParameterHandlerGetters
   double GetThrowMatrix(const int i, const int j) const { return throwMatrixCholDecomp[i][j];}
-  /// @brief Get the Cholesky decomposition of the throw matrix
-  /// @ingroup ParameterHandlerGetters
-  inline TMatrixD *GetThrowMatrix_CholDecomp() const {return throwMatrix_CholDecomp;}
 
   /// @brief KS: Convert covariance matrix to correlation matrix and return TH2D which can be used for fancy plotting
   /// @details This function converts the covariance matrix to a correlation matrix and
@@ -477,8 +474,6 @@ protected:
 
   /// Matrix which we use for step proposal before Cholesky decomposition (not actually used for step proposal)
   TMatrixDSym* throwMatrix;
-  /// Matrix which we use for step proposal after Cholesky decomposition
-  TMatrixD* throwMatrix_CholDecomp;
   /// Throw matrix that is being used in the fit, much faster as TMatrixDSym cache miss
   double** throwMatrixCholDecomp;
 


### PR DESCRIPTION
# Pull request description
ROOT's cholesky is enough for most fits. However for HUGE matrices like 5k that T2K is using or 3k that Abi is using it can be bit slow.

This adds new choleksy which is faster because of better cache structure and OMP. Included example in PR which used for comapring both implemantions

## Changes or fixes


## Examples
<img width="325" height="73" alt="2kTest" src="https://github.com/user-attachments/assets/8b3db22d-a9b6-42ba-81d9-4bb14a1d177e" />
<img width="311" height="60" alt="3K" src="https://github.com/user-attachments/assets/09290715-91c0-4fe4-859e-345273165eb7" />
<img width="349" height="79" alt="SpeedyCHolesky" src="https://github.com/user-attachments/assets/cfa0270b-a1f8-4c98-9e2a-3bb1ed1ca9a3" />

[TestBlarb.txt](https://github.com/user-attachments/files/22391497/TestBlarb.txt)


---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
