### PR TITLE
feat: Doxygen for MP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,10 @@ if(MaCh3_MULTITHREAD_ENABLED)
     target_link_libraries(MaCh3CompilerOptions INTERFACE gomp)
   endif()
   target_compile_definitions(MaCh3CompileDefinitions INTERFACE MULTITHREAD)
+  # KS: This will pass variable to doxgyen and tell whether documentation should be with MP functions
+  set(DOXYGEN_PREDEFINED "MULTITHREAD")
+else()
+  set(DOXYGEN_PREDEFINED "")
 endif()
 
 if(MaCh3_GPU_ENABLED) 

--- a/cmake/Templates/Doxyfile.in
+++ b/cmake/Templates/Doxyfile.in
@@ -2192,7 +2192,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = @DOXYGEN_PREDEFINED@
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
# Pull request description
In MaCh3 we have plenty of ifdef MULTIHTREAD
Problem is, Doxygen by default doesn't recognize it.

This feature reads variable from cmake and passes to doxyfile.
It could be extended to also add CUDA/DEBUG flags. However this feature is mainly for WEB doxygen which is meant to use default values.
MULTIHREADS is default

## Examples
<img width="2296" height="1022" alt="image" src="https://github.com/user-attachments/assets/d8abe61f-1a93-48f6-bc45-d2a24de83f2d" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
