### PR TITLE
bugfix: Correclty display math in doxygen

### DIFF
--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -42,13 +42,13 @@ jobs:
 
       # Installs libjs-mathjax for rendering mathematical notation 
       # in Doxygen documentation
-      - run: dnf install -y mathjax-perl
+      - run: dnf install -y mathjax
 
       # Install perl for bibtex
       - run: dnf install -y perl
 
-      # Install perl for bibtex
-      - run: dnf install -y perl
+        # Install doxgyen
+      - run: dnf install -y doxygen
 
       # Runs a single command using the runners shell
       - name: Build and generate documentation

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -9,7 +9,7 @@ on:
   # Triggers the workflow on push or pull request events 
   # but only for the develop branch
   push:
-    branches: [develop]
+    branches: [develop, feature/kskwarczynski/DoxyfileMath]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -23,6 +23,9 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    container:
+      image: ghcr.io/mach3-software/mach3:alma9latest
+
     permissions:
       contents: write
       id-token: write
@@ -34,26 +37,27 @@ jobs:
       # so your job can access it
       - uses: actions/checkout@v5
       
-      # Updates the package list to ensure you get the latest version of packages
-      - run: sudo apt-get update
-
       # Installs texlive for LaTeX support in Doxygen documentation
-      - run: sudo apt-get install -y texlive
+      - run: dnf install -y texlive-scheme-basic texlive-latex
 
       # Installs libjs-mathjax for rendering mathematical notation 
       # in Doxygen documentation
-      - run: sudo apt-get install -y libjs-mathjax
+      - run: dnf install -y mathjax-perl
 
       # Install perl for bibtex
-      - run: sudo apt-get install -y perl
+      - run: dnf install -y perl
+
+      # Install perl for bibtex
+      - run: dnf install -y perl
 
       # Runs a single command using the runners shell
-      - uses: DenverCoder1/doxygen-github-pages-action@v2.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          folder: Doc/html
-          branch: gh-pages
-          config_file: Doc/Doxyfile
+      - name: Build and generate documentation
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cd ..
+          doxygen Doc/Doxyfile
 
       - name: Upload Doxygen Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -9,7 +9,7 @@ on:
   # Triggers the workflow on push or pull request events 
   # but only for the develop branch
   push:
-    branches: [develop, feature/kskwarczynski/DoxyfileMath]
+    branches: [develop]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/Doc/Doxyfile
+++ b/Doc/Doxyfile
@@ -160,7 +160,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = /home/runner/work/MaCh3/MaCh3/
+STRIP_FROM_PATH        = /__w/MaCh3/MaCh3/
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -169,7 +169,7 @@ STRIP_FROM_PATH        = /home/runner/work/MaCh3/MaCh3/
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = /home/runner/work/MaCh3/MaCh3/
+STRIP_FROM_INC_PATH    = /__w/MaCh3/MaCh3/
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't

--- a/Doc/Doxyfile
+++ b/Doc/Doxyfile
@@ -1611,7 +1611,7 @@ MATHJAX_FORMAT         = HTML-CSS
 # The default value is: https://cdn.jsdelivr.net/npm/mathjax@2.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@2
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example

--- a/cmake/Templates/Doxyfile.in
+++ b/cmake/Templates/Doxyfile.in
@@ -160,7 +160,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = /home/runner/work/MaCh3/MaCh3/
+STRIP_FROM_PATH        = /__w/MaCh3/MaCh3/
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -169,7 +169,7 @@ STRIP_FROM_PATH        = /home/runner/work/MaCh3/MaCh3/
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = /home/runner/work/MaCh3/MaCh3/
+STRIP_FROM_INC_PATH    = /__w/MaCh3/MaCh3/
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't

--- a/cmake/Templates/Doxyfile.in
+++ b/cmake/Templates/Doxyfile.in
@@ -1611,7 +1611,7 @@ MATHJAX_FORMAT         = HTML-CSS
 # The default value is: https://cdn.jsdelivr.net/npm/mathjax@2.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@2
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example


### PR DESCRIPTION
# Pull request description
Math was wrongly displayed on page while it worked fine for me locally.
This is becasue mathjax wasn't correctly linked with webpage.

Now it wrosk fine

## Changes or fixes


## Examples
<img width="1638" height="1018" alt="image" src="https://github.com/user-attachments/assets/d17526d6-6409-4164-aafe-e90cf4625848" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
