### PR TITLE
bugfix: Bring back ice cream to plotting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build*/
 install/
 Doc/html
 Doc/latex
+Doc/Doxyfile
 .cache/
 
 # Ignore emacs/vim stuff

--- a/Plotting/PlotLLH.cpp
+++ b/Plotting/PlotLLH.cpp
@@ -24,6 +24,27 @@ double ratioLabelScaling;
 
 MaCh3Plotting::PlottingManager *man;
 
+/// @brief TPad is SUPER FRAGILE, it is safer to jsut make raw pointer, while ROOT behave weirdly with smar pointes
+void SetTPads(TPad*& LLHPad, TPad*& ratioPad)
+{
+  int originalErrorLevel = gErrorIgnoreLevel;
+  gErrorIgnoreLevel = kFatal;
+  if (man->getPlotRatios())
+  {
+    LLHPad = new TPad("LLHPad", "LLHPad", 0.0, ratioPlotSplit, 1.0, 1.0);
+    LLHPad->SetBottomMargin(0.0);
+    ratioPad = new TPad("ratioPad", "ratioPad", 0.0, 0.0, 1.0, ratioPlotSplit);
+    ratioPad->SetTopMargin(0.0);
+    ratioPad->SetBottomMargin(0.3);
+  } else {
+    LLHPad = new TPad("AllSampPad", "AllSampPad", 0.0, 0.0, 1.0, 1.0);
+    ratioPad = new TPad("AllSampRatioPad", "AllSampRatioPad", 0.0, 0.0, 0.0, 0.0);
+  }
+  LLHPad->AppendPad();
+  ratioPad->AppendPad();
+  gErrorIgnoreLevel = originalErrorLevel;
+}
+
 void getSplitSampleStack(int fileIdx, std::string parameterName, TH1D LLH_allSams,
                          std::vector<float> &cumSums, std::vector<bool> &drawLabel,
                          THStack *sampleStack, TLegend *splitSamplesLegend,
@@ -122,13 +143,15 @@ void drawRatioStack(THStack *ratioCompStack) {
 void makeLLHScanComparisons(const std::string& paramName,
                             const std::string& LLHType,
                             const std::string& outputFileName,
-                            const std::unique_ptr<TCanvas>& canv,
-                            const std::unique_ptr<TPad>& LLHPad,
-                            const std::unique_ptr<TPad>& ratioPad) {
+                            const std::unique_ptr<TCanvas>& canv) {
   // will use these to make comparisons of likelihoods
   auto compStack = std::make_unique<THStack>("LLH_Stack", "");
   auto ratioCompStack = std::make_unique<THStack>("LLH_Ratio_Stack", "");
   auto legend = std::make_unique<TLegend>(0.3, 0.6, 0.7, 0.8);
+
+  TPad* LLHPad = nullptr;
+  TPad* ratioPad = nullptr;
+  SetTPads(LLHPad, ratioPad);
 
   // get the sample reweight hist from the main file
   TH1D LLH_main = man->input().getLLHScan_TH1D(0, paramName, LLHType);
@@ -210,14 +233,18 @@ void makeLLHScanComparisons(const std::string& paramName,
 
   // save to the output file
   canv->SaveAs(outputFileName.c_str());
+  delete LLHPad;
+  delete ratioPad;
 }
 
 void makeSplitSampleLLHScanComparisons(const std::string& paramName,
                                        const std::string& outputFileName,
-                                       const std::unique_ptr<TCanvas>& canv,
-                                       const std::unique_ptr<TPad>& LLHPad,
-                                       const std::unique_ptr<TPad>& ratioPad) {
+                                       const std::unique_ptr<TCanvas>& canv) {
   MACH3LOG_DEBUG(" Making split sample LLH comparison");
+  // split the canvas if plotting ratios
+  TPad* LLHPad = nullptr;
+  TPad* ratioPad = nullptr;
+  SetTPads(LLHPad, ratioPad);
   canv->Clear();
   canv->Draw();
 
@@ -305,7 +332,11 @@ void makeSplitSampleLLHScanComparisons(const std::string& paramName,
     splitSamplesStack->SetBit(kCanDelete);
     splitSamplesLegend->SetBit(kCanDelete);
 
+    int originalErrorLevel = gErrorIgnoreLevel;
+    gErrorIgnoreLevel = kFatal;
     TH1D compLLH_main = man->input().getLLHScan_TH1D(extraFileIdx, paramName, "sample");
+    compLLH_main.SetName((compLLH_main.GetName() + std::string("_file_") + extraFileIdx).Data());
+    gErrorIgnoreLevel = originalErrorLevel;
     if (compLLH_main.GetNbinsX() == 1)
     {
       delete splitSamplesStack;
@@ -340,6 +371,12 @@ void makeSplitSampleLLHScanComparisons(const std::string& paramName,
     }
     splitSamplesLegend->Draw();
 
+    // KS: Not sure why but need to plot after it's drawn otherwise ROOT throws segfault...
+    baseSplitSamplesStack->GetYaxis()->SetTitle("-2LLH_{sam}");
+    if (man->getPlotRatios() == false) baseSplitSamplesStack->GetXaxis()->SetTitle("Parameter Variation");
+    gPad->Modified();
+    gPad->Update();
+
     // need to draw the labels after other stuff or they dont show up
     for (uint i = 0; i < man->input().getTaggedSamples(man->getOption<std::vector<std::string>>("sampleTags")).size(); i++)
     {
@@ -356,9 +393,9 @@ void makeSplitSampleLLHScanComparisons(const std::string& paramName,
 
       TList *baselineHistList = baseSplitSamplesStack->GetHists();
       TList *compHistList = splitSamplesStack->GetHists();
-
       for (uint sampleIdx = 0; sampleIdx < man->input().getTaggedSamples(man->getOption<std::vector<std::string>>("sampleTags")).size(); sampleIdx++)
       {
+
         TH1D *divHist = new TH1D(
             Form("%s_%s_splitDiv_%i", paramName.c_str(), man->getFileLabel(extraFileIdx).c_str(),
                  sampleIdx),
@@ -376,11 +413,11 @@ void makeSplitSampleLLHScanComparisons(const std::string& paramName,
         ratioPad->SetGrid();
       ratioPad->Draw();
       ratioPad->cd();
-
       drawRatioStack(splitSamplesStackRatios);
     }
   }
   canv->SaveAs(outputFileName.c_str());
+  delete LLHPad;
 }
 
 int PlotLLH() {
@@ -391,20 +428,6 @@ int PlotLLH() {
   gStyle->SetOptTitle(2);
   // split up the canvas so can have side by side plots, one for each file
   auto splitSamplesCanv = std::make_unique<TCanvas>("splitSampCanv", "", 4096 * man->getNFiles(), 4096);
-
-  // split the canvas if plotting ratios
-  std::unique_ptr<TPad> LLHPad, ratioPad;
-  if (man->getPlotRatios())
-  {
-    LLHPad = std::make_unique<TPad>("LLHPad", "LLHPad", 0.0, ratioPlotSplit, 1.0, 1.0);
-    LLHPad->SetBottomMargin(0.0);
-    ratioPad = std::make_unique<TPad>("ratioPad", "ratioPad", 0.0, 0.0, 1.0, ratioPlotSplit);
-    ratioPad->SetTopMargin(0.0);
-    ratioPad->SetBottomMargin(0.3);
-  } else {
-    LLHPad = std::make_unique<TPad>("AllSampPad", "AllSampPad", 0.0, 0.0, 1.0, 1.0);
-    ratioPad = std::make_unique<TPad>("AllSampRatioPad", "AllSampRatioPad", 0.0, 0.0, 0.0, 0.0);
-  }
 
   canv->SaveAs((man->getOutputName("_Sample") + "[").c_str());
   canv->SaveAs((man->getOutputName("_Penalty") + "[").c_str());
@@ -421,21 +444,15 @@ int PlotLLH() {
     // ###############################################################
     // First lets do just the straight up likelihoods from all samples
     // ###############################################################
-
-    makeLLHScanComparisons(paramName, "sample", man->getOutputName("_Sample"), canv, LLHPad,
-                           ratioPad);
-    makeLLHScanComparisons(paramName, "penalty", man->getOutputName("_Penalty"), canv, LLHPad,
-                           ratioPad);
-    makeLLHScanComparisons(paramName, "total", man->getOutputName("_Total"), canv, LLHPad,
-                           ratioPad);
-
+    makeLLHScanComparisons(paramName, "sample", man->getOutputName("_Sample"), canv);
+    makeLLHScanComparisons(paramName, "penalty", man->getOutputName("_Penalty"), canv);
+    makeLLHScanComparisons(paramName, "total", man->getOutputName("_Total"), canv);
     // #########################################
     // ## now lets make plots split by sample ##
     // #########################################
     if (man->getSplitBySample())
     {
-      makeSplitSampleLLHScanComparisons(paramName, man->getOutputName("_bySample"),
-                                        splitSamplesCanv, LLHPad, ratioPad);
+      makeSplitSampleLLHScanComparisons(paramName, man->getOutputName("_bySample"), splitSamplesCanv);
     }
   }
 
@@ -468,6 +485,11 @@ int main(int argc, char **argv) {
 
   // scale the ratio plot labels by this much to make them same size as the normal plot
   ratioLabelScaling = (1.0 / ratioPlotSplit - 1.0);
+
+  if(man->getPlotRatios() && man->input().getNInputFiles() == 1){
+    MACH3LOG_ERROR("Can't plot ratio with single file...");
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
 
   return PlotLLH();
 }

--- a/Plotting/plottingUtils/styleManager.cpp
+++ b/Plotting/plottingUtils/styleManager.cpp
@@ -28,7 +28,7 @@ void StyleManager::setPalette(const std::string& configStyleName) const {
   }
 
   auto paletteDef = GetFromManager<std::vector<std::vector<double>>>(
-    styleDef["MarkerColor"],
+    styleDef,
     std::vector<std::vector<double>>{
       {4.0},                         // NCont
       {0.0   , 0.33  , 0.66 , 1.0},  // stops


### PR DESCRIPTION
# Pull request description
Fixes two issues related to plotting

## Changes or fixes
- ice cream weren't made because style was wrongly being set which is my fault...
- Secondly now code is not crashing when running with ratio. ratio with single file make no sense but now we have proper error. When running with ratio and split by sample code was throwing very hard to track error. tl:dr TPad is mess and it is safer to just make tpad for each plot rather than some better with smart pointers...

## Examples
<img width="1237" height="1293" alt="image" src="https://github.com/user-attachments/assets/82d57c5e-41d2-4d82-9efc-f543904e528d" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
