### PR TITLE
bugfix: Allow post pred from NDonly

### DIFF
--- a/.github/workflows/Telemetry.yml
+++ b/.github/workflows/Telemetry.yml
@@ -22,11 +22,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Run MaCh3 Validations
-        uses: ./.github/actions/mach3-validations
-        with:
-          mach3_branch: ${{ github.head_ref }}
-          compilation_flags: ""
+      - name: Get MaCh3 Validations
+        run: |
+          cd /opt/
+          # Clone the MaCh3Tutorial repository with the current branch
+          git clone --branch main https://github.com/mach3-software/MaCh3Tutorial.git MaCh3Validations
+          cd MaCh3Validations
+          mkdir build
+          cd build
+          cmake ../ -DMaCh3_Branch=${{ github.head_ref }}
+
+      - name: Build MaCh3 Validations
+        run: |
+          cd /opt/MaCh3Validations/build
+          make -j4 install # Build and install the project
 
       - name: Run memory telemetry and generate plot
         run: |

--- a/Fitters/PredictiveThrower.h
+++ b/Fitters/PredictiveThrower.h
@@ -71,6 +71,9 @@ class PredictiveThrower : public FitterBase {
   /// @brief Setup sample information
   void SetupSampleInformation();
 
+  /// @brief Get Fancy parameters stored in mcmc chains for passed ParameterHandler
+  std::vector<std::string> GetStoredFancyName(ParameterHandlerBase* Systematics) const;
+
   /// @brief Produce posterior predictive distribution
   std::vector<std::unique_ptr<TH1>> MakePredictive(const std::vector<std::vector<std::unique_ptr<TH1>>>& Toys,
                                                    const std::vector<TDirectory*>& Director,

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -391,13 +391,20 @@ class ParameterHandlerBase {
   /// @brief Matches branches in a TTree to parameters in a systematic handler.
   ///
   /// @param PosteriorFile Pointer to the ROOT TTree from MaCh3 fit.
-  /// @param[out] BranchValues Vector to store the values of the branches (resized inside).
-  /// @param[out] BranchNames Vector to store the names of the branches (resized inside).
+  /// @param BranchValues Vector to store the values of the branches (resized inside).
+  /// @param BranchNames Vector to store the names of the branches (resized inside).
+  /// @param FancyNames Optional vector of "fancy names" to match. If empty, all parameters are matched.
+  ///
+  ///  - If `FancyNames` is provided, it matches only the parameters whose "fancy names"
+  ///    are in `FancyNames`. This is useful for studies where one performs ND fits and passes
+  ///    them to FD fits, which may have additional parameters (e.g., oscillations).
+  ///  - If `FancyNames` is empty, it matches all parameters in the systematic handler.
   ///
   /// @throws MaCh3Exception if any parameter branch is uninitialized.
   void MatchMaCh3OutputBranches(TTree *PosteriorFile,
                                 std::vector<double>& BranchValues,
-                                std::vector<std::string>& BranchNames);
+                                std::vector<std::string>& BranchNames,
+                                const std::vector<std::string>& FancyNames = {});
 
 protected:
   /// @brief Initialisation of the class using matrix from root file


### PR DESCRIPTION
# Pull request description
One usually runs ND only chain without osc parameters. Then uses this chain to test post pred for SK code.
After merge of Osc and Generic only way for above workflow to work is to run ND chain with osc parameters.

This PR addresses this issue. Now matching is done more smartly as demonstrated by plots below

## Examples
<img width="586" height="258" alt="blarb" src="https://github.com/user-attachments/assets/68e03bf5-7f6b-4e05-b4ff-401963b825d2" />

[Overlay_Predictive.pdf](https://github.com/user-attachments/files/25289770/Overlay_Predictive.pdf)


---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
