### PR TITLE
feat: Post Pred and Flexible binning

### DIFF
--- a/.github/workflows/WeeklyValgrind.yml
+++ b/.github/workflows/WeeklyValgrind.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run MaCh3 Validations
-        uses: ./.github/actions/mach3-validations
+        uses: ./.github/actions/mach3-tutorial
         with:
           mach3_branch: "main"
           compilation_flags: ""

--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -1319,6 +1319,7 @@ void WriteHistograms(TH1 *hist, const std::string& baseName) {
   }
   hist->SetDirectory(nullptr);
   hist->Write(baseName.c_str());
+  delete hist;
 }
 
 // *************************
@@ -1342,7 +1343,6 @@ void WriteHistogramsByMode(SampleHandlerBase *sample,
         for (int iMode = 0; iMode < modes->GetNModes(); ++iMode) {
           auto modeHist = sample->Get1DVarHistByModeAndChannel(iSample, ProjectionName, iMode);
           WriteHistograms(modeHist, sampleName + "_" + modes->GetMaCh3ModeName(iMode) + ProjectionSuffix + suffix);
-          delete modeHist;
         }
       }
 
@@ -1350,7 +1350,6 @@ void WriteHistogramsByMode(SampleHandlerBase *sample,
         for (int iChan = 0; iChan < sample->GetNOscChannels(iSample); ++iChan) {
           auto chanHist = sample->Get1DVarHistByModeAndChannel(iSample, ProjectionName, -1, iChan); // -1 skips over mode plotting
           WriteHistograms(chanHist, sampleName + "_" + sample->GetFlavourName(iSample, iChan) + ProjectionSuffix + suffix);
-          delete chanHist;
         }
       }
 
@@ -1359,7 +1358,6 @@ void WriteHistogramsByMode(SampleHandlerBase *sample,
           for (int iChan = 0; iChan < sample->GetNOscChannels(iSample); ++iChan) {
             auto hist = sample->Get1DVarHistByModeAndChannel(iSample, ProjectionName, iMode, iChan);
             WriteHistograms(hist, sampleName + "_" + modes->GetMaCh3ModeName(iMode) + "_" + sample->GetFlavourName(iSample, iChan) + ProjectionSuffix + suffix);
-            delete hist;
           }
         }
       }
@@ -1367,7 +1365,6 @@ void WriteHistogramsByMode(SampleHandlerBase *sample,
       if (!by_mode && !by_channel) {
         auto hist = sample->Get1DVarHist(iSample, ProjectionName);
         WriteHistograms(hist, sampleName + ProjectionSuffix + suffix);
-        delete hist;
         // Only for 2D and Beyond
         for (int iDim2 = iDim1 + 1; iDim2 < sample->GetNDim(iSample); ++iDim2) {
           // Get the names for the two dimensions
@@ -1380,9 +1377,6 @@ void WriteHistogramsByMode(SampleHandlerBase *sample,
           // Write the histogram
           std::string suffix2D = "_2DProj_" + std::to_string(iDim1) + "_vs_" + std::to_string(iDim2) + suffix;
           WriteHistograms(hist2D, sampleName + suffix2D);
-
-          // Clean up
-          delete hist2D;
         }
       }
     }

--- a/Fitters/PredictiveThrower.cpp
+++ b/Fitters/PredictiveThrower.cpp
@@ -889,7 +889,6 @@ std::vector<std::unique_ptr<TH1>> PredictiveThrower::MakePredictive(const std::v
             for (int ix = 1; ix <= nbinsx; ++ix) {
               int Bin = (iy-1) * nbinsx + (ix-1);
               double content = Toys[sample][iToy]->GetBinContent(ix, iy);
-              Posterior_hist[sample][Bin];
               Posterior_hist[sample][Bin]->Fill(content, ReweightWeight[iToy]);
             } // end loop over X bins
           } // end loop over Y bins

--- a/Fitters/PredictiveThrower.cpp
+++ b/Fitters/PredictiveThrower.cpp
@@ -6,11 +6,16 @@
 // *************************
 PredictiveThrower::PredictiveThrower(Manager *man) : FitterBase(man) {
 // *************************
- AlgorithmName = "PredictiveThrower";
+  AlgorithmName = "PredictiveThrower";
   if(!CheckNodeExists(fitMan->raw(), "Predictive")) {
    MACH3LOG_ERROR("Predictive is missing in your main yaml config");
    throw MaCh3Exception(__FILE__ , __LINE__ );
   }
+
+  StandardFluctuation = GetFromManager<bool>(fitMan->raw()["Predictive"]["StandardFluctuation"], true, __FILE__, __LINE__ );
+
+  if(StandardFluctuation) MACH3LOG_INFO("Using standard method of statistical fluctuation");
+  else MACH3LOG_INFO("Using alternative method of statistical fluctuation, which is much slower");
 
   ModelSystematic = nullptr;
   // Use the full likelihood for the Prior/Posterior predictive pvalue
@@ -66,13 +71,7 @@ void PredictiveThrower::SetParamters() {
 void PredictiveThrower::SetupSampleInformation() {
 // *************************
   TotalNumberOfSamples = 0;
-  for (size_t iPDF = 0; iPDF < samples.size(); iPDF++)
-  {
-    auto* MaCh3Sample = dynamic_cast<SampleHandlerFD*>(samples[iPDF]);
-    if (!MaCh3Sample) {
-      MACH3LOG_ERROR("Sample {} do not inherit from SampleHandlerFD this is not implemented", samples[iPDF]->GetName());
-      throw MaCh3Exception(__FILE__, __LINE__);
-    }
+  for (size_t iPDF = 0; iPDF < samples.size(); iPDF++) {
     TotalNumberOfSamples += samples[iPDF]->GetNsamples();
   }
 
@@ -94,8 +93,7 @@ void PredictiveThrower::SetupSampleInformation() {
     for (int SampleIndex = 0; SampleIndex < samples[iPDF]->GetNsamples(); ++SampleIndex) {
       SampleInfo[counter].Name = samples[iPDF]->GetSampleTitle(SampleIndex);
       SampleInfo[counter].LocalId = SampleIndex;
-      SampleInfo[counter].SamHandler = dynamic_cast<SampleHandlerFD*>(samples[iPDF]);
-      SampleInfo[counter].Binning = SampleInfo[counter].SamHandler->GetBinningHandler();
+      SampleInfo[counter].SamHandler = samples[iPDF];
       SampleInfo[counter].Dimenstion = SampleInfo[counter].SamHandler->GetNDim(SampleIndex);
       counter++;
     }
@@ -326,6 +324,67 @@ std::vector<std::string> PredictiveThrower::GetStoredFancyName(ParameterHandlerB
   return FancyNames;
 }
 
+
+// *************************
+void PredictiveThrower::WriteToy(TDirectory* ToyDirectory,
+                                 TDirectory* Toy_1DDirectory,
+                                 TDirectory* Toy_2DDirectory,
+                                 const int iToy) {
+// *************************
+  int SampleCounter = 0;
+  for (size_t iPDF = 0; iPDF < samples.size(); iPDF++)
+  {
+    auto* SampleHandler = samples[iPDF];
+    for (int iSample = 0; iSample < SampleHandler->GetNsamples(); ++iSample)
+    {
+      ToyDirectory->cd();
+
+      auto SampleName = SampleHandler->GetSampleTitle(iSample);
+      TH1* MCHist = SampleHandler->GetMCHist(iSample);
+      MC_Hist_Toy[SampleCounter][iToy] = M3::Clone(MCHist, SampleName + "_mc_" + std::to_string(iToy));
+      MC_Hist_Toy[SampleCounter][iToy]->Write();
+
+      TH1* W2Hist = SampleHandler->GetW2Hist(iSample);
+      W2_Hist_Toy[SampleCounter][iToy] = M3::Clone(W2Hist, SampleName + "_w2_" + std::to_string(iToy));
+      W2_Hist_Toy[SampleCounter][iToy]->Write();
+
+      // now get 1D projection for every dimension
+      Toy_1DDirectory->cd();
+      for(int iDim = 0; iDim < SampleHandler->GetNDim(iSample); iDim++) {
+        std::string ProjectionName = SampleHandler->GetKinVarName(iSample, iDim);
+        std::string ProjectionSuffix = "_1DProj" + std::to_string(iDim) + "_" + std::to_string(iToy);
+
+        auto hist = SampleHandler->Get1DVarHist(iSample, ProjectionName);
+        hist->SetTitle((SampleName + ProjectionSuffix).c_str());
+        hist->SetName((SampleName + ProjectionSuffix).c_str());
+        hist->Write();
+        delete hist;
+      }
+
+      Toy_2DDirectory->cd();
+      // now get 2D projection for every combination
+      for(int iDim1 = 0; iDim1 < SampleHandler->GetNDim(iSample); iDim1++) {
+        for (int iDim2 = iDim1 + 1; iDim2 < SampleHandler->GetNDim(iSample); ++iDim2) {
+          // Get the names for the two dimensions
+          std::string XVarName = SampleHandler->GetKinVarName(iSample, iDim1);
+          std::string YVarName = SampleHandler->GetKinVarName(iSample, iDim2);
+
+          // Get the 2D histogram for this pair
+          auto hist2D = SampleHandler->Get2DVarHist(iSample, XVarName, YVarName);
+
+          // Write the histogram
+          std::string suffix2D = "_2DProj_" + std::to_string(iDim1) + "_vs_" + std::to_string(iDim2) + "_" + std::to_string(iToy);
+          hist2D->SetTitle((SampleName + suffix2D).c_str());
+          hist2D->SetName((SampleName + suffix2D).c_str());
+          hist2D->Write();
+          delete hist2D;
+        }
+      }
+      SampleCounter++;
+    }
+  }
+}
+
 // *************************
 // Produce MaCh3 toys:
 void PredictiveThrower::ProduceToys() {
@@ -392,6 +451,8 @@ void PredictiveThrower::ProduceToys() {
     }
   }
 
+  TDirectory* Toy_1DDirectory = outputFile->mkdir("Toys_1DHistVar");
+  TDirectory* Toy_2DDirectory = outputFile->mkdir("Toys_2DHistVar");
   /// this store value of parameters sampled from a chain
   std::vector<std::vector<double>> branch_vals(systematics.size());
   std::vector<std::vector<std::string>> branch_name(systematics.size());
@@ -484,23 +545,8 @@ void PredictiveThrower::ProduceToys() {
     for (size_t iPDF = 0; iPDF < samples.size(); iPDF++) {
       samples[iPDF]->Reweight();
     }
-
-    SampleCounter = 0;
-    for (size_t iPDF = 0; iPDF < samples.size(); iPDF++)
-    {
-      auto* MaCh3Sample = dynamic_cast<SampleHandlerFD*>(samples[iPDF]);
-      for (int SampleIndex = 0; SampleIndex < MaCh3Sample->GetNsamples(); ++SampleIndex)
-      {
-        TH1* MCHist = MaCh3Sample->GetMCHist(SampleIndex);
-        MC_Hist_Toy[SampleCounter][i] = M3::Clone(MCHist, MaCh3Sample->GetSampleTitle(SampleIndex) + "_mc_" + std::to_string(i));
-        MC_Hist_Toy[SampleCounter][i]->Write();
-
-        TH1* W2Hist = MaCh3Sample->GetW2Hist(SampleIndex);
-        W2_Hist_Toy[SampleCounter][i] = M3::Clone(W2Hist, MaCh3Sample->GetSampleTitle(SampleIndex) + "_w2_" + std::to_string(i));
-        W2_Hist_Toy[SampleCounter][i]->Write();
-        SampleCounter++;
-      }
-    }
+    // Save histograms to file
+    WriteToy(ToyDirectory, Toy_1DDirectory, Toy_2DDirectory, i);
 
     // Fill parameter value so we know throw values
     for (size_t iPar = 0; iPar < ParamValues.size(); iPar++) {
@@ -512,83 +558,132 @@ void PredictiveThrower::ProduceToys() {
   TempClock.Stop();
 
   if(PosteriorFile) delete PosteriorFile;
-  ToyDirectory->Close();
-  delete ToyDirectory;
+  ToyDirectory->Close(); delete ToyDirectory;
+  Toy_1DDirectory->Close(); delete Toy_1DDirectory;
+  Toy_2DDirectory->Close(); delete Toy_2DDirectory;
 
   outputFile->cd();
-  ToyTree->Write();
-  delete ToyTree;
+  ToyTree->Write(); delete ToyTree;
 
   MACH3LOG_INFO("{} took {:.2f}s to finish for {} toys", __func__, TempClock.RealTime(), Ntoys);
 }
 
 // *************************
-std::vector<std::vector<std::unique_ptr<TH2D>>> PredictiveThrower::ProduceSpectra(
-                                                    const std::vector<std::vector<std::unique_ptr<TH1>>>& Toys,
-                                                    const std::vector<TDirectory*>& SampleDirectories,
-                                                    const std::string suffix) {
+void PredictiveThrower::Study1DProjections(const std::vector<TDirectory*>& SampleDirectories) const {
 // *************************
-  std::vector<std::vector<double>> MaxValue(TotalNumberOfSamples);
-  //Projections[sample][toy][dim]
-  std::vector<std::vector<std::vector<std::unique_ptr<TH1>>>> Projections(TotalNumberOfSamples);
+  MACH3LOG_INFO("Starting {}", __func__);
 
-  // 1. Create 1D projections, this is not thread safe, also we will use it a lot later on
+  TDirectory * ogdir = gDirectory;
+  auto PosteriorFileName = Get<std::string>(fitMan->raw()["Predictive"]["PosteriorFile"], __FILE__, __LINE__);
+  // Open the ROOT file
+  int originalErrorWarning = gErrorIgnoreLevel;
+  gErrorIgnoreLevel = kFatal;
+
+  TFile* file = TFile::Open(PosteriorFileName.c_str(), "READ");
+
+  gErrorIgnoreLevel = originalErrorWarning;
+  TDirectory* ToyDir = file->GetDirectory("Toys_1DHistVar");
+  // If toys not amiable in posterior file this means they must be in output file
+  if(ToyDir == nullptr) {
+    ToyDir = outputFile->GetDirectory("Toys_1DHistVar");
+  }
+  // [sample], [toy], [dim]
+  std::vector<std::vector<std::vector<std::unique_ptr<TH1D>>>> ProjectionToys(TotalNumberOfSamples);
   for (int sample = 0; sample < TotalNumberOfSamples; ++sample) {
-    SampleDirectories[sample]->cd();
-
+    ProjectionToys[sample].resize(Ntoys);
     const int nDims = SampleInfo[sample].Dimenstion;
-    MaxValue[sample].assign(nDims, 0);
-    Projections[sample].resize(Ntoys);
-    for (int toy = 0; toy < Ntoys; ++toy) {
-      if (nDims == 1) {
-        // For 1D histograms, no projection needed.
-        // Leave Projections[sample][toy][0] == nullptr
-      } else if (nDims == 2) {
-        Projections[sample][toy].resize(nDims);
-        TH2* h2 = dynamic_cast<TH2*>(Toys[sample][toy].get());
-        if (!h2) {
-          MACH3LOG_ERROR("Histogram is not TH2 for nDims==2");
-          throw MaCh3Exception(__FILE__, __LINE__);
-        }
-        auto px = h2->ProjectionX();
-        px->SetDirectory(nullptr);
-        Projections[sample][toy][0] = M3::Clone(px);
+    for (int iToy = 0; iToy < Ntoys; ++iToy) {
+      ProjectionToys[sample][iToy].resize(nDims);
+    }
+  }
 
-        auto py = h2->ProjectionY();
-        py->SetDirectory(nullptr);
-        Projections[sample][toy][1] = M3::Clone(py);
+  for (int iToy = 0; iToy < Ntoys; ++iToy) {
+    if (iToy % 100 == 0) MACH3LOG_INFO("   Loaded Projection toys {}", iToy);
+    for (int sample = 0; sample < TotalNumberOfSamples; ++sample) {
+      const int nDims = SampleInfo[sample].Dimenstion;
+      for(int iDim = 0; iDim < nDims; iDim ++){
+        std::string ProjectionSuffix = "_1DProj" + std::to_string(iDim) + "_" + std::to_string(iToy);
+        TH1D* MCHist1D = static_cast<TH1D*>(ToyDir->Get((SampleInfo[sample].Name + ProjectionSuffix).c_str()));
+        ProjectionToys[sample][iToy][iDim] = M3::Clone(MCHist1D);
+      }
+    } // end loop over samples
+  } // end loop over toys
+  file->Close(); delete file;
+  if(ogdir){ ogdir->cd(); }
 
-        delete px;
-        delete py;
-      } else {
-        MACH3LOG_ERROR("Asking for {} with N Dimension = {}. This is not implemented", __func__, nDims);
-        throw MaCh3Exception(__FILE__, __LINE__);
+  ProduceSpectra(ProjectionToys, SampleDirectories, "mc");
+  for (int sample = 0; sample < TotalNumberOfSamples; ++sample) {
+    const int nDims = SampleInfo[sample].Dimenstion;
+    // KS: We only care about doing projections for 2D, for 1D we have well 1D, for beyond 2D we have flattened TH1D
+    if(nDims == 2){
+      auto hist = Data_Hist[sample].get();
+      SampleDirectories[sample]->cd();
+
+      std::string nameX = "Data_" + SampleInfo[sample].Name + "_Dim0";
+      std::string nameY = "Data_" + SampleInfo[sample].Name + "_Dim1";
+
+      if(std::string(hist->ClassName()) == "TH2Poly") {
+        TAxis* xax = ProjectionToys[sample][0][0]->GetXaxis();
+        TAxis* yax = ProjectionToys[sample][0][1]->GetXaxis();
+
+        std::vector<double> XBinning(xax->GetNbins()+1);
+        std::vector<double> YBinning(yax->GetNbins()+1);
+
+        for(int i=0;i<=xax->GetNbins();++i)
+          XBinning[i] = xax->GetBinLowEdge(i+1);
+
+        for(int i=0;i<=yax->GetNbins();++i)
+          YBinning[i] = yax->GetBinLowEdge(i+1);
+
+        TH1D* ProjectionX = PolyProjectionX(static_cast<TH2Poly*>(hist), nameX.c_str(), XBinning, false);
+        TH1D* ProjectionY = PolyProjectionY(static_cast<TH2Poly*>(hist), nameY.c_str(), YBinning, false);
+
+        ProjectionX->SetDirectory(nullptr);
+        ProjectionY->SetDirectory(nullptr);
+
+        ProjectionX->Write(nameX.c_str());
+        ProjectionY->Write(nameY.c_str());
+
+        delete ProjectionX;
+        delete ProjectionY;
+      } else { //TH2D
+        TH1D* ProjectionX = static_cast<TH2D*>(hist)->ProjectionX(nameX.c_str());
+        TH1D* ProjectionY = static_cast<TH2D*>(hist)->ProjectionY(nameY.c_str());
+
+        ProjectionX->SetDirectory(nullptr);
+        ProjectionY->SetDirectory(nullptr);
+
+        ProjectionX->Write(nameX.c_str());
+        ProjectionY->Write(nameY.c_str());
+        delete ProjectionX;
+        delete ProjectionY;
       }
     }
+  }
+}
+
+// *************************
+void PredictiveThrower::ProduceSpectra(const std::vector<std::vector<std::vector<std::unique_ptr<TH1D>>>>& Toys,
+                                       const std::vector<TDirectory*>& SampleDirectories,
+                                       const std::string suffix) const {
+// *************************
+  std::vector<std::vector<double>> MaxValue(TotalNumberOfSamples);
+
+  // 1. Create Max value
+  for (int sample = 0; sample < TotalNumberOfSamples; ++sample) {
+    const int nDims = SampleInfo[sample].Dimenstion;
+    MaxValue[sample].assign(nDims, 0);
   }
 
   // 2. Find maximum entries over all toys
   #ifdef MULTITHREAD
-  #pragma omp parallel for collapse(2)
+  #pragma omp parallel for
   #endif
   for (int sample = 0; sample < TotalNumberOfSamples; ++sample) {
     for (int toy = 0; toy < Ntoys; ++toy) {
-      const int nDims = Toys[sample][0]->GetDimension();
+      const int nDims = SampleInfo[sample].Dimenstion;
       for (int dim = 0; dim < nDims; dim++) {
-        double max_val = 0;
-        if (nDims == 1) {
-          max_val = Toys[sample][toy]->GetMaximum();
-        }
-        else if (nDims == 2) {
-          if (dim == 0) {
-            max_val = Projections[sample][toy][0]->GetMaximum();
-          } else {
-            max_val = Projections[sample][toy][1]->GetMaximum();
-          }
-        } else {
-          MACH3LOG_ERROR("Asking for {} with N Dimension = {}. This is not implemented", __func__, nDims);
-          throw MaCh3Exception(__FILE__, __LINE__);
-        }
+        double max_val = Toys[sample][toy][dim]->GetMaximum();
         MaxValue[sample][dim] = std::max(MaxValue[sample][dim], max_val);
       }
     }
@@ -602,33 +697,13 @@ std::vector<std::vector<std::unique_ptr<TH2D>>> PredictiveThrower::ProduceSpectr
     Spectra[sample].resize(nDims);
     for (int dim = 0; dim < nDims; dim++) {
       // Get MC histogram x-axis binning
-      TH1D* refHist = nullptr;
-      if (nDims == 1) {
-        refHist = static_cast<TH1D*>(Toys[sample][0].get());
-      }
-      else if (nDims == 2) {
-        if (dim == 0) {
-          refHist = static_cast<TH1D*>(Projections[sample][0][0].get());
-        } else {
-          refHist = static_cast<TH1D*>(Projections[sample][0][1].get());
-        }
-      }
-      else {
-        MACH3LOG_ERROR("Asking for {} with N Dimension = {}. This is not implemented", __func__, nDims);
-        throw MaCh3Exception(__FILE__, __LINE__);
-      }
-
-      if (!refHist) {
-        MACH3LOG_ERROR("Failed to cast to {} dimensions in {}!", nDims, __func__);
-        throw MaCh3Exception(__FILE__, __LINE__);
-      }
+      TH1D* refHist = Toys[sample][0][dim].get();
 
       const int n_bins_x = refHist->GetNbinsX();
       std::vector<double> x_bin_edges(n_bins_x + 1);
-      for (int b = 0; b <= n_bins_x; ++b) {
-        x_bin_edges[b] = refHist->GetXaxis()->GetBinLowEdge(b + 1); // ROOT bins start at 1
+      for (int b = 0; b < n_bins_x; ++b) {
+        x_bin_edges[b] = refHist->GetXaxis()->GetBinLowEdge(b + 1);
       }
-      // Last edge is upper edge of last bin:
       x_bin_edges[n_bins_x] = refHist->GetXaxis()->GetBinUpEdge(n_bins_x);
 
       constexpr int n_bins_y = 400;
@@ -653,22 +728,13 @@ std::vector<std::vector<std::unique_ptr<TH2D>>> PredictiveThrower::ProduceSpectr
 
   // 4. now we can actually fill our projections
   #ifdef MULTITHREAD
-  #pragma omp parallel for
+  #pragma omp parallel for collapse(2)
   #endif
   for (int sample = 0; sample < TotalNumberOfSamples; ++sample) {
-    const int nDims = SampleInfo[sample].Dimenstion;
-    for (int dim = 0; dim < nDims; dim++) {
-      for (int toy = 0; toy < Ntoys; ++toy) {
-        if (nDims == 1) {
-          FastViolinFill(Spectra[sample][dim].get(), static_cast<TH1D*>(Toys[sample][toy].get()));
-        }
-        else if (nDims == 2) {
-          FastViolinFill(Spectra[sample][dim].get(), static_cast<TH1D*>(Projections[sample][toy][dim].get()));
-        }
-        else {
-          MACH3LOG_ERROR("Asking for {} with N Dimension = {}. This is not implemented", __func__, nDims);
-          throw MaCh3Exception(__FILE__, __LINE__);
-        }
+    for (int toy = 0; toy < Ntoys; ++toy) {
+      const int nDims = SampleInfo[sample].Dimenstion;
+      for (int dim = 0; dim < nDims; dim++) {
+        FastViolinFill(Spectra[sample][dim].get(), Toys[sample][toy][dim].get());
       }
     }
   }
@@ -676,14 +742,109 @@ std::vector<std::vector<std::unique_ptr<TH2D>>> PredictiveThrower::ProduceSpectr
   // 5. Save histograms which is not thread save
   for (int sample = 0; sample < TotalNumberOfSamples; ++sample) {
     SampleDirectories[sample]->cd();
+    const int nDims = SampleInfo[sample].Dimenstion;
     for (long unsigned int dim = 0; dim < Spectra[sample].size(); dim++) {
       Spectra[sample][dim]->Write();
+      // For case of 2D make additional histograms
+      if(nDims == 2) {
+        const std::string name = SampleInfo[sample].Name + "_" + suffix+ "_PostPred_dim" + std::to_string(dim);
+        auto Summary = MakeSummaryFromSpectra(Spectra[sample][dim].get(), name);
+        Summary->Write();
+      }
     }
   }
-
-  return Spectra;
 }
 
+// *************************
+std::string PredictiveThrower::GetBinName(TH1* hist,
+                                          const bool uniform,
+                                          const int Dim,
+                                          const std::vector<int>& bins) const {
+// *************************
+  std::string BinName = "";
+  if(Dim == 1) { // True 1D distribution using TH1D
+    const int b = bins[0];
+    const TAxis* ax = hist->GetXaxis();
+    const double low = ax->GetBinLowEdge(b);
+    const double up  = ax->GetBinUpEdge(b);
+
+    BinName = fmt::format("Dim0 ({:g}, {:g})", low, up);
+  } else if (Dim == 2) { // True 2D dsitrubitons
+    if(uniform == true) { //using TH2D
+      const int bx = bins[0];
+      const int by = bins[1];
+      const TAxis* ax = hist->GetXaxis();
+      const TAxis* ay = hist->GetYaxis();
+      BinName = fmt::format("Dim0 ({:g}, {:g}), ", ax->GetBinLowEdge(bx), ax->GetBinUpEdge(bx));
+      BinName += fmt::format("Dim1 ({:g}, {:g})", ay->GetBinLowEdge(by), ay->GetBinUpEdge(by));
+    } else { // using TH2Poly
+      TH2PolyBin* bin = static_cast<TH2PolyBin*>(static_cast<TH2Poly*>(hist)->GetBins()->At(bins[0]-1));
+      // Just make a little fancy name
+      BinName += fmt::format("Dim{} ({:g}, {:g})", 0, bin->GetXMin(), bin->GetXMax());
+      BinName += fmt::format("Dim{} ({:g}, {:g})", 1, bin->GetYMin(), bin->GetYMax());
+    }
+  } else { // N-dimensional distribution using flatten TH1D
+    BinName = hist->GetXaxis()->GetBinLabel(bins[0]);
+  }
+  return BinName;
+}
+
+// *************************
+std::vector<std::unique_ptr<TH1D>> PredictiveThrower::PerBinHistogram(TH1* hist,
+                                                                      const int SampleId,
+                                                                      const int Dim,
+                                                                      const std::string& suffix) const {
+// *************************
+  std::vector<std::unique_ptr<TH1D>> PosteriorHistVec;
+  constexpr int nBins = 100;
+  const std::string Sample_Name = SampleInfo[SampleId].Name;
+  if (Dim == 2) {
+      if(std::string(hist->ClassName()) == "TH2Poly") {
+        for (int i = 1; i <= static_cast<TH2Poly*>(hist)->GetNumberOfBins(); ++i) {
+          std::string ProjName = fmt::format("{} {} Bin: {}",
+                                             Sample_Name, suffix,
+                                             GetBinName(hist, false, Dim, {i}));
+          //KS: When a histogram is created with an axis lower limit greater or equal to its upper limit ROOT will automatically adjust histogram range
+          // https://root.cern.ch/doc/master/classTH1.html#auto-bin
+          auto PosteriorHist = std::make_unique<TH1D>(ProjName.c_str(), ProjName.c_str(), nBins, 1, -1);
+          PosteriorHist->SetDirectory(nullptr);
+          PosteriorHist->GetXaxis()->SetTitle("Events");
+          PosteriorHistVec.push_back(std::move(PosteriorHist));
+        } //end loop over bin
+      } else {
+        int nbinsx = hist->GetNbinsX();
+        int nbinsy = hist->GetNbinsY();
+        for (int iy = 1; iy <= nbinsy; ++iy) {
+          for (int ix = 1; ix <= nbinsx; ++ix) {
+            std::string ProjName = fmt::format("{} {} Bin: {}",
+                                              Sample_Name, suffix,
+                                              GetBinName(hist, true, Dim, {ix,iy}));
+            //KS: When a histogram is created with an axis lower limit greater or equal to its upper limit ROOT will automatically adjust histogram range
+            // https://root.cern.ch/doc/master/classTH1.html#auto-bin
+            auto PosteriorHist = std::make_unique<TH1D>(ProjName.c_str(), ProjName.c_str(), nBins, 1, -1);
+            PosteriorHist->SetDirectory(nullptr);
+            PosteriorHist->GetXaxis()->SetTitle("Events");
+            PosteriorHistVec.push_back(std::move(PosteriorHist));
+          }
+        }
+      }
+  } else {
+    int nbinsx = hist->GetNbinsX();
+    PosteriorHistVec.reserve(nbinsx);
+    for (int i = 1; i <= nbinsx; ++i) {
+      std::string ProjName = fmt::format("{} {} Bin: {}",
+                                          Sample_Name, suffix,
+                                          GetBinName(hist, true, Dim, {i}));
+      //KS: When a histogram is created with an axis lower limit greater or equal to its upper limit ROOT will automatically adjust histogram range
+      // https://root.cern.ch/doc/master/classTH1.html#auto-bin
+      auto PosteriorHist = std::make_unique<TH1D>(ProjName.c_str(), ProjName.c_str(), nBins, 1, -1);
+      PosteriorHist->SetDirectory(nullptr);
+      PosteriorHist->GetXaxis()->SetTitle("Events");
+      PosteriorHistVec.push_back(std::move(PosteriorHist));
+    }
+  }
+  return PosteriorHistVec;
+}
 
 // *************************
 std::vector<std::unique_ptr<TH1>> PredictiveThrower::MakePredictive(const std::vector<std::vector<std::unique_ptr<TH1>>>& Toys,
@@ -691,98 +852,94 @@ std::vector<std::unique_ptr<TH1>> PredictiveThrower::MakePredictive(const std::v
                                                                     const std::string& suffix,
                                                                     const bool DebugHistograms) {
 // *************************
-  /// @todo KS: If we break up into 1.initialisation->2.writing->3.saving into separate loops we can multithread
-  std::vector<std::unique_ptr<TH1>> PostPred_mc(TotalNumberOfSamples);
-
+  std::vector<std::unique_ptr<TH1>> PostPred(TotalNumberOfSamples);
+  std::vector<std::vector<std::unique_ptr<TH1D>>> Posterior_hist(TotalNumberOfSamples);
+  // 1.initialisation
   for (int sample = 0; sample < TotalNumberOfSamples; ++sample) {
-    Directory[sample]->cd();
     const int nDims = SampleInfo[sample].Dimenstion;
     const std::string Sample_Name = SampleInfo[sample].Name;
-    if (nDims == 1) {
-      int nbinsx = Toys[sample][0]->GetNbinsX();
-      const double* xbins = Toys[sample][0]->GetXaxis()->GetXbins()->GetArray();
-      auto PredictiveHist = std::make_unique<TH1D>(
-        (Sample_Name + "_" + suffix + "_PostPred").c_str(),
-        (Sample_Name + "_" + suffix + "_PostPred").c_str(),
-         nbinsx, xbins
-      );
-      PredictiveHist->GetXaxis()->SetTitle(Toys[sample][0]->GetXaxis()->GetTitle());
-      PredictiveHist->GetYaxis()->SetTitle("Events");
-      PredictiveHist->SetDirectory(nullptr);
-
-      for (int i = 1; i <= nbinsx; ++i) {
-        std::string ProjName = fmt::format("{} {} Bin: {}",
-                                           SampleInfo[sample].Name, suffix,
-                                           SampleInfo[sample].Binning->GetBinName(SampleInfo[sample].LocalId, i-1));
-        //KS: When a histogram is created with an axis lower limit greater or equal to its upper limit ROOT will automatically adjust histogram range
-        // https://root.cern.ch/doc/master/classTH1.html#auto-bin
-        auto PosteriorHist = std::make_unique<TH1D>(ProjName.c_str(), ProjName.c_str(), 100, 1, -1);
-        PosteriorHist->SetDirectory(nullptr);
-        PosteriorHist->GetXaxis()->SetTitle("Events");
-
-        for (size_t iToy = 0; iToy < Toys[sample].size(); ++iToy) {
-          double content = Toys[sample][iToy]->GetBinContent(i);
-          PosteriorHist->Fill(content, ReweightWeight[iToy]);
-        }
-
-        if (DebugHistograms) PosteriorHist->Write();
-
-        PredictiveHist->SetBinContent(i, PosteriorHist->GetMean());
-        PredictiveHist->SetBinError(i, PosteriorHist->GetRMS());
-      }
-      PredictiveHist->Write();
-      PostPred_mc[sample] = std::move(PredictiveHist);
-    }
-    else if (nDims == 2) {
-      int nbinsx = Toys[sample][0]->GetNbinsX();
-      int nbinsy = Toys[sample][0]->GetNbinsY();
-      const double* xbins = Toys[sample][0]->GetXaxis()->GetXbins()->GetArray();
-      const double* ybins = Toys[sample][0]->GetYaxis()->GetXbins()->GetArray();
-
-      // Create 2D predictive histogram with same binning as Toys[sample][0]
-      auto PredictiveHist = std::make_unique<TH2D>(
-        (Sample_Name + "_" + suffix + "_PostPred").c_str(),
-        (Sample_Name + "_" + suffix + "_PostPred").c_str(),
-        nbinsx, xbins,
-        nbinsy, ybins
-      );
-      PredictiveHist->GetXaxis()->SetTitle(Toys[sample][0]->GetXaxis()->GetTitle());
-      PredictiveHist->GetYaxis()->SetTitle(Toys[sample][0]->GetYaxis()->GetTitle());
-      PredictiveHist->SetDirectory(nullptr);
-
-      for (int iy = 1; iy <= nbinsy; ++iy) {
-        for (int ix = 1; ix <= nbinsx; ++ix) {
-          // MaCh3 vs ROOT conventions, above loop should be over MaCh3 bins
-          const int MaCh3Bin = SampleInfo[sample].Binning->GetBinSafe(SampleInfo[sample].LocalId, {ix-1, iy-1});
-          std::string ProjName = fmt::format("{} {} Bin: {}",
-                                      SampleInfo[sample].Name, suffix,
-                                      SampleInfo[sample].Binning->GetBinName(SampleInfo[sample].LocalId, MaCh3Bin));
-          //KS: When a histogram is created with an axis lower limit greater or equal to its upper limit ROOT will automatically adjust histogram range
-          // https://root.cern.ch/doc/master/classTH1.html#auto-bin
-          auto PosteriorHist = std::make_unique<TH1D>(ProjName.c_str(), ProjName.c_str(), 100, 1, -1);
-          PosteriorHist->SetDirectory(nullptr);
-          PosteriorHist->GetXaxis()->SetTitle("Events");
-          int bin = Toys[sample][0]->GetBin(ix, iy);
-          for (size_t iToy = 0; iToy < Toys[sample].size(); ++iToy) {
-            double content = Toys[sample][iToy]->GetBinContent(bin);
-            PosteriorHist->Fill(content, ReweightWeight[iToy]);
-          }
-
-          if (DebugHistograms) PosteriorHist->Write();
-
-          PredictiveHist->SetBinContent(ix, iy, PosteriorHist->GetMean());
-          PredictiveHist->SetBinError(ix, iy, PosteriorHist->GetRMS());
-        }
-      }
-      PredictiveHist->Write();
-      PostPred_mc[sample] = std::move(PredictiveHist);
-    }
-    else {
-      MACH3LOG_ERROR("Asking for {} with N Dimension = {}. This is not implemented", __func__, nDims);
-      throw MaCh3Exception(__FILE__, __LINE__);
-    }
+    Posterior_hist[sample] = PerBinHistogram(Toys[sample][0].get(), sample, nDims, suffix);
+    auto PredictiveHist = M3::Clone(Toys[sample][0].get());
+    // Clear the bin contents
+    PredictiveHist->Reset();
+    PredictiveHist->SetName((Sample_Name + "_" + suffix + "_PostPred").c_str());
+    PredictiveHist->SetTitle((Sample_Name + "_" + suffix + "_PostPred").c_str());
+    PredictiveHist->SetDirectory(nullptr);
+    PostPred[sample] = std::move(PredictiveHist);
   }
-  return PostPred_mc;
+
+  /// 2. Fill histograms, thread safe as all histograms are allocated before and we loop over samples
+  #ifdef MULTITHREAD
+  #pragma omp parallel for
+  #endif
+  for (int sample = 0; sample < TotalNumberOfSamples; ++sample) {
+    const int nDims = SampleInfo[sample].Dimenstion;
+    auto& hist = Toys[sample][0];
+    for (size_t iToy = 0; iToy < Toys[sample].size(); ++iToy) {
+      if(nDims == 2) {
+        if(std::string(hist->ClassName()) == "TH2Poly") {
+          for (int i = 1; i <= static_cast<TH2Poly*>(hist.get())->GetNumberOfBins(); ++i) {
+            double content = Toys[sample][iToy]->GetBinContent(i);
+            Posterior_hist[sample][i-1]->Fill(content, ReweightWeight[iToy]);
+          }
+        } else {
+          int nbinsx = hist->GetNbinsX();
+          int nbinsy = hist->GetNbinsY();
+          for (int iy = 1; iy <= nbinsy; ++iy) {
+            for (int ix = 1; ix <= nbinsx; ++ix) {
+              int Bin = (iy-1) * nbinsx + (ix-1);
+              double content = Toys[sample][iToy]->GetBinContent(ix, iy);
+              Posterior_hist[sample][Bin];
+              Posterior_hist[sample][Bin]->Fill(content, ReweightWeight[iToy]);
+            } // end loop over X bins
+          } // end loop over Y bins
+        }
+      } else {
+        int nbinsx = hist->GetNbinsX();
+          for (int i = 1; i <= nbinsx; ++i) {
+            double content = Toys[sample][iToy]->GetBinContent(i);
+            Posterior_hist[sample][i-1]->Fill(content, ReweightWeight[iToy]);
+          } // end loop over bins
+        } // end if over dimensions
+    } // end loop over toys
+  } // end loop over samples
+
+  // 3.save
+  for (int sample = 0; sample < TotalNumberOfSamples; ++sample) {
+    const int nDims = SampleInfo[sample].Dimenstion;
+    auto& hist = Toys[sample][0];
+    Directory[sample]->cd();
+    if(nDims == 2) {
+      if(std::string(hist->ClassName()) == "TH2Poly") {
+        for (int i = 1; i <= static_cast<TH2Poly*>(hist.get())->GetNumberOfBins(); ++i) {
+          PostPred[sample]->SetBinContent(i, Posterior_hist[sample][i-1]->GetMean());
+          // KS: If ROOT below 6.18 one need -1 only for error due to stupid bug...
+          PostPred[sample]->SetBinError(i, Posterior_hist[sample][i-1]->GetRMS());
+          if (DebugHistograms) Posterior_hist[sample][i-1]->Write();
+        } // end loop over poly bins
+      } else {
+        int nbinsx = hist->GetNbinsX();
+        int nbinsy = hist->GetNbinsY();
+        for (int iy = 1; iy <= nbinsy; ++iy) {
+          for (int ix = 1; ix <= nbinsx; ++ix) {
+            int Bin = (iy-1) * nbinsx + (ix-1);
+            if (DebugHistograms) Posterior_hist[sample][Bin]->Write();
+            PostPred[sample]->SetBinContent(ix, iy, Posterior_hist[sample][Bin]->GetMean());
+            PostPred[sample]->SetBinError(ix, iy, Posterior_hist[sample][Bin]->GetRMS());
+          } // end loop over x
+        } // end loop over y
+      }
+    } else {
+      int nbinsx = hist->GetNbinsX();
+      for (int i = 1; i <= nbinsx; ++i) {
+        PostPred[sample]->SetBinContent(i, Posterior_hist[sample][i-1]->GetMean());
+        PostPred[sample]->SetBinError(i, Posterior_hist[sample][i-1]->GetRMS());
+        if (DebugHistograms) Posterior_hist[sample][i-1]->Write();
+      }
+    }
+    PostPred[sample]->Write();
+  } // end loop over samples
+  return PostPred;
 }
 
 // *************************
@@ -790,10 +947,14 @@ std::vector<std::unique_ptr<TH1>> PredictiveThrower::MakePredictive(const std::v
 void PredictiveThrower::RunPredictiveAnalysis() {
 // *************************
   MACH3LOG_INFO("Starting {}", __func__);
+  MACH3LOG_WARN("\033[0;31mCurrent Total RAM usage is {:.2f} GB\033[0m", MaCh3Utils::getValue("VmRSS") / 1048576.0);
+  MACH3LOG_WARN("\033[0;31mOut of Total available RAM {:.2f} GB\033[0m", MaCh3Utils::getValue("MemTotal") / 1048576.0);
+
   TStopwatch TempClock;
   TempClock.Start();
 
   auto DebugHistograms = GetFromManager<bool>(fitMan->raw()["Predictive"]["DebugHistograms"], false, __FILE__, __LINE__);
+  auto StudyBeta = GetFromManager<bool>(fitMan->raw()["Predictive"]["StudyBetaParameters"], true, __FILE__, __LINE__);
 
   TDirectory* PredictiveDir = outputFile->mkdir("Predictive");
   std::vector<TDirectory*> SampleDirectories;
@@ -805,7 +966,7 @@ void PredictiveThrower::RunPredictiveAnalysis() {
   }
 
   // Produce Violin style spectra
-  auto Spectra_mc = ProduceSpectra(MC_Hist_Toy, SampleDirectories, "mc");
+  Study1DProjections(SampleDirectories);
   // Produce posterior predictive distribution
   auto PostPred_mc = MakePredictive(MC_Hist_Toy, SampleDirectories, "mc", DebugHistograms);
   // Calculate Posterior Predictive $p$-value
@@ -817,7 +978,7 @@ void PredictiveThrower::RunPredictiveAnalysis() {
     delete SampleDirectories[sample];
   }
   // Perform beta analysis for mc statical uncertainty
-  StudyBetaParameters(PredictiveDir);
+  if(StudyBeta) StudyBetaParameters(PredictiveDir);
 
   PredictiveDir->Close();
   delete PredictiveDir;
@@ -846,11 +1007,37 @@ double PredictiveThrower::GetLLH(const std::unique_ptr<TH1>& DatHist,
   return 2*llh;
 }
 
+// ****************
+//KS: We have two methods how to apply statistical fluctuation standard is faster hence is default
+void PredictiveThrower::MakeFluctuatedHistogram(TH1* FluctHist, TH1* Hist, const int nDims) {
+// ****************
+  if(StandardFluctuation){
+    if (nDims == 2) {
+      if(std::string(Hist->ClassName()) == "TH2Poly") {
+        MakeFluctuatedHistogramStandard(static_cast<TH2Poly*>(FluctHist), static_cast<TH2Poly*>(Hist), random.get());
+      } else {
+        MakeFluctuatedHistogramStandard(static_cast<TH2D*>(FluctHist), static_cast<TH2D*>(Hist), random.get());
+      }
+    } else {
+      MakeFluctuatedHistogramStandard(static_cast<TH1D*>(FluctHist), static_cast<TH1D*>(Hist), random.get());
+    }
+  } else {
+    if (nDims == 2) {
+      if(std::string(Hist->ClassName()) == "TH2Poly") {
+        MakeFluctuatedHistogramAlternative(static_cast<TH2Poly*>(FluctHist), static_cast<TH2Poly*>(Hist), random.get());
+      } else {
+        MakeFluctuatedHistogramAlternative(static_cast<TH2D*>(FluctHist), static_cast<TH2D*>(Hist), random.get());
+      }
+    } else {
+        MakeFluctuatedHistogramAlternative(static_cast<TH1D*>(FluctHist), static_cast<TH1D*>(Hist), random.get());
+    }
+  }
+}
+
 // *************************
 void PredictiveThrower::PosteriorPredictivepValue(const std::vector<std::unique_ptr<TH1>>& PostPred_mc,
                                                   const std::vector<TDirectory*>& SampleDir) {
 // *************************
-  //(void) PostPred_w2;
   // [Toys][Sample]
   std::vector<std::vector<double>> chi2_dat_vec(Ntoys);
   std::vector<std::vector<double>> chi2_mc_vec(Ntoys);
@@ -865,24 +1052,15 @@ void PredictiveThrower::PosteriorPredictivepValue(const std::vector<std::unique_
     chi2_mc_vec[iToy].back() = PenaltyTerm[iToy];
     chi2_pred_vec[iToy].back() = PenaltyTerm[iToy];
 
-    /// TODO This can be multithreaded
+    /// TODO This can be multithreaded but be careful for Clone!!!
     for (int iSample = 0; iSample < TotalNumberOfSamples; ++iSample) {
       const int nDims = SampleInfo[iSample].Dimenstion;
 
       auto DrawFluctHist = M3::Clone(MC_Hist_Toy[iSample][iToy].get());
       auto PredFluctHist = M3::Clone(PostPred_mc[iSample].get());
-      if (nDims == 1) {
-        MakeFluctuatedHistogramAlternative(static_cast<TH1D*>(DrawFluctHist.get()), static_cast<TH1D*>(MC_Hist_Toy[iSample][iToy].get()), random.get());
-        MakeFluctuatedHistogramAlternative(static_cast<TH1D*>(PredFluctHist.get()), static_cast<TH1D*>(PostPred_mc[iSample].get()), random.get());
-      }
-      else if (nDims == 2) {
-        MakeFluctuatedHistogramAlternative(static_cast<TH2D*>(DrawFluctHist.get()), static_cast<TH2D*>(MC_Hist_Toy[iSample][iToy].get()), random.get());
-        MakeFluctuatedHistogramAlternative(static_cast<TH2D*>(PredFluctHist.get()), static_cast<TH2D*>(PostPred_mc[iSample].get()), random.get());
-      }
-      else {
-        MACH3LOG_ERROR("Asking for {} with N Dimension = {}. This is not implemented", __func__, nDims);
-        throw MaCh3Exception(__FILE__, __LINE__);
-      }
+
+      MakeFluctuatedHistogram(DrawFluctHist.get(), MC_Hist_Toy[iSample][iToy].get(), nDims);
+      MakeFluctuatedHistogram(PredFluctHist.get(), PostPred_mc[iSample].get(), nDims);
 
       // Okay now we can do our chi2 calculation for our sample
       chi2_dat_vec[iToy][iSample]  = GetLLH(Data_Hist[iSample], MC_Hist_Toy[iSample][iToy], W2_Hist_Toy[iSample][iToy], SampleInfo[iSample].SamHandler);
@@ -959,17 +1137,13 @@ void PredictiveThrower::StudyBetaParameters(TDirectory* PredictiveDir) {
 
   /// 1. Initialise Beta histogram
   for (int iSample = 0; iSample < TotalNumberOfSamples; ++iSample) {
-    BetaHist[iSample].resize(SampleInfo[iSample].Binning->GetNBins(SampleInfo[iSample].LocalId));
-
-    for (int iBin = 0; iBin < SampleInfo[iSample].Binning->GetNBins(SampleInfo[iSample].LocalId); iBin++ ) {
-      std::string title = fmt::format("#beta param, {} Bin: {}",
-                                      SampleInfo[iSample].Name,
-                                      SampleInfo[iSample].Binning->GetBinName(SampleInfo[iSample].LocalId, iBin));
-      //KS: When a histogram is created with an axis lower limit greater or equal to its upper limit ROOT will automatically adjust histogram range
-      // https://root.cern.ch/doc/master/classTH1.html#auto-bin
-      BetaHist[iSample][iBin] = std::make_unique<TH1D>(title.c_str(), title.c_str(), 100, 1, -1);
-      BetaHist[iSample][iBin]->SetDirectory(nullptr);
-      BetaHist[iSample][iBin]->GetXaxis()->SetTitle("beta parameter");
+    const int nDims = SampleInfo[iSample].Dimenstion;
+    // Use any histogram that defines the binning structure
+    TH1* RefHist = Data_Hist[iSample].get();
+    BetaHist[iSample] = PerBinHistogram(RefHist, iSample, nDims, "Beta_Parameter");
+    // Change x-axis title
+    for (size_t i = 0; i < BetaHist[iSample].size(); ++i) {
+      BetaHist[iSample][i]->GetXaxis()->SetTitle("beta parameter");
     }
   }
 
@@ -979,49 +1153,52 @@ void PredictiveThrower::StudyBetaParameters(TDirectory* PredictiveDir) {
   #endif
   for (int iSample = 0; iSample < TotalNumberOfSamples; ++iSample) {
     const int nDims = SampleInfo[iSample].Dimenstion;
-    if (nDims == 1) {
-      int nbinsx = Data_Hist[iSample]->GetNbinsX();
-      for (int iBinX = 0; iBinX < nbinsx; ++iBinX) {
-        const int RootBin = iBinX+1;
-        for (int iToy = 0; iToy < Ntoys; ++iToy) {
-          /// ROOT enumerates from 1 while MaCh3 from 0
-          const double Data = Data_Hist[iSample]->GetBinContent(RootBin);
-          const double MC = MC_Hist_Toy[iSample][iToy]->GetBinContent(RootBin);
-          const double w2 = W2_Hist_Toy[iSample][iToy]->GetBinContent(RootBin);
-          const auto likelihood = SampleInfo[iSample].SamHandler->GetTestStatistic();
-
-          const double BetaParam = GetBetaParameter(Data, MC, w2, likelihood);
-          BetaHist[iSample][iBinX]->Fill(BetaParam, ReweightWeight[iToy]);
-        }
-      }
-    } else if (nDims == 2) {
-      const int nX = Data_Hist[iSample]->GetNbinsX();
-      const int nY = Data_Hist[iSample]->GetNbinsY();
-      for (int y = 0; y < nY; ++y) {
-        for (int x = 0; x < nX; ++x) {
-          const int RootBin = Data_Hist[iSample]->GetBin(x+1, y+1);
-          const int MaCh3Bin = SampleInfo[iSample].Binning->GetBinSafe(SampleInfo[iSample].LocalId, {x, y});
-
-          for (int iToy = 0; iToy < Ntoys; ++iToy) {
-            const double Data = Data_Hist[iSample]->GetBinContent(RootBin);
-            const double MC   = MC_Hist_Toy[iSample][iToy]->GetBinContent(RootBin);
-            const double w2   = W2_Hist_Toy[iSample][iToy]->GetBinContent(RootBin);
-            const auto likelihood = SampleInfo[iSample].SamHandler->GetTestStatistic();
+    const auto likelihood = SampleInfo[iSample].SamHandler->GetTestStatistic();
+    for (int iToy = 0; iToy < Ntoys; ++iToy) {
+      if (nDims == 2) {
+        if(std::string(Data_Hist[iSample]->ClassName()) == "TH2Poly") {
+          for (int i = 1; i <= static_cast<TH2Poly*>(Data_Hist[iSample].get())->GetNumberOfBins(); ++i) {
+            const double Data = Data_Hist[iSample]->GetBinContent(i);
+            const double MC   = MC_Hist_Toy[iSample][iToy]->GetBinContent(i);
+            const double w2   = W2_Hist_Toy[iSample][iToy]->GetBinContent(i);
 
             const double BetaParam = GetBetaParameter(Data, MC, w2, likelihood);
-            BetaHist[iSample][MaCh3Bin]->Fill(BetaParam, ReweightWeight[iToy]);
-          }
-        }
+            BetaHist[iSample][i-1]->Fill(BetaParam, ReweightWeight[iToy]);
+          } // end loop over poly bins
+        } else {
+          const int nX = Data_Hist[iSample]->GetNbinsX();
+          const int nY = Data_Hist[iSample]->GetNbinsY();
+          for (int iy = 1; iy <= nY; ++iy) {
+            for (int ix = 1; ix <= nX; ++ix) {
+              const int FlatBin = (iy-1) * nX + (ix-1);
+
+              const double Data = Data_Hist[iSample]->GetBinContent(ix, iy);
+              const double MC   = MC_Hist_Toy[iSample][iToy]->GetBinContent(ix, iy);
+              const double w2   = W2_Hist_Toy[iSample][iToy]->GetBinContent(ix, iy);
+
+              const double BetaParam = GetBetaParameter(Data, MC, w2, likelihood);
+              BetaHist[iSample][FlatBin]->Fill(BetaParam, ReweightWeight[iToy]);
+            }
+          } // end loop over x
+        } // end loop over y
+      } else {
+        int nbinsx = Data_Hist[iSample]->GetNbinsX();
+        for (int ix = 1; ix <= nbinsx; ++ix) {
+          /// ROOT enumerates from 1 while MaCh3 from 0
+          const double Data = Data_Hist[iSample]->GetBinContent(ix);
+          const double MC = MC_Hist_Toy[iSample][iToy]->GetBinContent(ix);
+          const double w2 = W2_Hist_Toy[iSample][iToy]->GetBinContent(ix);
+
+          const double BetaParam = GetBetaParameter(Data, MC, w2, likelihood);
+          BetaHist[iSample][ix-1]->Fill(BetaParam, ReweightWeight[iToy]);
+        } // end loop over bins
       }
-    } else {
-      MACH3LOG_ERROR("Asking for {} with N Dimension = {}. This is not implemented", __func__, nDims);
-      throw MaCh3Exception(__FILE__, __LINE__);
-    }
-  }
+    } // end loop over toys
+  } // end loop over samples
 
   /// 3. Write to file
   for (int iSample = 0; iSample < TotalNumberOfSamples; ++iSample) {
-    for (int iBin = 0; iBin < SampleInfo[iSample].Binning->GetNBins(SampleInfo[iSample].LocalId); iBin++ ) {
+    for (size_t iBin = 0; iBin < BetaHist[iSample].size(); iBin++) {
       DirBeta[iSample]->cd();
       BetaHist[iSample][iBin]->Write();
     }

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -1397,6 +1397,7 @@ TH1* SampleHandlerFD::Get1DVarHist(const int iSample, const std::string& Project
     _h1DVar = new TH1D("", "", int(xBinEdges.size())-1, xBinEdges.data());
   }
   _h1DVar->GetXaxis()->SetTitle(ProjectionVar_Str.c_str());
+  _h1DVar->GetYaxis()->SetTitle("Events");
 
   if (IsSubEventVarString(ProjectionVar_Str)) {
     Fill1DSubEventHist(iSample, _h1DVar, ProjectionVar_Str, SubEventSelectionVec, WeightStyle);
@@ -1475,6 +1476,7 @@ TH2* SampleHandlerFD::Get2DVarHist(const int iSample,
   }
   _h2DVar->GetXaxis()->SetTitle(ProjectionVar_StrX.c_str());
   _h2DVar->GetYaxis()->SetTitle(ProjectionVar_StrY.c_str());
+  _h2DVar->GetZaxis()->SetTitle("Events");
 
   bool IsSubEventHist = IsSubEventVarString(ProjectionVar_StrX) || IsSubEventVarString(ProjectionVar_StrY);
   if (IsSubEventHist) Fill2DSubEventHist(iSample, _h2DVar, ProjectionVar_StrX, ProjectionVar_StrY, SubEventSelectionVec, WeightStyle);


### PR DESCRIPTION
# Pull request description
When introducing flexible binning post pred code wasn't updated (code was forcing to use at most 2D binning even if fit was run with more). This changes this.

Conceptually similar to sigma var as we perform Get 1d var hist for each dimension which allows to reliably do 1D projection.
In addition, following convention of sample handler beyond 2D we use flat TH1D allowing to easily calculate post pred pvalue for even most convoluted binning

## Examples
[Overlay_Predictive.pdf](https://github.com/user-attachments/files/25477333/Overlay_Predictive.pdf)
<img width="1186" height="779" alt="image" src="https://github.com/user-attachments/assets/5a66a119-bfb7-4cf5-9562-3cef76cfcb48" />
<img width="1179" height="788" alt="image" src="https://github.com/user-attachments/assets/1c63fb40-dc65-48f5-822f-50aea256277b" />


---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
