### PR TITLE
feat: Sanitizer for Spline File

### DIFF
--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -344,7 +344,7 @@ void FitterBase::StartFromPreviousFit(const std::string& FitName) {
 
       if (!compareYAMLNodes(CovSettings, ConfigCurrent))
       {
-        MACH3LOG_ERROR("Yaml configs in previous chain and current one are different", FitName);
+        MACH3LOG_ERROR("Yaml configs in previous chain (from path {}) and current one are different", FitName);
         throw MaCh3Exception(__FILE__ , __LINE__ );
       }
 

--- a/Fitters/MCMCProcessor.cpp
+++ b/Fitters/MCMCProcessor.cpp
@@ -4235,16 +4235,17 @@ void MCMCProcessor::PowerSpectrumAnalysis() {
     for (int jj = start; jj < end; ++jj)
     {
       std::complex<M3::float_t> a_j = 0.0;
+      const double two_pi_over_N_jj = two_pi_over_N * jj;
       for (int n = 0; n < _N; ++n)
       {
         //if(StepNumber[n] < BurnInCut) continue;
-        std::complex<M3::float_t> exp_temp(0, two_pi_over_N * jj * n);
+        std::complex<M3::float_t> exp_temp(0, two_pi_over_N_jj * n);
         a_j += ParStep[j][n] * std::exp(exp_temp);
       }
       a_j /= std::sqrt(float(_N));
       const int _c = jj - start;
 
-      k_j[j][_c] = two_pi_over_N * jj;
+      k_j[j][_c] = two_pi_over_N_jj;
       // Equation 13
       P_j[j][_c] = std::norm(a_j);
     }


### PR DESCRIPTION
# Pull request description
Spline File is supposed to be super fast to load precomputed coefficients which can directly be used by Spline Class.
There is danger person will change YAML config and expect this to work.

Easiest fix is to embed YAML config and make sure embedded matrix in Spline File and one used are same.
If not user has to remake spline file which is easy.

## Changes or fixes


## Examples
<img width="2058" height="814" alt="image" src="https://github.com/user-attachments/assets/1e9c9756-67ea-457a-b168-ffaab4f5a886" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
