### PR TITLE
bugfix: Stop autocorr plotting hardcoding

### DIFF
--- a/Diagnostics/PlotMCMCDiag.cpp
+++ b/Diagnostics/PlotMCMCDiag.cpp
@@ -247,7 +247,9 @@ void PlotAutoCorr(TString fname1, TString flabel1, TString fname2, TString flabe
         // KS: This is unfortunately hardcoded, need to find better way to write this
         // histos.back()->GetListOfFunctions()->ls();
         RemoveFitter(histos.back().get(), "Fitter");
-        double MinValue = GetMinimumInRange(histos.back().get(), 0, 24000);
+        // KS: Very arbitrary check if autocorrelation dropped below threshold in half of consider LagL
+        double UpperEdgeBeforeLast = histos.back()->GetXaxis()->GetBinUpEdge(histos.back()->GetNbinsX()/2);
+        double MinValue = GetMinimumInRange(histos.back().get(), 0, UpperEdgeBeforeLast);
 
         if (MinValue >= 0.80)
           histos.back()->SetLineColor(kRed);

--- a/Fitters/MCMCProcessor.cpp
+++ b/Fitters/MCMCProcessor.cpp
@@ -4289,7 +4289,6 @@ void MCMCProcessor::PowerSpectrumAnalysis() {
     Posterior->SetLogx();
     Posterior->SetLogy();
     Posterior->SetGrid();
-    plot->Write(plot->GetName());
     plot->Draw("AL");
     func->Draw("SAME");
     if(printToPDF) Posterior->Print(CanvasName);


### PR DESCRIPTION
# Pull request description


## Changes or fixes
- Stop saving power spectrum to PDF, not a clue why this happened...
- Auto corr plotting was supposed to use colour coding scaling to help find if there are issues. However, 24k was hardcoded so any auto cor done with 10k for example was being shown as ALL GREEN. This is now fixed

## Examples
<img width="1293" height="995" alt="image" src="https://github.com/user-attachments/assets/bf64ddf4-b8a1-4486-b8ec-970a39eaeb83" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
