### PR TITLE
bugfix: Throw error when parameter is fixed to a value out of bounds

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -915,6 +915,11 @@ void ParameterHandlerBase::ToggleFixParameter(const int i) {
       _fError[i] *= -1.0;
       MACH3LOG_INFO("Setting {}(parameter {}) to fixed at {}", GetParFancyName(i), i, _fCurrVal[i]);
     }
+    if(_fCurrVal[i] > _fUpBound[i] || _fCurrVal[i] < _fLowBound[i]) {
+      MACH3LOG_ERROR("Parameter {} (index {}) is fixed at {}, which is outside of its bounds [{}, {}]", GetParFancyName(i), i, _fCurrVal[i], _fLowBound[i], _fUpBound[i]);
+      throw MaCh3Exception(__FILE__ , __LINE__ );
+    }
+
   } else {
     PCAObj->ToggleFixParameter(i, _fNames);
   }


### PR DESCRIPTION
# Pull request description
Throw error when parameter is fixed to a value out of bounds
---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
