### PR TITLE
feat: Skip Reset if there are no shifts

### DIFF
--- a/Parameters/ParameterStructs.h
+++ b/Parameters/ParameterStructs.h
@@ -172,8 +172,6 @@ struct TypeParameterBase {
 struct NormParameter : public TypeParameterBase {
   /// Mode which parameter applies to
   std::vector<int> modes;
-  /// Horn currents which parameter applies to
-  std::vector<int> horncurrents;
   /// PDG which parameter applies to
   std::vector<int> pdgs;
   /// Preosc PDG which parameter applies to
@@ -193,7 +191,7 @@ struct NormParameter : public TypeParameterBase {
   std::vector< std::string > KinematicVarStr;
 };
 
-// HH - a shorthand type for funcpar functions
+/// HH - a shorthand type for funcpar functions
 using FuncParFuncType = std::function<void (const double*, std::size_t)>;
 // *******************
 /// @brief HH - Functional parameters
@@ -202,8 +200,6 @@ struct FunctionalParameter : public TypeParameterBase {
 // *******************
   /// Mode which parameter applies to
   std::vector<int> modes;
-  /// Horn currents which parameter applies to
-  std::vector<int> horncurrents;
   /// PDG which parameter applies to
   std::vector<int> pdgs;
   /// Preosc PDG which parameter applies to

--- a/Samples/BinningHandler.cpp
+++ b/Samples/BinningHandler.cpp
@@ -62,7 +62,8 @@ int BinningHandler::FindGlobalBin(const int NomSample,
     return GlobalBin;
   } else{
     const auto& _restrict_ BinMapping = Binning.BinGridMapping[GlobalBin];
-    for(size_t iBin = 0; iBin < BinMapping.size(); iBin++) {
+    const size_t nNonUniBins = BinMapping.size();
+    for(size_t iBin = 0; iBin < nNonUniBins; iBin++) {
       const int BinNumber = BinMapping[iBin];
       const auto& _restrict_ NonUniBin = Binning.Bins[BinNumber];
       if(NonUniBin.IsEventInside(KinVar)){

--- a/Samples/SampleHandlerFD.h
+++ b/Samples/SampleHandlerFD.h
@@ -256,21 +256,25 @@ class SampleHandlerFD :  public SampleHandlerBase
   bool IsSubEventSelected(const std::vector<KinematicCut> &SubEventCuts, const int iEvent, unsigned const int iSubEvent, size_t nsubevents);
   /// @brief HH - reset the shifted values to the original values
   virtual void ResetShifts(const int iEvent) {(void)iEvent;};
+  /// @brief HH - a grid of vectors of enums for each sample and event
+  std::vector<std::vector<FunctionalShifter*>> funcParsGrid;
+  /// @brief HH - a map that relates the funcpar enum to pointer of FuncPars
+  /// struct
+  /// HH - Changed to a vector of pointers since it's faster than unordered_map
+  /// and we are using ints as keys
+  std::vector<FunctionalShifter> funcParsMap;
+
+  /// @todo KS: Below functional variables are used only on setup, thus we should refactor them in such a way
+  /// that they are removed as class members but this would be breaking change thus keep it for the time being.
+
   /// @brief HH - a vector that stores all the FuncPars struct
   std::vector<FunctionalParameter> funcParsVec;
   /// @brief HH - a map that relates the name of the functional parameter to
   /// funcpar enum
   std::unordered_map<std::string, int> funcParsNamesMap;
-  /// @brief HH - a map that relates the funcpar enum to pointer of FuncPars
-  /// struct
-  /// HH - Changed to a vector of pointers since it's faster than unordered_map
-  /// and we are using ints as keys
-  std::vector<FunctionalParameter *> funcParsMap;
   /// @brief HH - a map that relates the funcpar enum to pointer of the actual
   /// function
   std::unordered_map<int, FuncParFuncType> funcParsFuncMap;
-  /// @brief HH - a grid of vectors of enums for each sample and event
-  std::vector<std::vector<int>> funcParsGrid;
   /// @brief HH - a vector of string names for each functional parameter
   std::vector<std::string> funcParsNamesVec = {};
 

--- a/Samples/SampleStructs.h
+++ b/Samples/SampleStructs.h
@@ -9,6 +9,7 @@
 #include "Manager/MaCh3Exception.h"
 #include "Manager/MaCh3Logger.h"
 #include "Manager/Core.h"
+#include "Parameters/ParameterStructs.h"
 
 _MaCh3_Safe_Include_Start_ //{
 // ROOT include
@@ -155,19 +156,29 @@ struct KinematicCut {
   double UpperBound = M3::_BAD_DOUBLE_;
 };
 
+// ***************************
+/// @brief Small struct used for applying shifts due to functional params
+/// @author Hank Hua
+struct FunctionalShifter {
+// ***************************
+  /// Pointer to parameter value
+  const double* valuePtr = nullptr;
+  /// Pointer to shifting function
+  FuncParFuncType* funcPtr = nullptr;
+};
 
 // ***************************
 /// @brief KS: Store bin lookups allowing to quickly find bin after migration
 struct BinShiftLookup {
 // ***************************
-  /// lower to check if Eb has moved the erec bin
-  double lower_binedge;
-  /// lower to check if Eb has moved the erec bin
-  double lower_lower_binedge;
-  /// upper to check if Eb has moved the erec bin
-  double upper_binedge;
-  /// upper to check if Eb has moved the erec bin
-  double upper_upper_binedge;
+  /// lower to check if shift has moved the event to different bin
+  double lower_binedge = M3::_BAD_DOUBLE_;
+  /// lower to check if shift has moved the event to different bin
+  double lower_lower_binedge = M3::_BAD_DOUBLE_;
+  /// upper to check if shift has moved the event to different bin
+  double upper_binedge = M3::_BAD_DOUBLE_;
+  /// upper to check if shift has moved the event to different bin
+  double upper_upper_binedge = M3::_BAD_DOUBLE_;
 };
 
 // ***************************


### PR DESCRIPTION
# Pull request description
Shifts can be expensive and depending on setting there might be plenty of events which are not shifted.
If event are not shifted, then there is no point in resetting.

In addition, slightly modifies data structures used for shifting.
Instead of enum grid, we store a pointer to  `FunctionalShifter` which is a new struct holding only `std:: function` and `pointer value`. By being smaller, it should allow better cache performance.

In addition, removes `horncurrents `which are not used any more.

Using simplistic benchmark we should see performance increase. Test done with tutorial, so with actual improvement, will be smaller.
<img width="885" height="689" alt="image" src="https://github.com/user-attachments/assets/350dd983-32af-4b89-93d7-8efdf1bed464" />

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
