### PR TITLE
feat: Additional binning specifiers

### DIFF
--- a/Manager/Core.h
+++ b/Manager/Core.h
@@ -132,7 +132,8 @@ _Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"") \
 _Pragma("GCC diagnostic ignored \"-Wswitch-enum\"") \
 _Pragma("GCC diagnostic ignored \"-Wconversion\"") \
 _Pragma("GCC diagnostic ignored \"-Wshadow\"") \
-_Pragma("GCC diagnostic ignored \"-Wsuggest-override\"")
+_Pragma("GCC diagnostic ignored \"-Wsuggest-override\"") \
+_Pragma("GCC diagnostic ignored \"-Wtautological-compare\"")
 #if defined(__GNUC__) && __GNUC__ >= 13
   _Pragma("GCC diagnostic ignored \"-Wdangling-reference\"")
 #endif
@@ -152,7 +153,8 @@ _Pragma("GCC diagnostic pop")
   _Pragma("clang diagnostic ignored \"-Wconversion\"") \
   _Pragma("clang diagnostic ignored \"-Wshadow\"") \
   _Pragma("clang diagnostic ignored \"-Wdeprecated-literal-operator\"") \
-  _Pragma("clang diagnostic ignored \"-Wsuggest-override\"")
+  _Pragma("clang diagnostic ignored \"-Wsuggest-override\"") \
+  _Pragma("clang diagnostic ignored \"-Wtautological-compare\"")
   #undef _MaCh3_Safe_Include_End_
   #define _MaCh3_Safe_Include_End_ \
   _Pragma("clang diagnostic pop")

--- a/Samples/BinningHandler.cpp
+++ b/Samples/BinningHandler.cpp
@@ -199,8 +199,22 @@ void BinningHandler::SetupSampleBinning(const YAML::Node& Settings, SampleInfo& 
   bool Uniform = Get<bool>(Settings["Uniform"], __FILE__ , __LINE__);
   bool found_range_specifier = false;
   if(Uniform == false) {
-    auto Bins = Get<std::vector<std::vector<std::vector<double>>>>(Settings["Bins"], __FILE__, __LINE__);
-    SingleBinning.InitNonUniform(Bins);
+    if(Settings["Bins"].IsSequence()){
+        SingleBinning.InitNonUniform(Get<std::vector<std::vector<std::vector<double>>>>(Settings["Bins"], __FILE__, __LINE__));
+    } else if(Settings["Bins"].IsMap()){
+      auto file = Get<std::string>(Settings["Bins"]["File"], __FILE__, __LINE__);
+      auto key = Get<std::string>(Settings["Bins"]["Key"], __FILE__, __LINE__);
+      auto binfile = LoadYamlConfig(file, __FILE__, __LINE__);
+      SingleBinning.InitNonUniform(Get<std::vector<std::vector<std::vector<double>>>>(binfile[key], __FILE__, __LINE__));
+    } else {
+      std::stringstream ss;
+      ss << Settings["Bins"];
+      MACH3LOG_ERROR(
+          "When parsing binning, expected to find a YAML map or sequence, "
+          "but found:\n{}",
+          ss.str());
+      throw MaCh3Exception(__FILE__, __LINE__);
+    }
   } else {
     YAML::Node const & bin_edges_node = Settings["BinEdges"] ? Settings["BinEdges"] : Settings["VarBins"];
     if(!bin_edges_node){

--- a/Samples/BinningHandler.cpp
+++ b/Samples/BinningHandler.cpp
@@ -1,7 +1,7 @@
 #include "Samples/BinningHandler.h"
-
+_MaCh3_Safe_Include_Start_ //{
 #include "spdlog/fmt/ranges.h"
-
+_MaCh3_Safe_Include_End_ //}
 // ************************************************
 BinningHandler::BinningHandler() {
 // ************************************************

--- a/Samples/BinningHandler.cpp
+++ b/Samples/BinningHandler.cpp
@@ -9,11 +9,13 @@ BinningHandler::BinningHandler() {
 
 auto BinRangeToBinEdges(YAML::Node const &bin_range) {
   bool is_lin = true;
-  YAML::Node bin_range_specifier = bin_range["linspace"];
-  if (bin_range["logspace"]) {
+  YAML::Node bin_range_specifier;
+  if (bin_range["linspace"]) {
+    bin_range_specifier = bin_range["linspace"];
+  } else if (bin_range["logspace"]) {
     is_lin = false;
     bin_range_specifier = bin_range["logspace"];
-  } else if (!bin_range["linspace"]) {
+  } else {
     std::stringstream ss;
     ss << bin_range;
     MACH3LOG_ERROR("When parsing binning, expected bin range specifier with "

--- a/Samples/BinningHandler.cpp
+++ b/Samples/BinningHandler.cpp
@@ -1,8 +1,161 @@
 #include "Samples/BinningHandler.h"
 
+#include "spdlog/fmt/ranges.h"
+
 // ************************************************
 BinningHandler::BinningHandler() {
 // ************************************************
+}
+
+auto BinRangeToBinEdges(const YAML::Node &bin_range) {
+  bool is_lin = true;
+  if (bin_range["logspace"]) {
+    is_lin = false;
+  } else if (!bin_range["linspace"]) {
+    std::stringstream ss;
+    ss << bin_range;
+    MACH3LOG_ERROR("When parsing binning, expected bin range specifier with "
+                   "key linspace or logspace, but found,\n{}",
+                   ss.str());
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+
+  auto nb = Get<int>(bin_range["nb"],__FILE__, __LINE__);
+  auto low = Get<double>(bin_range["low"],__FILE__, __LINE__);
+  auto up = Get<double>(bin_range["up"],__FILE__, __LINE__);
+
+  std::vector<double> edges(nb + 1, low);
+  // force the last bin to be exactly as parsed to avoid numerical instabilities
+  // not quite lining back up with the end of the range, which could
+  // cause spurious errors or infinitesimally small bins for specifications
+  // like: [ { logspace: { nb: 10, 1E-1, 10}, 10, 11} ]
+  edges.back() = up;
+
+  if (is_lin) {
+    double bw = (up - low) / nb;
+    for (int i = 0; i < (nb-1); ++i) {
+      edges[i + 1] = edges[i] + bw;
+    }
+  } else {
+    double llow = std::log10(low);
+    double lup = std::log10(up);
+    double lbw = (lup - llow) / nb;
+    for (int i = 0; i < (nb - 1); ++i) {
+      edges[i + 1] = std::pow(10, llow + (i + 1) * lbw);
+    }
+  }
+
+  return edges;
+}
+
+/// @brief Builds a single dimension's bin edges from YAML::Node
+/// @details
+/// BinEdges:  [ <dim0bin0lowedge>, <dim0bin1upedge>, <dim0bin2upedge>, ...
+/// <dim0binNupedge> ] BinEdges:  { linspace: { nb: 100, low: 0, up: 10} }
+/// BinEdges:  { logspace: { nb: 100, low: 1E-1, up: 10} }
+/// BinEdges:  [ { linspace: { nb: 100, low: 0, up: 10} }, 10, 15, { logspace: {
+/// nb: 5, low: 15, up: 100} } ]
+auto BuildBinEdgesFromNode(const YAML::Node &bin_edges_node) {
+  if (bin_edges_node.IsMap()) {
+    return BinRangeToBinEdges(bin_edges_node);
+  }
+  std::vector<double> edges_builder;
+  if (!bin_edges_node.IsSequence()) {
+    std::stringstream ss;
+    ss << bin_edges_node;
+    MACH3LOG_ERROR("When parsing binning, expected to find a YAML map or sequence, "
+                   "but found:\n{}",
+                   ss.str());
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+  for (auto const &it : bin_edges_node) {
+    if (it.IsScalar()) {
+      edges_builder.push_back(it.as<double>());
+    } else if (it.IsMap()) {
+      auto range_edges = BinRangeToBinEdges(bin_edges_node);
+      std::copy(range_edges.begin(), range_edges.end(),
+                std::back_inserter(edges_builder));
+    } else {
+      std::stringstream ss;
+      ss << bin_edges_node;
+      MACH3LOG_ERROR(
+          "When parsing binning, expected elements in outer sequence to all be "
+          "either scalars or maps, but found:\n{}",
+          ss.str());
+      throw MaCh3Exception(__FILE__, __LINE__);
+    }
+  }
+
+  // Check for duplicates or out-of-order bins
+  std::vector<double> edges;
+  for (size_t eb_it = 0; eb_it < edges_builder.size(); ++eb_it) {
+    if (edges.size()) {
+      if (edges_builder[eb_it] == edges.back()) { // remove duplicate edges
+        continue;
+      } else if (edges_builder[eb_it] < edges.back()) {
+        MACH3LOG_ERROR(
+            "When parsing binning, found edges that were not monotonically "
+            "increasing, problem bin at index: {}:\n{}",
+            eb_it, edges_builder);
+        throw MaCh3Exception(__FILE__, __LINE__);
+      }
+    }
+    edges.push_back(edges_builder[eb_it]);
+  }
+
+  return edges;
+}
+
+/// @brief Parses YAML node describing multidim uniform binning
+/// @details
+/// # dimensional list implicit for 1D binnings
+/// BinEdges:  [<dim0bin0lowedge>, <dim0bin1upedge>, <dim0bin2upedge>, ... <dim0binNupedge>]
+///
+/// BinEdges: [ [<dim0bin0lowedge>, <dim0bin1upedge>, <dim0bin2upedge>, ... <dim0binNupedge>],
+///            ...
+///            [<dimNbin0lowedge>, <dimNbin1upedge>, <dimNbin2upedge>, ... <dimNbinNupedge>] ]
+///
+/// # bin edge list implicit for 1D range-only binnings
+/// BinEdges: { linspace: { nb: 100, low: 0, up: 10} }
+/// # mixed syntax binnings allowed
+/// BinEdges: [ { linspace: { nb: 100, low: 0, up: 10} }, 10, 15, { logspace: { nb: 5, low: 15, up: 100} }  ]
+/// # for ND range-only binnings, lists are required to disambiguate 1D mixed specifier binnings from ND binnings
+/// BinEdges: [ [ { linspace: { nb: 100, low: 0, up: 10} } ],
+///            ...
+///            [<dimNbin0lowedge>, <dimNbin1upedge>, <dimNbin2upedge>, ... <dimNbinNupedge>] ]
+/// BinEdges: [ [ { linspace: { nb: 100, low: 0, up: 10} }, 10, 15, { logspace: { nb: 5, low: 15, up: 100} }  ],
+///            ...
+///            [<dimNbin0lowedge>, <dimNbin1upedge>, <dimNbin2upedge>, ... <dimNbinNupedge>] ]
+auto UniformBinEdgeConfigParser(const YAML::Node &bin_edges_node) {
+  if (bin_edges_node.IsMap()) {
+    return std::vector<std::vector<double>>{BinRangeToBinEdges(bin_edges_node),};
+  } else if (bin_edges_node.IsSequence()) {
+    if (!bin_edges_node.size()) {
+      std::stringstream ss;
+      ss << bin_edges_node;
+      MACH3LOG_ERROR("When parsing binning, found an empty sequence:\n{}",
+                     ss.str());
+      throw MaCh3Exception(__FILE__, __LINE__);
+    }
+    auto const & first_el = bin_edges_node[0];
+    if(first_el.IsScalar() || first_el.IsMap()){ // 1D binning
+      return std::vector<std::vector<double>>{BuildBinEdgesFromNode(bin_edges_node),};
+    }
+    //ND binning
+    std::vector<std::vector<double>> dims;
+    for(auto const &dim_node : bin_edges_node){
+      dims.push_back(BuildBinEdgesFromNode(dim_node));
+    }
+    return dims;
+  } else {
+    std::stringstream ss;
+    ss << bin_edges_node;
+    MACH3LOG_ERROR(
+        "When parsing binning, expected to find a YAML map or sequence, "
+        "but found:\n{}",
+        ss.str());
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
 }
 
 // ************************************************
@@ -23,8 +176,12 @@ void BinningHandler::SetupSampleBinning(const YAML::Node& Settings, SampleInfo& 
     auto Bins = Get<std::vector<std::vector<std::vector<double>>>>(Settings["Bins"], __FILE__, __LINE__);
     SingleBinning.InitNonUniform(Bins);
   } else {
-    auto Bin_Edges = Get<std::vector<std::vector<double>>>(Settings["VarBins"], __FILE__ , __LINE__);
-    SingleBinning.InitUniform(Bin_Edges);
+    YAML::Node const & bin_edges_node = Settings["BinEdges"] ? Settings["BinEdges"] : Settings["VarBins"];
+    if(!bin_edges_node){
+      MACH3LOG_ERROR("When setting up Uniform sample binning, didn't find expected key: BinEdges (or VarBins for backward compatibility).");
+      throw MaCh3Exception(__FILE__, __LINE__);
+    }
+    SingleBinning.InitUniform(UniformBinEdgeConfigParser(bin_edges_node));
   }
   if(SingleSample.VarStr.size() != SingleBinning.BinEdges.size()) {
     MACH3LOG_ERROR("Number of variables ({}) does not match number of bin edge sets ({}) in sample config '{}'",

--- a/Samples/BinningHandler.cpp
+++ b/Samples/BinningHandler.cpp
@@ -188,7 +188,11 @@ void BinningHandler::SetupSampleBinning(const YAML::Node& Settings, SampleInfo& 
 // ************************************************
   MACH3LOG_INFO("Setting up Sample Binning");
   //Binning
-  SingleSample.VarStr = Get<std::vector<std::string>>(Settings["VarStr"], __FILE__ , __LINE__);
+  SingleSample.VarStr = (Settings["VarStr"] && Settings["VarStr"].IsScalar())
+                            ? std::vector<std::string>{Get<std::string>(
+                                  Settings["VarStr"], __FILE__, __LINE__)}
+                            : Get<std::vector<std::string>>(Settings["VarStr"],
+                                                            __FILE__, __LINE__);
   SingleSample.nDimensions = static_cast<int>(SingleSample.VarStr.size());
 
   SampleBinningInfo SingleBinning;

--- a/Samples/BinningHandler.cpp
+++ b/Samples/BinningHandler.cpp
@@ -1,7 +1,5 @@
 #include "Samples/BinningHandler.h"
-_MaCh3_Safe_Include_Start_ //{
-#include "spdlog/fmt/ranges.h"
-_MaCh3_Safe_Include_End_ //}
+
 // ************************************************
 BinningHandler::BinningHandler() {
 // ************************************************
@@ -101,10 +99,16 @@ auto BuildBinEdgesFromNode(YAML::Node const &bin_edges_node,
       if (edges_builder[eb_it] == edges.back()) { // remove duplicate edges
         continue;
       } else if (edges_builder[eb_it] < edges.back()) {
+        std::stringstream ss;
+        ss << "[ ";
+        for(auto const & e : edges_builder){
+          ss << fmt::format("{:g.3} ", e);
+        }
+        ss << "]";
         MACH3LOG_ERROR(
             "When parsing binning, found edges that were not monotonically "
             "increasing, problem bin at index: {}:\n{}",
-            eb_it, edges_builder);
+            eb_it, ss.str());
         throw MaCh3Exception(__FILE__, __LINE__);
       }
     }

--- a/Samples/BinningHandler.cpp
+++ b/Samples/BinningHandler.cpp
@@ -7,10 +7,12 @@ BinningHandler::BinningHandler() {
 // ************************************************
 }
 
-auto BinRangeToBinEdges(const YAML::Node &bin_range) {
+auto BinRangeToBinEdges(YAML::Node const &bin_range) {
   bool is_lin = true;
+  YAML::Node bin_range_specifier = bin_range["linspace"];
   if (bin_range["logspace"]) {
     is_lin = false;
+    bin_range_specifier = bin_range["logspace"];
   } else if (!bin_range["linspace"]) {
     std::stringstream ss;
     ss << bin_range;
@@ -20,9 +22,9 @@ auto BinRangeToBinEdges(const YAML::Node &bin_range) {
     throw MaCh3Exception(__FILE__, __LINE__);
   }
 
-  auto nb = Get<int>(bin_range["nb"],__FILE__, __LINE__);
-  auto low = Get<double>(bin_range["low"],__FILE__, __LINE__);
-  auto up = Get<double>(bin_range["up"],__FILE__, __LINE__);
+  auto nb = Get<int>(bin_range_specifier["nb"], __FILE__, __LINE__);
+  auto low = Get<double>(bin_range_specifier["low"], __FILE__, __LINE__);
+  auto up = Get<double>(bin_range_specifier["up"], __FILE__, __LINE__);
 
   std::vector<double> edges(nb + 1, low);
   // force the last bin to be exactly as parsed to avoid numerical instabilities
@@ -33,7 +35,7 @@ auto BinRangeToBinEdges(const YAML::Node &bin_range) {
 
   if (is_lin) {
     double bw = (up - low) / nb;
-    for (int i = 0; i < (nb-1); ++i) {
+    for (int i = 0; i < (nb - 1); ++i) {
       edges[i + 1] = edges[i] + bw;
     }
   } else {
@@ -55,24 +57,28 @@ auto BinRangeToBinEdges(const YAML::Node &bin_range) {
 /// BinEdges:  { logspace: { nb: 100, low: 1E-1, up: 10} }
 /// BinEdges:  [ { linspace: { nb: 100, low: 0, up: 10} }, 10, 15, { logspace: {
 /// nb: 5, low: 15, up: 100} } ]
-auto BuildBinEdgesFromNode(const YAML::Node &bin_edges_node) {
+auto BuildBinEdgesFromNode(YAML::Node const &bin_edges_node,
+                           bool &found_range_specifier) {
   if (bin_edges_node.IsMap()) {
+    found_range_specifier = true;
     return BinRangeToBinEdges(bin_edges_node);
   }
   std::vector<double> edges_builder;
   if (!bin_edges_node.IsSequence()) {
     std::stringstream ss;
     ss << bin_edges_node;
-    MACH3LOG_ERROR("When parsing binning, expected to find a YAML map or sequence, "
-                   "but found:\n{}",
-                   ss.str());
+    MACH3LOG_ERROR(
+        "When parsing binning, expected to find a YAML map or sequence, "
+        "but found:\n{}",
+        ss.str());
     throw MaCh3Exception(__FILE__, __LINE__);
   }
   for (auto const &it : bin_edges_node) {
     if (it.IsScalar()) {
       edges_builder.push_back(it.as<double>());
     } else if (it.IsMap()) {
-      auto range_edges = BinRangeToBinEdges(bin_edges_node);
+      found_range_specifier = true;
+      auto range_edges = BinRangeToBinEdges(it);
       std::copy(range_edges.begin(), range_edges.end(),
                 std::back_inserter(edges_builder));
     } else {
@@ -109,26 +115,37 @@ auto BuildBinEdgesFromNode(const YAML::Node &bin_edges_node) {
 /// @brief Parses YAML node describing multidim uniform binning
 /// @details
 /// # dimensional list implicit for 1D binnings
-/// BinEdges:  [<dim0bin0lowedge>, <dim0bin1upedge>, <dim0bin2upedge>, ... <dim0binNupedge>]
+/// BinEdges:  [<dim0bin0lowedge>, <dim0bin1upedge>, <dim0bin2upedge>, ...
+/// <dim0binNupedge>]
 ///
-/// BinEdges: [ [<dim0bin0lowedge>, <dim0bin1upedge>, <dim0bin2upedge>, ... <dim0binNupedge>],
+/// BinEdges: [ [<dim0bin0lowedge>, <dim0bin1upedge>, <dim0bin2upedge>, ...
+/// <dim0binNupedge>],
 ///            ...
-///            [<dimNbin0lowedge>, <dimNbin1upedge>, <dimNbin2upedge>, ... <dimNbinNupedge>] ]
+///            [<dimNbin0lowedge>, <dimNbin1upedge>, <dimNbin2upedge>, ...
+///            <dimNbinNupedge>] ]
 ///
 /// # bin edge list implicit for 1D range-only binnings
 /// BinEdges: { linspace: { nb: 100, low: 0, up: 10} }
 /// # mixed syntax binnings allowed
-/// BinEdges: [ { linspace: { nb: 100, low: 0, up: 10} }, 10, 15, { logspace: { nb: 5, low: 15, up: 100} }  ]
-/// # for ND range-only binnings, lists are required to disambiguate 1D mixed specifier binnings from ND binnings
+/// BinEdges: [ { linspace: { nb: 100, low: 0, up: 10} }, 10, 15, { logspace: {
+/// nb: 5, low: 15, up: 100} }  ] # for ND range-only binnings, lists are
+/// required to disambiguate 1D mixed specifier binnings from ND binnings
 /// BinEdges: [ [ { linspace: { nb: 100, low: 0, up: 10} } ],
 ///            ...
-///            [<dimNbin0lowedge>, <dimNbin1upedge>, <dimNbin2upedge>, ... <dimNbinNupedge>] ]
-/// BinEdges: [ [ { linspace: { nb: 100, low: 0, up: 10} }, 10, 15, { logspace: { nb: 5, low: 15, up: 100} }  ],
+///            [<dimNbin0lowedge>, <dimNbin1upedge>, <dimNbin2upedge>, ...
+///            <dimNbinNupedge>] ]
+/// BinEdges: [ [ { linspace: { nb: 100, low: 0, up: 10} }, 10, 15, { logspace:
+/// { nb: 5, low: 15, up: 100} }  ],
 ///            ...
-///            [<dimNbin0lowedge>, <dimNbin1upedge>, <dimNbin2upedge>, ... <dimNbinNupedge>] ]
-auto UniformBinEdgeConfigParser(const YAML::Node &bin_edges_node) {
+///            [<dimNbin0lowedge>, <dimNbin1upedge>, <dimNbin2upedge>, ...
+///            <dimNbinNupedge>] ]
+auto UniformBinEdgeConfigParser(YAML::Node const &bin_edges_node,
+                                bool &found_range_specifier) {
   if (bin_edges_node.IsMap()) {
-    return std::vector<std::vector<double>>{BinRangeToBinEdges(bin_edges_node),};
+    found_range_specifier = true;
+    return std::vector<std::vector<double>>{
+        BinRangeToBinEdges(bin_edges_node),
+    };
   } else if (bin_edges_node.IsSequence()) {
     if (!bin_edges_node.size()) {
       std::stringstream ss;
@@ -137,14 +154,16 @@ auto UniformBinEdgeConfigParser(const YAML::Node &bin_edges_node) {
                      ss.str());
       throw MaCh3Exception(__FILE__, __LINE__);
     }
-    auto const & first_el = bin_edges_node[0];
-    if(first_el.IsScalar() || first_el.IsMap()){ // 1D binning
-      return std::vector<std::vector<double>>{BuildBinEdgesFromNode(bin_edges_node),};
+    auto const &first_el = bin_edges_node[0];
+    if (first_el.IsScalar() || first_el.IsMap()) { // 1D binning
+      return std::vector<std::vector<double>>{
+          BuildBinEdgesFromNode(bin_edges_node, found_range_specifier),
+      };
     }
-    //ND binning
+    // ND binning
     std::vector<std::vector<double>> dims;
-    for(auto const &dim_node : bin_edges_node){
-      dims.push_back(BuildBinEdgesFromNode(dim_node));
+    for (auto const &dim_node : bin_edges_node) {
+      dims.push_back(BuildBinEdgesFromNode(dim_node, found_range_specifier));
     }
     return dims;
   } else {
@@ -172,6 +191,7 @@ void BinningHandler::SetupSampleBinning(const YAML::Node& Settings, SampleInfo& 
 
   SampleBinningInfo SingleBinning;
   bool Uniform = Get<bool>(Settings["Uniform"], __FILE__ , __LINE__);
+  bool found_range_specifier = false;
   if(Uniform == false) {
     auto Bins = Get<std::vector<std::vector<std::vector<double>>>>(Settings["Bins"], __FILE__, __LINE__);
     SingleBinning.InitNonUniform(Bins);
@@ -181,11 +201,25 @@ void BinningHandler::SetupSampleBinning(const YAML::Node& Settings, SampleInfo& 
       MACH3LOG_ERROR("When setting up Uniform sample binning, didn't find expected key: BinEdges (or VarBins for backward compatibility).");
       throw MaCh3Exception(__FILE__, __LINE__);
     }
-    SingleBinning.InitUniform(UniformBinEdgeConfigParser(bin_edges_node));
+    SingleBinning.InitUniform(UniformBinEdgeConfigParser(bin_edges_node, found_range_specifier));
   }
   if(SingleSample.VarStr.size() != SingleBinning.BinEdges.size()) {
     MACH3LOG_ERROR("Number of variables ({}) does not match number of bin edge sets ({}) in sample config '{}'",
                    SingleSample.VarStr.size(), SingleBinning.BinEdges.size(),SingleSample.SampleTitle);
+    if(found_range_specifier){
+      std::stringstream ss;
+      ss << (Settings["BinEdges"] ? Settings["BinEdges"] : Settings["VarBins"]);
+      MACH3LOG_ERROR(R"(A bin range specifier was found in node:
+
+  {}
+
+Please carefully check the number of square brackets used, a 2D binning
+  comprised of just 2 range specifiers must explicitly include the axis
+  list specifier like:
+
+  BinEdges: [ [ {{linspace: {{nb:10, low:0, up: 10}}}} ], [ {{linspace: {{nb:5, low:10, up: 100}}}} ] ]
+)", ss.str());
+    }
     throw MaCh3Exception(__FILE__, __LINE__);
   }
 

--- a/Samples/BinningHandler.cpp
+++ b/Samples/BinningHandler.cpp
@@ -102,7 +102,7 @@ auto BuildBinEdgesFromNode(YAML::Node const &bin_edges_node,
         std::stringstream ss;
         ss << "[ ";
         for(auto const & e : edges_builder){
-          ss << fmt::format("{:g.3} ", e);
+          ss << fmt::format("{:.3g} ", e);
         }
         ss << "]";
         MACH3LOG_ERROR(

--- a/Samples/BinningHandler.h
+++ b/Samples/BinningHandler.h
@@ -160,6 +160,8 @@ class BinningHandler {
   int GetNBins() const {return TotalNumberOfBins;};
   /// @brief Get total number of bins over for a given sample
   int GetNBins(const int iSample) const {return static_cast<int>(SampleBinning[iSample].nBins);};
+  /// @brief Get total number of dimensions for sample iSample
+  int GetNDim(const int iSample) const { return int(SampleBinning[iSample].BinEdges.size()); }
   /// @brief Get fancy name for a given bin, to help match it with global properties
   /// @param GlobalBin Global Bin integrated over all samples
   std::string GetBinName(const int GlobalBin) const;

--- a/Samples/SampleStructs.h
+++ b/Samples/SampleStructs.h
@@ -252,6 +252,8 @@ struct SampleBinningInfo {
   std::vector<std::vector<int>> BinGridMapping;
 
   /// @brief Initialise Uniform Binning
+  /// @details The outer vector loops over dimensions and the inner vector specifies
+  //           all bin edges along that dimension. Get 1 less bin than number of edges.
   void InitUniform(const std::vector<std::vector<double>>& InputEdges) {
     BinEdges = InputEdges;
     Uniform = true;
@@ -262,7 +264,7 @@ struct SampleBinningInfo {
     {
       const auto& Edges = BinEdges[iDim];
       if (!std::is_sorted(Edges.begin(), Edges.end())) {
-        MACH3LOG_ERROR("VarBins for Dim {} must be in increasing order in sample config, VarBins: [{}]",
+        MACH3LOG_ERROR("Bin edges for Dim {} must be in increasing order in sample config. Bin edges passed: [{}]",
                        iDim, fmt::join(Edges, ", "));
         throw MaCh3Exception(__FILE__, __LINE__);
       }
@@ -735,9 +737,9 @@ namespace MaCh3Utils {
       case 12:
       case 14:
       case 16:
-        return 0.; 
+        return 0.;
       // Photon
-      case 22: return 0.; 
+      case 22: return 0.;
       // Mesons
       case 211: return 0.13957039; // pi_+/-
       case 111: return 0.1349768;  // pi_0


### PR DESCRIPTION
# Pull request description

Augments the uniform binning parser to allow bin range specifiers.

## Examples

```yaml
# dimensional list implicit for 1D binnings
BinEdges:  [<dim0bin0lowedge>, <dim0bin1upedge>, <dim0bin2upedge>, ... <dim0binNupedge>]

BinEdges: [ [<dim0bin0lowedge>, <dim0bin1upedge>, <dim0bin2upedge>, ... <dim0binNupedge>],
                    # ...
                    [<dimNbin0lowedge>, <dimNbin1upedge>, <dimNbin2upedge>, ... <dimNbinNupedge>] ]

# bin edge list implicit for 1D range-only binnings
BinEdges: { linspace: { nb: 100, low: 0, up: 10} }
# mixed syntax binnings allowed
BinEdges: [ { linspace: { nb: 100, low: 0, up: 10} }, 10, 15, { logspace: { nb: 5, low: 15, up: 100} }  ]
# for ND range-only binnings, lists are required to disambiguate 1D mixed specifier binnings from ND binnings
BinEdges: [ [ { linspace: { nb: 100, low: 0, up: 10} } ],
                     # ...
                    [<dimNbin0lowedge>, <dimNbin1upedge>, <dimNbin2upedge>, ... <dimNbinNupedge>] ]
BinEdges: [ [ { linspace: { nb: 100, low: 0, up: 10} }, 10, 15, { logspace: { nb: 5, low: 15, up: 100} }  ],
                    # ...
                    [<dimNbin0lowedge>, <dimNbin1upedge>, <dimNbin2upedge>, ... <dimNbinNupedge>] ]
```

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
