### PR TITLE
bugfix: Improve starting from previous chain

### DIFF
--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -350,7 +350,7 @@ void FitterBase::StartFromPreviousFit(const std::string& FitName) {
   MACH3LOG_INFO("Getting starting position from {}", FitName);
   TFile *infile = M3::Open(FitName, "READ", __FILE__, __LINE__);
   TTree *posts = infile->Get<TTree>("posteriors");
-  int step_val = 0;
+  unsigned int step_val = 0;
   double log_val = M3::_LARGE_LOGL_;
   posts->SetBranchAddress("step",&step_val);
   posts->SetBranchAddress("LogL",&log_val);
@@ -397,7 +397,7 @@ void FitterBase::StartFromPreviousFit(const std::string& FitName) {
     }
   }
   logLCurr = log_val;
-
+  logLProp = log_val;
   delete posts;
   infile->Close();
   delete infile;

--- a/Fitters/MCMCBase.cpp
+++ b/Fitters/MCMCBase.cpp
@@ -43,12 +43,15 @@ void MCMCBase::RunMCMC() {
     // Print Progress before Propose Step
     PrintProgress(false);
 
-    // Reconfigure the samples, systematics and oscillation for first weight
-    // ProposeStep sets logLProp
-    ProposeStep();
-    // Set the current logL to the proposed logL for the 0th step
-    // Accept the first step to set logLCurr: this shouldn't affect the MCMC because we ignore the first N steps in burn-in
-    logLCurr = logLProp;
+    // Only propose step if we are running fresh chain. If we are running from previous chain then it's not needed and we can use usual pipeline
+    if(stepStart == 0) {
+        // Reconfigure the samples, systematics and oscillation for first weight
+        // ProposeStep sets logLProp
+        ProposeStep();
+        // Set the current logL to the proposed logL for the 0th step
+        // Accept the first step to set logLCurr: this shouldn't affect the MCMC because we ignore the first N steps in burn-in
+        logLCurr = logLProp;
+    }
 
     // Begin MCMC
     const auto StepEnd = stepStart + chainLength;
@@ -58,7 +61,6 @@ void MCMCBase::RunMCMC() {
     }
     // Save all the MCMC output
     SaveOutput();
-
 
     // Process MCMC
     ProcessMCMC();


### PR DESCRIPTION
# Pull request description
Run fresh chain with arbitrary wrong starting position, so LLH was huge. Started new chain from it and LLH was better. Indicating start from previous work.

We had inefficiency that before main MCMC we propose step and `logLCurr = logLProp;`
Effectively accepting step...
With oscillation params like delta m2 it is quite easy to flip into unfavoured ordering. Especially for DUNE where error was observed.

The solution was to not propose step and setting as "start LLH" but to load it directly from chain.

Even though it is called bug fix it does NOT affect physics. Only sampling was less effective.

**Confirmed reasoning with Dan (hold my DAQ) Barrow**

## Examples
Left is default, right start from
<img width="2292" height="785" alt="image" src="https://github.com/user-attachments/assets/0f9c0946-34ef-46f7-ac08-7a2fdb6ac41a" />

New chain
<img width="591" height="297" alt="NewChain" src="https://github.com/user-attachments/assets/5a7e86b2-1bdb-406d-9682-b8b042820a89" />

<img width="747" height="294" alt="StartPrevious" src="https://github.com/user-attachments/assets/23804ce7-3b95-4dcd-8874-1df285d5c022" />

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
