### PR TITLE
tidy: Rename modify weights

### DIFF
--- a/Splines/BinnedSplineHandler.cpp
+++ b/Splines/BinnedSplineHandler.cpp
@@ -300,15 +300,11 @@ void BinnedSplineHandler::Evaluate() {
 
   //KS: Huge MP loop over all valid splines
   CalcSplineWeights();
-
-  //KS: Huge MP loop over all events calculating total weight
-  ModifyWeights();
 }
 
 //****************************************
-void BinnedSplineHandler::CalcSplineWeights()
+void BinnedSplineHandler::CalcSplineWeights() {
 //****************************************
-{
   #ifdef MULTITHREAD
   #pragma omp parallel for simd
   #endif

--- a/Splines/BinnedSplineHandler.h
+++ b/Splines/BinnedSplineHandler.h
@@ -76,8 +76,6 @@ class BinnedSplineHandler : public SplineBase {
   protected:
     /// @brief CPU based code which eval weight for each spline
     void CalcSplineWeights() override;
-    /// @brief Calc total event weight, not used by Bin-by-bin splines
-    void ModifyWeights() override {return;};
     /// Pointer to covariance from which we get information about spline params
     ParameterHandlerGeneric* xsec;
 

--- a/Splines/SplineBase.cpp
+++ b/Splines/SplineBase.cpp
@@ -18,6 +18,26 @@ SplineBase::~SplineBase() {
 }
 
 // *************************
+void SplineBase::CheckSegmentValidity(const M3::int_t i,
+                                      const M3::int_t segment,
+                                      const M3::float_t xvar,
+                                      const std::vector<M3::float_t>& xPts) const {
+// *************************
+  if (xPts[segment] > xvar && segment != 0) {
+    MACH3LOG_ERROR("Found a segment which is _ABOVE_ the variation!");
+    MACH3LOG_ERROR("IT SHOULD ALWAYS BE BELOW! (except when segment 0)");
+    MACH3LOG_ERROR("Spline: {}", i);
+    MACH3LOG_ERROR("Found segment = {}", segment);
+    MACH3LOG_ERROR("Doing variation = {}", xvar);
+    MACH3LOG_ERROR("x in spline = {}", xPts[segment]);
+    for (size_t j = 0; j < xPts.size(); ++j) {
+      MACH3LOG_ERROR("    {} = {}", j, xPts[j]);
+    }
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+}
+
+// *************************
 // CW: Only need to do the binary search once per parameter, not once per event!
 // Takes down the number of binary searches from 1.2M to 17, ha!
 // For ROOT version see root/hist/hist/src/TSpline3.cxx TSpline3::FindX(double)
@@ -76,25 +96,14 @@ void SplineBase::FindSplineSegment() {
 
     if (segment >= nPoints-1 && nPoints > 1) segment = nPoints-2;
 
-    //CW: This way we avoid doing 1.2M+ binary searches on the GPU
+    // CW: This way we avoid doing 1.2M+ binary searches on the GPU
     // and literally just multiply lots of numbers together on the GPU without any algorithm
     // Update the values and which segment it belongs to
     SplineInfoArray[i].CurrSegment = segment;
     SplineSegments[i] = short(SplineInfoArray[i].CurrSegment);
 
     #ifdef DEBUG
-    if (SplineInfoArray[i].xPts[segment] > xvar && segment != 0) {
-      MACH3LOG_ERROR("Found a segment which is _ABOVE_ the variation!");
-      MACH3LOG_ERROR("IT SHOULD ALWAYS BE BELOW! (except when segment 0)");
-      MACH3LOG_ERROR("Spline: {}", i);
-      MACH3LOG_ERROR("Found segment = {}", segment);
-      MACH3LOG_ERROR("Doing variation = {}", xvar);
-      MACH3LOG_ERROR("x in spline = {}", SplineInfoArray[i].xPts[segment]);
-      for (M3::int_t j = 0; j < SplineInfoArray[j].nPts; ++j) {
-        MACH3LOG_ERROR("    {} = {}", j, SplineInfoArray[i].xPts[j]);
-      }
-      throw MaCh3Exception(__FILE__ , __LINE__ );
-    }
+    CheckSegmentValidity(i, segment, xvar, SplineInfoArray[i].xPts);
     #endif
   } //end loop over params
 }
@@ -125,7 +134,6 @@ void SplineBase::GetTF1Coeff(TF1_red* &spl, int &nPoints, float *& coeffs) const
   }
   // The structure is now coeffs  = {a,b,c,d,e}
 }
-
 
 // *****************************************
 void SplineBase::PrepareFastSplineInfoDir(std::unique_ptr<TFile>& SplineFile) const {

--- a/Splines/SplineBase.h
+++ b/Splines/SplineBase.h
@@ -22,6 +22,8 @@ _MaCh3_Safe_Include_Start_ //{
 _MaCh3_Safe_Include_End_ //}
 
 /// @brief Base class for calculating weight from spline
+/// @author Dan Barrow
+/// @author Kamil Skwarczynski
 class SplineBase {
   public:
     /// @brief Constructor
@@ -33,10 +35,10 @@ class SplineBase {
     virtual void Evaluate() = 0;
 
     /// @brief Get class name
-    virtual inline std::string GetName() const {return "SplineBase";};
+    virtual std::string GetName() const {return "SplineBase";};
 
     /// @brief Get number of spline parameters
-    short int GetNParams()const {return nParams;};
+    short int GetNParams() const {return nParams;};
 
     /// @brief KS: Prepare spline file that can be used for fast loading
     virtual void PrepareSplineFile(std::string FileName) = 0;
@@ -52,8 +54,6 @@ class SplineBase {
     void FindSplineSegment();
     /// @brief CPU based code which eval weight for each spline
     virtual void CalcSplineWeights() = 0;
-    /// @brief Calc total event weight
-    virtual void ModifyWeights() = 0;
 
     /// @brief KS: Prepare Fast Spline Info within SplineFile
     /// @param File File to which we add new tree
@@ -79,4 +79,15 @@ class SplineBase {
     float *ParamValues;
     /// Number of parameters that have splines
     short int nParams;
+
+  private:
+     /// @brief Validates that the spline segment is correct for the given variation.
+     /// @param i Index of the spline in SplineInfoArray.
+     /// @param segment The segment index to validate.
+     /// @param xvar The variation value being checked.
+     /// @param xPts The array of x-values for the spline.
+    void CheckSegmentValidity(const M3::int_t i,
+                              const M3::int_t segment,
+                              const M3::float_t xvar,
+                              const std::vector<M3::float_t>& xPts) const;
 };

--- a/Splines/SplineMonolith.cpp
+++ b/Splines/SplineMonolith.cpp
@@ -718,8 +718,8 @@ void SMonolith::Evaluate() {
   //KS: Huge MP loop over all valid splines
   CalcSplineWeights();
 
-  //KS: Huge MP loop over all events calculating total weight
-  ModifyWeights();
+  //KS: Huge MP loop over all events calculating total weight per event
+  CalcTotalEventWeight();
 }
 #endif
 
@@ -789,7 +789,7 @@ void SMonolith::CalcSplineWeights() {
 
 //*********************************************************
 //KS: Calc total event weight on CPU
-void SMonolith::ModifyWeights() {
+void SMonolith::CalcTotalEventWeight() {
 //*********************************************************
   #ifdef MULTITHREAD
   #pragma omp parallel for
@@ -828,7 +828,6 @@ void SMonolith::ModifyWeights() {
     cpu_total_weights[EventNum] = totalWeight;
   }
 }
-
 
 //*********************************************************
 //KS: Print info about how much knots etc has been initialised

--- a/Splines/SplineMonolith.h
+++ b/Splines/SplineMonolith.h
@@ -98,7 +98,7 @@ class SMonolith : public SplineBase {
     /// @brief CPU based code which eval weight for each spline
     void CalcSplineWeights() override;
     /// @brief Calc total event weight
-    void ModifyWeights() override;
+    void CalcTotalEventWeight();
 
     /// Number of events
     unsigned int NEvents;

--- a/python/splines.cpp
+++ b/python/splines.cpp
@@ -57,15 +57,6 @@ public:
             CalcSplineWeights    /* Name of function in C++ (must match Python name) */
         );
     }
-
-    void ModifyWeights() override {
-        PYBIND11_OVERRIDE_PURE_NAME(
-            void,             /* Return type */
-            SplineBase,       /* Parent class */
-            "modify_weights", /* Name in python*/
-            ModifyWeights     /* Name of function in C++ (must match Python name) */
-        );
-    }
 };
 
 


### PR DESCRIPTION
# Pull request description
As discussed on slack `ModifyWeight `was a confusing names so now we have `CalcTotalEventWeight`
Plus other minor tidy

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
