### PR TITLE
tidy: Add GLoBESN and tidy cmake

### DIFF
--- a/.github/workflows/CDImage.yml
+++ b/.github/workflows/CDImage.yml
@@ -29,16 +29,8 @@ jobs:
           - os: rocky9cuda
             file: Doc/MaCh3DockerFiles/Rocky9/Dockerfile
             tag_latest: rocky9cudalatest
-            cmakeoptions: -DMaCh3_PYTHON_ENABLED=ON -DNuFastLinear_ENABLED=ON -DCUDAProb3_ENABLED=ON -DProb3ppLinear_ENABLED=ON
+            cmakeoptions: -DMaCh3_PYTHON_ENABLED=ON -DNuFastLinear_ENABLED=ON -DCUDAProb3Linear_ENABLED=ON -DCUDAProb3_ENABLED=ON -DProb3ppLinear_ENABLED=ON -DProbGPU_ENABLED=ON
             installoptions: -j4
-#          - os: ubuntu22.04
-#            file: Doc/MaCh3DockerFiles/Ubuntu22.04/Dockerfile
-#            tag_latest: ubuntu22.04latest
-#            installoptions: -j4
-#          - os: fedora32
-#            file: Doc/MaCh3DockerFiles/Fedora32/Dockerfile
-#            tag_latest: fedora32latest
-#            installoptions: -j4
 
     name: Image CD ${{ matrix.os }}
 

--- a/.github/workflows/CIFindPackage.yml
+++ b/.github/workflows/CIFindPackage.yml
@@ -24,7 +24,7 @@ jobs:
 
           - name: Find Package Rocky9 CUDA
             container: ghcr.io/mach3-software/mach3:rocky9cudav2.2.0
-            cmakeoptions: -DMaCh3_PYTHON_ENABLED=ON -DNuFastLinear_ENABLED=ON -DCUDAProb3_ENABLED=ON -DProb3ppLinear_ENABLED=ON
+            cmakeoptions: -DMaCh3_PYTHON_ENABLED=ON -DNuFastLinear_ENABLED=ON -DCUDAProb3Linear_ENABLED=ON -DCUDAProb3_ENABLED=ON -DProb3ppLinear_ENABLED=ON -DProbGPU_ENABLED=ON
 
     name: ${{ matrix.name }}
 

--- a/cmake/Modules/NuOscillatorSetup.cmake
+++ b/cmake/Modules/NuOscillatorSetup.cmake
@@ -5,15 +5,16 @@ set(OSCILLATOR_OPTIONS
     CUDAProb3
     ProbGPULinear
     Prob3ppLinear
-    NuFASTLinear
+    NuFastLinear
     NuSQUIDSLinear
     OscProb
     GLoBESLinear
 )
+
 # KS: Tells whether all oscillators were disabled
 set(ALL_OSCILLATORS_DISABLED TRUE)
 
-# KS: Oscillation calculation
+# Oscillation calculation
 foreach(option IN LISTS OSCILLATOR_OPTIONS)
     DefineEnabledRequiredSwitch(${option}_ENABLED FALSE)
     # If at least one oscillator is enabled then set ALL_OSCILLATORS_DISABLED to false
@@ -24,7 +25,7 @@ endforeach()
 
 #KS: If all Oscillators are turned off then enable NuFastLinear_ENABLED and CUDAProb3_ENABLED
 if(ALL_OSCILLATORS_DISABLED)
-    set(NuFASTLinear_ENABLED TRUE)
+    set(NuFastLinear_ENABLED TRUE)
     set(CUDAProb3_ENABLED TRUE)
 endif()
 
@@ -34,16 +35,17 @@ foreach(option IN LISTS OSCILLATOR_OPTIONS)
   if(${option}_ENABLED)
     LIST(APPEND MaCh3_Oscillator_ENABLED ${option})
   endif()
-
-  #NuOscillator uses 1/0 instead of true/false thus use conversion
-  IsTrue(${option}_ENABLED USE_${option})
 endforeach()
 
-# Prepare the options for CPMAddPackage
-set(NUOSCILLATOR_OPTIONS "")
-foreach(option IN LISTS OSCILLATOR_OPTIONS)
-    list(APPEND NUOSCILLATOR_OPTIONS "Use${option} ${USE_${option}}")
-endforeach()
+#NuOscillator uses 1/0 instead of true/false thus use conversion
+IsTrue(CUDAProb3Linear_ENABLED USE_CUDAProb3Linear)
+IsTrue(CUDAProb3_ENABLED USE_CUDAProb3)
+IsTrue(ProbGPULinear_ENABLED USE_ProbGPULinear)
+IsTrue(Prob3ppLinear_ENABLED USE_Prob3ppLinear)
+IsTrue(NuFastLinear_ENABLED USE_NuFastLinear)
+IsTrue(NuSQUIDSLinear_ENABLED USE_NuSQUIDSLinear)
+IsTrue(OscProb_ENABLED USE_OscProb)
+IsTrue(GLoBESLinear_ENABLED USE_GLoBESLinear)
 
 #Also additional flags
 IsTrue(MaCh3_GPU_ENABLED DAN_USE_GPU)
@@ -80,7 +82,14 @@ CPMAddPackage(
     "UseMultithreading ${DAN_USE_MULTITHREAD}"
     "UseDoubles ${DAN_DOUBLE}"
 
-    ${NUOSCILLATOR_OPTIONS}
+    "UseCUDAProb3Linear ${USE_CUDAProb3Linear}"
+    "UseCUDAProb3 ${USE_CUDAProb3}"
+    "UseProbGPULinear ${USE_ProbGPULinear}"
+    "UseProb3ppLinear ${USE_Prob3ppLinear}"
+    "UseNuFASTLinear  ${USE_NuFastLinear}"
+    "UseNuSQUIDSLinear  ${USE_NuSQUIDSLinear}"
+    "UseOscProb ${USE_OscProb}"
+    "UseGLoBESLinear ${USE_GLoBESLinear}"
 
     "NuOscillator_Compiler_Flags ${cpu_compile_options_string}"
     "CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_STRING}"

--- a/cmake/Modules/NuOscillatorSetup.cmake
+++ b/cmake/Modules/NuOscillatorSetup.cmake
@@ -1,50 +1,49 @@
 ################################## Oscillation ################################
+# KS: Define the list of oscillator options
+set(OSCILLATOR_OPTIONS
+    CUDAProb3Linear
+    CUDAProb3
+    ProbGPULinear
+    Prob3ppLinear
+    NuFASTLinear
+    NuSQUIDSLinear
+    OscProb
+    GLoBESLinear
+)
+# KS: Tells whether all oscillators were disabled
+set(ALL_OSCILLATORS_DISABLED TRUE)
 
-# Oscillation calculation
-DefineEnabledRequiredSwitch(CUDAProb3Linear_ENABLED FALSE)
-DefineEnabledRequiredSwitch(CUDAProb3_ENABLED FALSE)
-DefineEnabledRequiredSwitch(ProbGPULinear_ENABLED FALSE)
-DefineEnabledRequiredSwitch(Prob3ppLinear_ENABLED FALSE)
-DefineEnabledRequiredSwitch(NuFastLinear_ENABLED FALSE)
-DefineEnabledRequiredSwitch(NuSQUIDSLinear_ENABLED FALSE)
-DefineEnabledRequiredSwitch(OscProb_ENABLED FALSE)
+# KS: Oscillation calculation
+foreach(option IN LISTS OSCILLATOR_OPTIONS)
+    DefineEnabledRequiredSwitch(${option}_ENABLED FALSE)
+    # If at least one oscillator is enabled then set ALL_OSCILLATORS_DISABLED to false
+    if(${option}_ENABLED)
+      set(ALL_OSCILLATORS_DISABLED FALSE)
+  endif()
+endforeach()
 
 #KS: If all Oscillators are turned off then enable NuFastLinear_ENABLED and CUDAProb3_ENABLED
-if (NOT CUDAProb3Linear_ENABLED AND
-    NOT CUDAProb3_ENABLED AND
-    NOT ProbGPULinear_ENABLED AND
-    NOT Prob3ppLinear_ENABLED AND
-    NOT NuFastLinear_ENABLED AND
-    NOT NuSQUIDSLinear_ENABLED AND
-    NOT OscProb_ENABLED)
-    set(NuFastLinear_ENABLED TRUE)
+if(ALL_OSCILLATORS_DISABLED)
+    set(NuFASTLinear_ENABLED TRUE)
     set(CUDAProb3_ENABLED TRUE)
 endif()
 
 #KS: Save which oscillators are being used
 set(MaCh3_Oscillator_ENABLED "")
-foreach(option
-    CUDAProb3Linear
-    CUDAProb3
-    ProbGPULinear
-    Prob3ppLinear
-    NuFastLinear
-    NuSQUIDSLinear
-    OscProb
-    )
+foreach(option IN LISTS OSCILLATOR_OPTIONS)
   if(${option}_ENABLED)
     LIST(APPEND MaCh3_Oscillator_ENABLED ${option})
   endif()
+
+  #NuOscillator uses 1/0 instead of true/false thus use conversion
+  IsTrue(${option}_ENABLED USE_${option})
 endforeach()
 
-#NuOscillator uses 1/0 instead of true/false thus use conversion
-IsTrue(CUDAProb3Linear_ENABLED USE_CUDAProb3Linear)
-IsTrue(CUDAProb3_ENABLED USE_CUDAProb3)
-IsTrue(ProbGPULinear_ENABLED USE_ProbGPULinear)
-IsTrue(Prob3ppLinear_ENABLED USE_Prob3ppLinear)
-IsTrue(NuFastLinear_ENABLED USE_NuFastLinear)
-IsTrue(NuSQUIDSLinear_ENABLED USE_NuSQUIDSLinear)
-IsTrue(OscProb_ENABLED USE_OscProb)
+# Prepare the options for CPMAddPackage
+set(NUOSCILLATOR_OPTIONS "")
+foreach(option IN LISTS OSCILLATOR_OPTIONS)
+    list(APPEND NUOSCILLATOR_OPTIONS "Use${option} ${USE_${option}}")
+endforeach()
 
 #Also additional flags
 IsTrue(MaCh3_GPU_ENABLED DAN_USE_GPU)
@@ -81,13 +80,7 @@ CPMAddPackage(
     "UseMultithreading ${DAN_USE_MULTITHREAD}"
     "UseDoubles ${DAN_DOUBLE}"
 
-    "UseCUDAProb3Linear ${USE_CUDAProb3Linear}"
-    "UseCUDAProb3 ${USE_CUDAProb3}"
-    "UseProbGPULinear ${USE_ProbGPULinear}"
-    "UseProb3ppLinear ${USE_Prob3ppLinear}"
-    "UseNuFASTLinear  ${USE_NuFastLinear}"
-    "UseNuSQUIDSLinear  ${USE_NuSQUIDSLinear}"
-    "UseOscProb ${USE_OscProb}"
+    ${NUOSCILLATOR_OPTIONS}
 
     "NuOscillator_Compiler_Flags ${cpu_compile_options_string}"
     "CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_STRING}"


### PR DESCRIPTION
# Pull request description
In our cmake there was plenty of copying and pasting. Now to add engine one need to simply expand OSCILLATOR_OPTIONS while before it require at least 4 different LOC.

Also GLoBES engine was missing.

## Examples
<img width="1793" height="747" alt="image" src="https://github.com/user-attachments/assets/33c381ed-42ea-434a-ad00-e53e4c7f4473" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
