### PR TITLE
feat: Update to store global step scale when using RM adaptive

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -1146,8 +1146,8 @@ void ParameterHandlerBase::UpdateAdaptiveCovariance(){
     // Also update global step scale so we're multiplying by 2.38^2/d OR our adapted scale
     bool verbose = false;
     #ifdef DEBUG
-    verbose = AdaptiveHandler->GetRobbinsMonroVerbose();
-    #endif
+    verbose = AdaptiveHandler->GetUseRobbinsMonro();
+#endif
     SetStepScale(AdaptiveHandler->GetAdaptionScale(), verbose);
 
     //Also Save the adaptive to file


### PR DESCRIPTION
# Pull request description
- Store global step scale in output chain when using Robbins-Monro
- Make RM less verbose by default
---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
