### PR TITLE
feat: Add FinaliseShifts hook

### DIFF
--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -47,7 +47,7 @@ SampleHandlerFD::SampleHandlerFD(std::string ConfigFileName, ParameterHandlerGen
 
 SampleHandlerFD::~SampleHandlerFD() {
   MACH3LOG_DEBUG("I'm deleting SampleHandlerFD");
-  
+
   if (SampleHandlerFD_array != nullptr) delete[] SampleHandlerFD_array;
   if (SampleHandlerFD_array_w2 != nullptr) delete[] SampleHandlerFD_array_w2;
   //ETA - there is a chance that you haven't added any data...
@@ -337,9 +337,9 @@ bool SampleHandlerFD::IsSubEventSelected(const std::vector<KinematicCut> &SubEve
 // Reweight function
 void SampleHandlerFD::Reweight() {
 //************************************************
-  //KS: Reset the histograms before reweight 
+  //KS: Reset the histograms before reweight
   ResetHistograms();
-  
+
   //You only need to do these things if Oscillator has been initialised
   //if not then you're not considering oscillations
   if (Oscillator) Oscillator->Evaluate();
@@ -375,7 +375,7 @@ void SampleHandlerFD::FillArray() {
 //************************************************
   //DB Reset which cuts to apply
   Selection = StoredSelection;
-  
+
   for (unsigned int iEvent = 0; iEvent < GetNEvents(); iEvent++) {
     ApplyShifts(iEvent);
     const EventInfo* _restrict_ MCEvent = &MCSamples[iEvent];
@@ -407,7 +407,7 @@ void SampleHandlerFD::FillArray() {
 #ifdef MULTITHREAD
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Walloca"
-// ************************************************ 
+// ************************************************
 /// Multithreaded version of fillArray @see fillArray()
 void SampleHandlerFD::FillArray_MP() {
 // ************************************************
@@ -470,7 +470,7 @@ void SampleHandlerFD::FillArray_MP() {
 // **************************************************
 // Helper function to reset the data and MC histograms
 void SampleHandlerFD::ResetHistograms() {
-// **************************************************  
+// **************************************************
   // DB Reset values stored in PDF array to 0.
   // Don't openMP this; no significant gain
   const int nBins = Binning->GetNBins();
@@ -503,7 +503,7 @@ void SampleHandlerFD::RegisterIndividualFunctionalParameter(const std::string& f
 void SampleHandlerFD::SetupFunctionalParameters() {
 // **************************************************
   funcParsVec = ParHandler->GetFunctionalParametersFromSampleName(SampleHandlerName);
-  // RegisterFunctionalParameters is implemented in experiment-specific code, 
+  // RegisterFunctionalParameters is implemented in experiment-specific code,
   // which calls RegisterIndividualFuncPar to populate funcParsNamesMap, funcParsNamesVec, and funcParsFuncMap
   RegisterFunctionalParameters();
   funcParsMap.resize(funcParsNamesMap.size());
@@ -576,6 +576,8 @@ void SampleHandlerFD::ApplyShifts(const int iEvent) {
     const auto* _restrict_ fp = shifts[iShift];
     (*fp->funcPtr)(fp->valuePtr, iEvent);
   }
+
+  FinaliseShifts(iEvent);
 }
 
 // ***************************************************************************
@@ -1525,13 +1527,13 @@ void SampleHandlerFD::Fill2DSubEventHist(const int iSample, TH2D* _h2DVar,
 // ************************************************
 
   bool IsSubEventVarX = IsSubEventVarString(ProjectionVar_StrX);
-  bool IsSubEventVarY = IsSubEventVarString(ProjectionVar_StrY);   
+  bool IsSubEventVarY = IsSubEventVarString(ProjectionVar_StrY);
 
   int ProjectionVar_IntX, ProjectionVar_IntY;
   if (IsSubEventVarX) ProjectionVar_IntX = ReturnKinematicVectorFromString(ProjectionVar_StrX);
   else ProjectionVar_IntX = ReturnKinematicParameterFromString(ProjectionVar_StrX);
   if (IsSubEventVarY) ProjectionVar_IntY = ReturnKinematicVectorFromString(ProjectionVar_StrY);
-  else ProjectionVar_IntY = ReturnKinematicParameterFromString(ProjectionVar_StrY); 
+  else ProjectionVar_IntY = ReturnKinematicParameterFromString(ProjectionVar_StrY);
 
   //JM Loop over all events
   for (unsigned int iEvent = 0; iEvent < GetNEvents(); iEvent++) {
@@ -1572,7 +1574,7 @@ void SampleHandlerFD::Fill2DSubEventHist(const int iSample, TH2D* _h2DVar,
           if (IsSubEventVarY) VarY = VecY[iSubEvent];
           _h2DVar->Fill(VarX,VarY,Weight);
         }
-      } 
+      }
     }
   }
 }

--- a/Samples/SampleHandlerFD.h
+++ b/Samples/SampleHandlerFD.h
@@ -45,7 +45,7 @@ class SampleHandlerFD :  public SampleHandlerBase
   const BinningHandler* GetBinningHandler() const {return Binning.get();}
 
   void PrintIntegral(const int iSample, const TString& OutputName="/dev/null", const int WeightStyle=0, const TString& OutputCSVName="/dev/null");
-  
+
   //===============================================================================
   // DB Reweighting and Likelihood functions
 
@@ -95,7 +95,7 @@ class SampleHandlerFD :  public SampleHandlerBase
   std::string GetFlavourName(const int iSample, const int iChannel) const override {
     if (iChannel < 0 || iChannel > GetNOscChannels(iSample)) {
       MACH3LOG_ERROR("Invalid Channel Requested: {}", iChannel);
-      throw MaCh3Exception(__FILE__ , __LINE__);      
+      throw MaCh3Exception(__FILE__ , __LINE__);
     }
     return SampleDetails[iSample].OscChannels[iChannel].flavourName;
   }
@@ -117,7 +117,7 @@ class SampleHandlerFD :  public SampleHandlerBase
                           int WeightStyle=0);
   void Fill2DSubEventHist(const int iSample, TH2D* _h2DVar, const std::string& ProjectionVarX, const std::string& ProjectionVarY,
                           const std::vector< KinematicCut >& SubEventSelectionVec = {}, int WeightStyle = 0);
-  
+
   TH1* Get1DVarHistByModeAndChannel(const int iSample, const std::string& ProjectionVar_Str,
                                     int kModeToFill = -1, int kChannelToFill = -1, int WeightStyle = 0, TAxis* Axis = nullptr) override;
   TH2* Get2DVarHistByModeAndChannel(const int iSample, const std::string& ProjectionVar_StrX,
@@ -142,7 +142,7 @@ class SampleHandlerFD :  public SampleHandlerBase
   THStack* ReturnStackedHistBySelection1D(const int iSample, const std::string& KinematicProjection,
                                           int Selection1, int Selection2 = -1, int WeightStyle = 0, TAxis* Axis = nullptr);
   TLegend* ReturnStackHistLegend() {return THStackLeg;}
-  
+
   /// @brief ETA function to generically convert a string from xsec cov to a kinematic type
   int ReturnKinematicParameterFromString(const std::string& KinematicStr) const;
   /// @brief ETA function to generically convert a kinematic type from xsec cov to a string
@@ -209,7 +209,7 @@ class SampleHandlerFD :  public SampleHandlerBase
 
   /// @brief Function which does a lot of the lifting regarding the workflow in creating different MC objects
   void Initialise();
-  
+
   /// @brief Contains all your splines (binned or unbinned) and handles the setup and the returning of weights from spline evaluations
   std::unique_ptr<SplineBase> SplineHandler;
 
@@ -248,6 +248,11 @@ class SampleHandlerFD :  public SampleHandlerBase
   bool IsSubEventSelected(const std::vector<KinematicCut> &SubEventCuts, const int iEvent, unsigned const int iSubEvent, size_t nsubevents);
   /// @brief HH - reset the shifted values to the original values
   virtual void ResetShifts(const int iEvent) {(void)iEvent;};
+  /// @brief LP - Optionally calculate derived observables after all shifts have been applied
+  /// @details LP - For example, have shifts that varied lepton energy and hadron energy separately
+  ///               in a subclass implementation of this method you may add the shifted quantities
+  ///               together to build a shifted neutrino energy estimator
+  virtual void FinaliseShifts(const int iEvent) {(void)iEvent;};
   /// @brief HH - a grid of vectors of enums for each sample and event
   std::vector<std::vector<FunctionalShifter*>> funcParsGrid;
   /// @brief HH - a map that relates the funcpar enum to pointer of FuncPars
@@ -286,7 +291,7 @@ class SampleHandlerFD :  public SampleHandlerBase
   /// @brief Return the value of an associated kinematic parameter for an event
   virtual double ReturnKinematicParameter(std::string KinematicParamter, int iEvent) = 0;
   virtual double ReturnKinematicParameter(int KinematicVariable, int iEvent) = 0;
-  
+
   // === JM declare the same functions for kinematic vectors ===
   virtual std::vector<double> ReturnKinematicVector(std::string KinematicParameter, int iEvent) {return {}; (void)KinematicParameter; (void)iEvent;};
   virtual std::vector<double> ReturnKinematicVector(int KinematicVariable, int iEvent) {return {}; (void)KinematicVariable; (void)iEvent;};
@@ -322,7 +327,7 @@ class SampleHandlerFD :  public SampleHandlerBase
 
   /// @brief Helper function to reset histograms
   void ResetHistograms();
-  
+
   //===============================================================================
   //DB Variables required for GetLikelihood
   /// KS: This stores binning information, in future could be come vector to store binning for every used sample
@@ -347,16 +352,16 @@ class SampleHandlerFD :  public SampleHandlerBase
   /// ETA - All experiments will need an xsec, det and osc cov
   ParameterHandlerGeneric *ParHandler = nullptr;
 
-  //=============================================================================== 
+  //===============================================================================
   /// @brief A unique ID for each sample based on which we can define what systematic should be applied
   std::string SampleHandlerName;
 
   //===========================================================================
   //DB Vectors to store which kinematic cuts we apply
-  //like in XsecNorms but for events in sample. Read in from sample yaml file 
-  //What gets used in IsEventSelected, which gets set equal to user input plus 
+  //like in XsecNorms but for events in sample. Read in from sample yaml file
+  //What gets used in IsEventSelected, which gets set equal to user input plus
   //all the vectors in StoreSelection
-  
+
   /// @brief What gets pulled from config options, these are constant after loading in
   /// this is of length 3: 0th index is the value, 1st is lower bound, 2nd is upper bound
   std::vector< std::vector< KinematicCut > > StoredSelection;
@@ -373,14 +378,14 @@ class SampleHandlerFD :  public SampleHandlerBase
   // === JM mapping between string and kinematic vector enum ===
   const std::unordered_map<std::string, int>* KinematicVectors;
   const std::unordered_map<int, std::string>* ReversedKinematicVectors;
-  // =========================================================== 
+  // ===========================================================
 
   /// The manager object used to read the sample yaml file
   std::unique_ptr<Manager> SampleManager;
   void InitialiseSplineObject();
 
   std::unordered_map<std::string, double> _modeNomWeightMap;
-  
+
   //===============================================================================
   /// DB Miscellaneous Variables
   TLegend* THStackLeg = nullptr;
@@ -399,7 +404,7 @@ class SampleHandlerFD :  public SampleHandlerBase
  private:
   std::unordered_map<std::string, NuPDG> FileToInitPDGMap;
   std::unordered_map<std::string, NuPDG> FileToFinalPDGMap;
-  
+
   enum FDPlotType {
     kModePlot = 0,
     kOscChannelPlot = 1


### PR DESCRIPTION
# Pull request description

Adds a new hook to SampleHandlerFD that subclasses can implement. Runs after all functional parameter variations have been applied to an event and should be used to calculate derived observables/quantities from shifted event quantities.

See #818 for more details.

Should be non-breaking.

## Changes or fixes

## Examples

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
