### PR TITLE
feat: Ability to set KinemBounds for splines

### DIFF
--- a/Parameters/ParameterHandlerGeneric.cpp
+++ b/Parameters/ParameterHandlerGeneric.cpp
@@ -169,6 +169,19 @@ NormParameter ParameterHandlerGeneric::GetNormParameter(const YAML::Node& param,
     MACH3LOG_ERROR("Normalisation parameters can't go bellow 0 as this is unphysical");
     throw MaCh3Exception(__FILE__, __LINE__);
   }
+
+  return norm;
+}
+
+// ********************************************
+// Get Base Param
+void ParameterHandlerGeneric::GetBaseParameter(const YAML::Node& param, const int Index, TypeParameterBase& Parameter) {
+// ********************************************
+  Parameter.name = GetParFancyName(Index);
+
+  // Set the global parameter index of the normalisation parameter
+  Parameter.index = Index;
+
   int NumKinematicCuts = 0;
   if(param["KinematicCuts"]) {
     NumKinematicCuts = int(param["KinematicCuts"].size());
@@ -184,39 +197,23 @@ NormParameter ParameterHandlerGeneric::GetNormParameter(const YAML::Node& param,
       }
       if(TempKinematicStrings.size() == 0) {
         MACH3LOG_ERROR("Received a KinematicCuts node but couldn't read the contents (it's a list of single-element dictionaries (python) = map of pairs (C++))");
-        MACH3LOG_ERROR("For Param {}", norm.name);
+        MACH3LOG_ERROR("For Param {}", Parameter.name);
         throw MaCh3Exception(__FILE__, __LINE__);
       }
     }//KinVar_i
-    norm.KinematicVarStr = TempKinematicStrings;
-    norm.Selection = TempKinematicBounds;
+    Parameter.KinematicVarStr = TempKinematicStrings;
+    Parameter.Selection = TempKinematicBounds;
   }
 
   //Next ones are kinematic bounds on where normalisation parameter should apply
   //We set a bool to see if any bounds exist so we can short-circuit checking all of them every step
   bool HasKinBounds = false;
 
-  if(norm.KinematicVarStr.size() > 0) HasKinBounds = true;
+  if(Parameter.KinematicVarStr.size() > 0) HasKinBounds = true;
 
-  norm.hasKinBounds = HasKinBounds;
+  Parameter.hasKinBounds = HasKinBounds;
   //End of kinematic bound checking
-
-  return norm;
 }
-
-// ********************************************
-// Get Base Param
-void ParameterHandlerGeneric::GetBaseParameter(const YAML::Node& param, const int Index, TypeParameterBase& Parameter) {
-// ********************************************
-  // KS: For now we don't use so avoid compilation error
-  (void) param;
-
-  Parameter.name = GetParFancyName(Index);
-
-  // Set the global parameter index of the normalisation parameter
-  Parameter.index = Index;
-}
-
 
 // ********************************************
 // Grab the global syst index for the relevant SampleName
@@ -288,34 +285,8 @@ FunctionalParameter ParameterHandlerGeneric::GetFunctionalParameters(const YAML:
   FunctionalParameter func;
   GetBaseParameter(param, Index, func);
 
-  func.pdgs = GetFromManager<std::vector<int>>(param["NeutrinoFlavour"], std::vector<int>(), __FILE__ , __LINE__);
-  func.targets = GetFromManager<std::vector<int>>(param["TargetNuclei"], std::vector<int>(), __FILE__ , __LINE__);
   func.modes = GetFromManager<std::vector<int>>(param["Mode"], std::vector<int>(), __FILE__ , __LINE__);
-  func.preoscpdgs = GetFromManager<std::vector<int>>(param["NeutrinoFlavourUnosc"], std::vector<int>(), __FILE__ , __LINE__);
 
-  // HH - Copied from GetXsecNorm
-  int NumKinematicCuts = 0;
-  if(param["KinematicCuts"]) {
-    NumKinematicCuts = int(param["KinematicCuts"].size());
-
-    std::vector<std::string> TempKinematicStrings;
-    std::vector<std::vector<std::vector<double>>> TempKinematicBounds;
-    //First element of TempKinematicBounds is always -999, and size is then 3
-    for(int KinVar_i = 0 ; KinVar_i < NumKinematicCuts ; ++KinVar_i){
-      //ETA: This is a bit messy, Kinematic cuts is a list of maps
-      for (YAML::const_iterator it = param["KinematicCuts"][KinVar_i].begin();it!=param["KinematicCuts"][KinVar_i].end();++it) {
-        TempKinematicStrings.push_back(it->first.as<std::string>());
-        TempKinematicBounds.push_back(Get2DBounds(it->second));
-      }
-      if(TempKinematicStrings.size() == 0) {
-        MACH3LOG_ERROR("Received a KinematicCuts node but couldn't read the contents (it's a list of single-element dictionaries (python) = map of pairs (C++))");
-        MACH3LOG_ERROR("For Param {}", func.name);
-        throw MaCh3Exception(__FILE__, __LINE__);
-      }
-    }//KinVar_i
-    func.KinematicVarStr = TempKinematicStrings;
-    func.Selection = TempKinematicBounds;
-  }
   func.valuePtr = RetPointer(Index);
   return func;
 }

--- a/Parameters/ParameterHandlerGeneric.cpp
+++ b/Parameters/ParameterHandlerGeneric.cpp
@@ -622,14 +622,20 @@ std::vector<std::string> ParameterHandlerGeneric::GetUniqueParameterGroups() con
 void ParameterHandlerGeneric::CheckCorrectInitialisation() const {
 // ********************************************
   // KS: Lambda Function which simply checks if there are no duplicates in std::vector
-  auto CheckForDuplicates = [](const std::vector<std::string>& names, const std::string& nameType) {
+  auto CheckForDuplicates = [](const std::vector<std::string>& names, const std::string& nameType, bool Warning) {
     std::unordered_map<std::string, size_t> seenStrings;
     for (size_t i = 0; i < names.size(); ++i) {
       const auto& name = names[i];
       if (seenStrings.find(name) != seenStrings.end()) {
         size_t firstIndex = seenStrings[name];
-        MACH3LOG_CRITICAL("There are two systematics with the same {} '{}', first at index {}, and again at index {}", nameType, name, firstIndex, i);
-        throw MaCh3Exception(__FILE__, __LINE__);
+        if(Warning){
+          MACH3LOG_WARN("There are two systematics with the same {} '{}', first at index {}, and again at index {}", nameType, name, firstIndex, i);
+          MACH3LOG_WARN("Is this desired?");
+          return;
+        } else {
+          MACH3LOG_CRITICAL("There are two systematics with the same {} '{}', first at index {}, and again at index {}", nameType, name, firstIndex, i);
+          throw MaCh3Exception(__FILE__, __LINE__);
+        }
       }
       seenStrings[name] = i;
     }
@@ -639,8 +645,8 @@ void ParameterHandlerGeneric::CheckCorrectInitialisation() const {
     SplineNameTemp[it] = SplineParams[it]._fSplineNames;
   }
   // KS: Checks if there are no duplicates in fancy names etc, this can happen if we merge configs etc
-  CheckForDuplicates(_fFancyNames, "_fFancyNames");
-  CheckForDuplicates(SplineNameTemp, "_fSplineNames");
+  CheckForDuplicates(_fFancyNames, "_fFancyNames", false);
+  CheckForDuplicates(SplineNameTemp, "_fSplineNames", true);
 }
 
 // ********************************************

--- a/Parameters/ParameterStructs.h
+++ b/Parameters/ParameterStructs.h
@@ -95,10 +95,23 @@ void CleanContainer(std::vector<T>& container) {
 // *******************
 /// @brief Base class storing info for parameters types, helping unify codebase
 /// @ingroup SamplesAndParameters
+/// @author Ed Atkin
+/// @author Kamil Skwarczynski
 struct TypeParameterBase {
 // *******************
   /// Name of parameters
   std::string name;
+
+  /// Does this parameter have kinematic bounds
+  bool hasKinBounds = false;
+  /// Generic vector contain enum relating to a kinematic variable
+  /// and lower and upper bounds. This can then be passed to IsEventSelected
+  std::vector< std::vector< std::vector<double> > > Selection;
+  /// Generic vector containing the string of kinematic type
+  /// This then needs to be converted to a kinematic type enum
+  /// within a SampleHandler daughter class
+  /// The bounds for each kinematic variable are given in Selection
+  std::vector< std::string > KinematicVarStr;
 
   /// Parameter number of this normalisation in current systematic model
   int index = M3::_BAD_INT_;
@@ -117,17 +130,6 @@ struct NormParameter : public TypeParameterBase {
   std::vector<int> preoscpdgs;
   /// Targets which parameter applies to
   std::vector<int> targets;
-  /// Does this parameter have kinematic bounds
-  bool hasKinBounds;
-  /// Generic vector contain enum relating to a kinematic variable
-  /// and lower and upper bounds. This can then be passed to IsEventSelected
-  std::vector< std::vector< std::vector<double> > > Selection;
-
-  /// Generic vector containing the string of kinematic type
-  /// This then needs to be converted to a kinematic type enum
-  /// within a SampleHandler daughter class
-  /// The bounds for each kinematic variable are given in Selection
-  std::vector< std::string > KinematicVarStr;
 };
 
 /// HH - a shorthand type for funcpar functions
@@ -140,29 +142,12 @@ struct FunctionalParameter : public TypeParameterBase {
 // *******************
   /// Mode which parameter applies to
   std::vector<int> modes;
-  /// PDG which parameter applies to
-  std::vector<int> pdgs;
-  /// Preosc PDG which parameter applies to
-  std::vector<int> preoscpdgs;
-  /// Targets which parameter applies to
-  std::vector<int> targets;
-  /// Does this parameter have kinematic bounds
-  bool hasKinBounds;
-  /// Generic vector contain enum relating to a kinematic variable
-  /// and lower and upper bounds. This can then be passed to IsEventSelected
-  std::vector< std::vector< std::vector<double> > > Selection;
-
-  /// Generic vector containing the string of kinematic type
-  /// This then needs to be converted to a kinematic type enum
-  /// within a SampleHandler daughter class
-  /// The bounds for each kinematic variable are given in Selection
-  std::vector< std::string > KinematicVarStr;
 
   /// Parameter value pointer
-  const double* valuePtr;
+  const double* valuePtr = nullptr;
 
   /// Function pointer
-  FuncParFuncType* funcPtr;
+  FuncParFuncType* funcPtr = nullptr;
 };
 
 /// Make an enum of the spline interpolation type

--- a/Samples/BinningHandler.h
+++ b/Samples/BinningHandler.h
@@ -125,6 +125,7 @@
 ///
 /// @author Kamil Skwarczynski
 /// @author Dan Barrow
+/// @author Luke Pickering
 class BinningHandler {
 // ***************************
  public:

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -1193,53 +1193,69 @@ M3::float_t SampleHandlerFD::GetEventWeight(const int iEntry) {
 }
 
 // ************************************************
+std::vector< std::vector<int> > SampleHandlerFD::GetSplineBins(int Event, BinnedSplineHandler* BinnedSpline, bool& ThrowCrititcal) const {
+// ************************************************
+  const int SampleIndex = MCSamples[Event].NominalSample;
+  const auto SampleTitle = GetSampleTitle(SampleIndex);
+  bool NoOscChannels = false;
+  if(Oscillator == nullptr && GetNOscChannels(SampleIndex) == 1) {
+    MACH3LOG_DEBUG("Assuming there are no osc channels in {}", __func__);
+    NoOscChannels = true;
+  }
+  const int OscIndex = NoOscChannels ? 0 : GetOscChannel(SampleDetails[SampleIndex].OscChannels,
+                                                         (*MCSamples[Event].nupdgUnosc), (*MCSamples[Event].nupdg));
+  const int Mode = int(*(MCSamples[Event].mode));
+  const double Etrue = *(MCSamples[Event].rw_etru);
+  std::vector< std::vector<int> > EventSplines;
+  switch(GetNDim(SampleIndex)) {
+    case 1:
+      EventSplines = BinnedSpline->GetEventSplines(SampleTitle, OscIndex, Mode, Etrue, *(MCSamples[Event].KinVar[0]), 0.);
+      break;
+    case 2:
+      EventSplines = BinnedSpline->GetEventSplines(SampleTitle, OscIndex, Mode, Etrue, *(MCSamples[Event].KinVar[0]), *(MCSamples[Event].KinVar[1]));
+      break;
+    default:
+      if(ThrowCrititcal) {
+        MACH3LOG_CRITICAL("MaCh3 doesn't support binned splines for more than 2D while you use {}", GetNDim(SampleIndex));
+        MACH3LOG_CRITICAL("Will use 2D like approach");
+        ThrowCrititcal = false;
+      }
+      EventSplines = BinnedSpline->GetEventSplines(SampleTitle, OscIndex, Mode, Etrue, *(MCSamples[Event].KinVar[0]), *(MCSamples[Event].KinVar[1]));
+      break;
+  }
+  return EventSplines;
+}
+
+// ************************************************
 void SampleHandlerFD::SetSplinePointers() {
 // ************************************************
   //Now loop over events and get the spline bin for each event
   if (auto BinnedSpline = dynamic_cast<BinnedSplineHandler*>(SplineHandler.get())) {
     bool ThrowCrititcal = true;
-
+    auto SplineParsVec = ParHandler->GetSplineParsFromSampleName(SampleHandlerName);
     for (unsigned int j = 0; j < GetNEvents(); ++j) {
-      const int SampleIndex = MCSamples[j].NominalSample;
-      const auto SampleTitle = GetSampleTitle(SampleIndex);
-      bool NoOscChannels = false;
-      if(Oscillator == nullptr && GetNOscChannels(SampleIndex) == 1) {
-        MACH3LOG_DEBUG("Assuming there are no osc channels in {}", __func__);
-        NoOscChannels = true;
-      }
-      const int OscIndex = NoOscChannels ? 0 : GetOscChannel(SampleDetails[SampleIndex].OscChannels,
-                                                             (*MCSamples[j].nupdgUnosc), (*MCSamples[j].nupdg));
-      const int Mode = int(*(MCSamples[j].mode));
-      const double Etrue = *(MCSamples[j].rw_etru);
-      std::vector< std::vector<int> > EventSplines;
-      switch(GetNDim(SampleIndex)) {
-        case 1:
-          EventSplines = BinnedSpline->GetEventSplines(SampleTitle, OscIndex, Mode, Etrue, *(MCSamples[j].KinVar[0]), 0.);
-          break;
-        case 2:
-          EventSplines = BinnedSpline->GetEventSplines(SampleTitle, OscIndex, Mode, Etrue, *(MCSamples[j].KinVar[0]), *(MCSamples[j].KinVar[1]));
-          break;
-        default:
-          if(ThrowCrititcal) {
-            MACH3LOG_CRITICAL("MaCh3 doesn't support binned splines for more than 2D while you use {}", GetNDim(SampleIndex));
-            MACH3LOG_CRITICAL("Will use 2D like approach");
-            ThrowCrititcal = false;
-          }
-          EventSplines = BinnedSpline->GetEventSplines(SampleTitle, OscIndex, Mode, Etrue, *(MCSamples[j].KinVar[0]), *(MCSamples[j].KinVar[1]));
-          break;
-      }
+      auto EventSplines = GetSplineBins(j, BinnedSpline, ThrowCrititcal);
       const int NSplines = static_cast<int>(EventSplines.size());
       if(NSplines == 0) continue;
-      const int PointersBefore = static_cast<int>(MCSamples[j].total_weight_pointers.size());
-      MCSamples[j].total_weight_pointers.resize(PointersBefore + NSplines);
+      auto& w_pointers = MCSamples[j].total_weight_pointers;
+      w_pointers.reserve(w_pointers.size() + NSplines);
 
       for(int spline = 0; spline < NSplines; spline++) {
+        int SystIndex = EventSplines[spline][2];
+
+        bool IsSelected = PassesSelection(SplineParsVec[SystIndex], j);
+        // Need to then break the event loop
+        if(!IsSelected){
+          MACH3LOG_TRACE("Event {}, missed Kinematic var check for dial {}", j, SplineParsVec[SystIndex].name);
+          continue;
+        }
         //Event Splines indexed as: sample name, oscillation channel, syst, mode, etrue, var1, var2 (var2 is a dummy 0 for 1D splines)
-        MCSamples[j].total_weight_pointers[PointersBefore+spline] = BinnedSpline->retPointer(EventSplines[spline][0], EventSplines[spline][1],
-                                                                                              EventSplines[spline][2], EventSplines[spline][3],
-                                                                                              EventSplines[spline][4], EventSplines[spline][5],
-                                                                                              EventSplines[spline][6]);
+        w_pointers.push_back(BinnedSpline->retPointer(EventSplines[spline][0], EventSplines[spline][1],
+                                                      EventSplines[spline][2], EventSplines[spline][3],
+                                                      EventSplines[spline][4], EventSplines[spline][5],
+                                                      EventSplines[spline][6]));
       } // end loop over splines
+      w_pointers.shrink_to_fit();
     } // end loop over events
   } else if (auto UnbinnedSpline = dynamic_cast<SMonolith*>(SplineHandler.get())) {
     /// @todo Fix this mess :(

--- a/Samples/SampleHandlerFD.h
+++ b/Samples/SampleHandlerFD.h
@@ -219,6 +219,9 @@ class SampleHandlerFD :  public SampleHandlerBase
   /// @brief Set pointers for each event to appropriate weights, for unbinned based on event number
   /// while for binned based on other kinematical properties
   void SetSplinePointers();
+  /// @brief Retrieve the spline bin indices associated with a given event.
+  /// @warning ThrowCrititcal argument will be eventually removed
+  std::vector< std::vector<int> > GetSplineBins(int Event, BinnedSplineHandler* BinnedSpline, bool& ThrowCrititcal) const;
 
   //Functions which find the nominal bin and bin edges
   void FindNominalBinAndEdges();

--- a/Splines/SplineStructs.h
+++ b/Splines/SplineStructs.h
@@ -15,6 +15,7 @@
 /// @brief Contains structures and helper functions for handling spline representations of systematic parameters in the MaCh3.
 /// @author Clarence Wret
 /// @author Kamil Skwarczynski
+/// @author Ewan Miller
 
 // *******************
 /// @brief CW: Add a struct to hold info about the splinified xsec parameters and help with FindSplineSegment


### PR DESCRIPTION
# Pull request description
Motivation is to be able to add additional bounds for spline params. For example, restrict so some spline params only affect events with Q2 in some range.

This is something most likely needed by T2K+SK analysis.
## Examples
```
- Systematic:
    Names:
      FancyName: BinnedSplineParam2
    KinematicCuts:
      - TrueQ2: [0.25, 0.5]
```
      
<img width="1332" height="512" alt="blarb" src="https://github.com/user-attachments/assets/a01c9d4b-857a-4d24-a636-329103673641" />


---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
