### PR TITLE
feat: Masking for IsEventInside

### DIFF
--- a/Samples/BinningHandler.cpp
+++ b/Samples/BinningHandler.cpp
@@ -60,7 +60,7 @@ int BinningHandler::FindGlobalBin(const int NomSample,
   if(Binning.Uniform) {
     GlobalBin += static_cast<int>(Binning.GlobalOffset);
     return GlobalBin;
-  } else{
+  } else {
     const auto& _restrict_ BinMapping = Binning.BinGridMapping[GlobalBin];
     const size_t nNonUniBins = BinMapping.size();
     for(size_t iBin = 0; iBin < nNonUniBins; iBin++) {

--- a/Samples/FarDetectorCoreInfoStruct.h
+++ b/Samples/FarDetectorCoreInfoStruct.h
@@ -77,6 +77,7 @@ struct SampleInfo {
 /// @author Dan Barrow
 /// @author Ed Atkin
 /// @author Kamil Skwarczynski
+/// @warning Try to no add more variables here as it will impact RAM usage
 struct EventInfo {
   /// @brief Default constructor.
   EventInfo(){}

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -405,7 +405,7 @@ void SampleHandlerFD::FillArray() {
 // ************************************************
 /// Multithreaded version of fillArray @see fillArray()
 void SampleHandlerFD::FillArray_MP() {
-// ************************************************
+  // ************************************************
   //DB Reset which cuts to apply
   Selection = StoredSelection;
 

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -402,10 +402,10 @@ void SampleHandlerFD::FillArray() {
 #ifdef MULTITHREAD
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Walloca"
-// ************************************************
+// ************************************************ 
 /// Multithreaded version of fillArray @see fillArray()
 void SampleHandlerFD::FillArray_MP() {
-  // ************************************************
+// ************************************************
   //DB Reset which cuts to apply
   Selection = StoredSelection;
 

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -402,7 +402,7 @@ void SampleHandlerFD::FillArray() {
 #ifdef MULTITHREAD
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Walloca"
-// ************************************************ 
+// ************************************************
 /// Multithreaded version of fillArray @see fillArray()
 void SampleHandlerFD::FillArray_MP() {
 // ************************************************

--- a/Samples/SampleHandlerFD.h
+++ b/Samples/SampleHandlerFD.h
@@ -291,7 +291,7 @@ class SampleHandlerFD :  public SampleHandlerBase
   std::vector<std::string> funcParsNamesVec = {};
 
   /// @brief Check whether a normalisation systematic affects an event or not
-  void CalcNormsBins(std::vector<NormParameter>& norm_parameters, std::vector< std::vector< int > >& xsec_norms_bins);
+  void CalcNormsBins(std::vector<NormParameter>& norm_parameters, std::vector< std::vector< int > >& norms_bins);
   template <typename ParT> bool PassesSelection(const ParT& Par, std::size_t iEvent);
   /// @brief Calculate the total weight weight for a given event
   M3::float_t CalcWeightTotal(const EventInfo* _restrict_ MCEvent) const;
@@ -367,8 +367,7 @@ class SampleHandlerFD :  public SampleHandlerBase
 
   //===============================================================================
   //DB Covariance Objects
-  //ETA - All experiments will need an xsec, det and osc cov
-  //these should be added to SampleHandlerBase to be honest
+  /// ETA - All experiments will need an xsec, det and osc cov
   ParameterHandlerGeneric *ParHandler = nullptr;
 
   //=============================================================================== 

--- a/Samples/SampleStructs.h
+++ b/Samples/SampleStructs.h
@@ -93,12 +93,12 @@ inline std::string TargetMat_ToString(const TargetMat i) {
 /// Enum to track the incoming neutrino species
 enum NuPDG {
 // *****************
-  kNue = 12,
-  kNumu = 14,
-  kNutau = 16,
-  kNueBar = -12,
-  kNumuBar = -14,
-  kNutauBar = -16
+  kNue      = 12,   //!< Electron neutrino
+  kNumu     = 14,   //!< Muon neutrino
+  kNutau    = 16,   //!< Tau neutrino
+  kNueBar   = -12,  //!< Electron antineutrino
+  kNumuBar  = -14,  //!< Muon antineutrino
+  kNutauBar = -16   //!< Tau antineutrino
 };
 
 /// Make an enum of the test statistic that we're using
@@ -780,7 +780,7 @@ namespace MaCh3Utils {
   /// @brief Convert from PDG flavour to NuOscillator type
   /// beware that in the case of anti-neutrinos the NuOscillator
   /// type simply gets multiplied by -1
-  inline int PDGToNuOscillatorFlavour(const int NuPdg){
+  inline int PDGToNuOscillatorFlavour(const int NuPdg) {
     int NuOscillatorFlavour = M3::_BAD_INT_;
     switch(std::abs(NuPdg)){
       case NuPDG::kNue:

--- a/Samples/SampleStructs.h
+++ b/Samples/SampleStructs.h
@@ -724,7 +724,7 @@ namespace MaCh3Utils {
   /// @todo this could be constexpr in c++17
   /// @cite pdg2024 (particle masses)
   /// @cite ame2020 (nuclear masses)
-  constexpr double GetMassFromPDG(const int PDG) {
+  inline double GetMassFromPDG(const int PDG) {
   // *****************************
     switch (abs(PDG)) {
       // Leptons

--- a/Splines/SplineMonolith.cpp
+++ b/Splines/SplineMonolith.cpp
@@ -885,7 +885,7 @@ void SMonolith::ModifyWeights(){
 
     // Compute total weight for the current event
     #ifdef MULTITHREAD
-    #pragma omp simd
+    #pragma omp simd reduction(*:totalWeight)
     #endif
     for (unsigned int id = 0; id < numParams; ++id) {
       totalWeight *= cpu_weights_spline_var[startIndex + id];
@@ -897,7 +897,7 @@ void SMonolith::ModifyWeights(){
 
     // Compute total weight for the current event
     #ifdef MULTITHREAD
-    #pragma omp simd
+    #pragma omp simd reduction(*:totalWeight)
     #endif
     for (unsigned int id = 0; id < numParams_tf1; ++id) {
       totalWeight *= cpu_weights_tf1_var[startIndex_tf1 + id];


### PR DESCRIPTION
# Pull request description
If using NonUniform number of calls per step will be `number of events x number of PolyBins per MappingBin`.
Which can of order of 10.

By using masking, one makes more predictable. Since whole operation is SUPER easy. Even if we do it more often, it still make performance better.

Only around dimension 10 it starts to getting to Plateau.
## Examples

<img width="667" height="365" alt="image" src="https://github.com/user-attachments/assets/fc4cbe27-d464-4054-a506-c48318667ac3" />


[test_IsEventInside.txt](https://github.com/user-attachments/files/25322405/test_IsEventInside.txt)



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
