### PR TITLE
feat: Port Rate analysis from ND280

### DIFF
--- a/Fitters/PredictiveThrower.h
+++ b/Fitters/PredictiveThrower.h
@@ -140,6 +140,11 @@ class PredictiveThrower : public FitterBase {
 
   /// @brief Evaluate prior/post predictive distribution for beta parameters (used for evaluating impact MC statistical uncertainty)
   void StudyBetaParameters(TDirectory* PredictiveDir);
+  /// @brief Make the 1D Event Rate Hist
+  void MakeCutEventRate(TH1D *Histogram, const double DataRate) const;
+  /// @brief Produce distribution of number of events for each sample
+  void RateAnalysis(const std::vector<std::vector<std::unique_ptr<TH1>>>& Toys,
+                                       const std::vector<TDirectory*>& SampleDirectories) const;
 
   /// KS: Use Full LLH or only sample contribution based on discussion with Asher we almost always only want the sample likelihood
   bool FullLLH;


### PR DESCRIPTION
# Pull request description
In ND280 analysis it is very useful to see how even rates changed before and after the fit including relative uncertainty.
Having tool which does it and automatically print without any hard-coding was missing in MaCh3.
This changes right now

## Examples

<img width="352" height="210" alt="ssss" src="https://github.com/user-attachments/assets/017c133d-1452-4590-857c-31e0e369fc31" />
<img width="263" height="191" alt="blarb" src="https://github.com/user-attachments/assets/24f59d56-18a1-4533-8995-d172abf16885" />
<img width="1184" height="726" alt="image" src="https://github.com/user-attachments/assets/abe954a4-fbbb-46e1-9506-dfbfcebdf3e9" />
<img width="1132" height="726" alt="image" src="https://github.com/user-attachments/assets/424003ae-56b8-4261-a928-4029c6fc4165" />


---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
