### PR TITLE
tidy: detach test statistic from manager

### DIFF
--- a/Manager/Manager.cpp
+++ b/Manager/Manager.cpp
@@ -101,23 +101,7 @@ int Manager::GetMCStatLLH() const {
   if (config["LikelihoodOptions"])
   {
     auto likelihood = GetFromManager<std::string>(config["LikelihoodOptions"]["TestStatistic"], "Barlow-Beeston", __FILE__ , __LINE__);
-
-    for(int i = 0; i < kNTestStatistics; i++) {
-      if(likelihood == TestStatistic_ToString(TestStatistic(i))) {
-        mc_stat_llh = TestStatistic(i);
-        break;
-      }
-    }
-    if(mc_stat_llh == kNTestStatistics)
-    {
-      MACH3LOG_ERROR("Wrong form of test-statistic specified!");
-      MACH3LOG_ERROR("You gave {} and I only support:", likelihood);
-      for(int i = 0; i < kNTestStatistics; i++)
-      {
-        MACH3LOG_ERROR("{}", TestStatistic_ToString(TestStatistic(i)));
-      }
-      throw MaCh3Exception(__FILE__ , __LINE__ );
-    }
+    mc_stat_llh = TestStatFromString(likelihood);
   } else {
     MACH3LOG_WARN("Didn't find a TestStatistic specified");
     MACH3LOG_WARN("Defaulting to using a {} likelihood", TestStatistic_ToString(kPoisson));
@@ -125,5 +109,3 @@ int Manager::GetMCStatLLH() const {
   }
   return mc_stat_llh;
 }
-
-

--- a/Plotting/GetPostfitParamPlots.cpp
+++ b/Plotting/GetPostfitParamPlots.cpp
@@ -57,9 +57,6 @@ std::vector<int> NDSamplesBins;
 std::vector<std::string> NDSamplesNames;
 
 std::string SaveName;
-
-// KS: Color for 0 - prefit, 1 postfit, 2 another postfit, 3 you know the drill
-constexpr Color_t PlotColor[] = {kRed, kBlack, kBlue, kGreen};
 std::string plotType;
 
 void copyParToBlockHist(const int localBin, const std::string& paramName, TH1D* blockHist,
@@ -131,22 +128,13 @@ void CopyViolinToBlock(TH2D* FullViolin, TH2D* ReducedViolin, const std::vector<
   ReducedViolin->GetXaxis()->LabelsOption("v");
 }
 
-void PrettifyTitles(TH1D *Hist) {
-  for (int i = 0; i < Hist->GetXaxis()->GetNbins(); ++i)
-  {
-    std::string title = Hist->GetXaxis()->GetBinLabel(i+1);
+template <typename HistType>
+void PrettifyTitles(HistType* hist) {
+  int nBins = hist->GetXaxis()->GetNbins();
+  for(int i = 0; i < nBins; ++i) {
+    std::string title = hist->GetXaxis()->GetBinLabel(i+1);
     title = PlotMan->style().prettifyParamName(title);
-    Hist->GetXaxis()->SetBinLabel(i+1, title.c_str());
-  }
-}
-
-void PrettifyTitles(TH2D *Hist) {
-  for (int i = 0; i < Hist->GetXaxis()->GetNbins(); ++i) 
-  {
-    std::string title = Hist->GetXaxis()->GetBinLabel(i+1);
-
-    title = PlotMan->style().prettifyParamName(title);
-    Hist->GetXaxis()->SetBinLabel(i+1, title.c_str());
+    hist->GetXaxis()->SetBinLabel(i+1, title.c_str());
   }
 }
 
@@ -733,14 +721,13 @@ void GetPostfitParamPlots()
     }
   }
 
-  TCanvas* canv = new TCanvas("canv", "canv", 1024, 1024);
+  auto canv = std::make_unique<TCanvas>("canv", "canv", 1024, 1024);
   //gStyle->SetPalette(51);
   gStyle->SetOptStat(0); //Set 0 to disable statistic box
   canv->SetLeftMargin(0.12);
   canv->SetBottomMargin(0.12);
   canv->SetTopMargin(0.08);
   canv->SetRightMargin(0.04);
-
   canv->Print((SaveName+"[").c_str());
 
   // Make a Legend page
@@ -767,9 +754,9 @@ void GetPostfitParamPlots()
   leg->Draw();
   canv->Print((SaveName).c_str());
 
-  MakeParameterPlots(canv);
+  MakeParameterPlots(canv.get());
 
-  MakeFluxPlots(canv);
+  MakeFluxPlots(canv.get());
 
   //KS: By default we don't run ProcessMCMC with PlotDet as this take some time, in case we did let's make fancy plots
   if(plotNDDet & (NDParameters > 0)) MakeNDDetPlots();
@@ -778,7 +765,6 @@ void GetPostfitParamPlots()
 
   MakeRidgePlots();
 
-  delete canv;
   delete Prefit;
 }
 
@@ -872,6 +858,8 @@ void GetViolinPlots()
   Postfit->SetMarkerStyle(7);
 
   std::vector<std::unique_ptr<TH2D>> Violin(PlotMan->getNFiles());
+  //KS: I know hardcoded but we can figure out later...
+  const std::vector<Color_t> FillColors  = { kBlue, kGreen, kMagenta };
   for(unsigned int fileId = 0; fileId < PlotMan->getNFiles(); fileId++) {
     Violin[fileId] = M3::Clone(PlotMan->input().getFile(fileId).file->Get<TH2D>( "param_violin" ));
     if(Violin[fileId] == nullptr)
@@ -879,26 +867,14 @@ void GetViolinPlots()
       MACH3LOG_ERROR("Couldn't find violin plot, make sure method from MCMCProcessor is being called");
       return;
     }
-    //KS: I know hardcoded but we can figure out later...
+    Violin[fileId]->SetMarkerColor(FillColors.at(fileId));
+    Violin[fileId]->SetLineColor(FillColors.at(fileId));
+    Violin[fileId]->SetFillColor(FillColors.at(fileId));
+    Violin[fileId]->SetFillColorAlpha(FillColors.at(fileId), 0.35);
+
     if(fileId == 0){
-      Violin[fileId]->SetFillColor(kBlue);
-      Violin[fileId]->SetFillColorAlpha(kBlue, 0.35);
-      Violin[fileId]->SetMarkerColor(kBlue);
       Violin[fileId]->SetMarkerStyle(20);
       Violin[fileId]->SetMarkerSize(0.5);
-    } else if (fileId == 1) {
-      Violin[fileId]->SetMarkerColor(kGreen);
-      Violin[fileId]->SetLineColor(kGreen);
-      Violin[fileId]->SetFillColor(kGreen);
-      Violin[fileId]->SetFillColorAlpha(kGreen, 0.35);
-    } else if (fileId == 2) {
-      Violin[fileId]->SetMarkerColor(kMagenta);
-      Violin[fileId]->SetLineColor(kMagenta);
-      Violin[fileId]->SetFillColor(kMagenta);
-      Violin[fileId]->SetFillColorAlpha(kMagenta, 0.35);
-    } else {
-      MACH3LOG_ERROR("Too many file, not implemented...");
-      throw MaCh3Exception(__FILE__ , __LINE__ );
     }
   }
 
@@ -1116,6 +1092,6 @@ int main(int argc, char *argv[])
     Get2DComparison(filename1, filename2);
   }
 
-  delete PlotMan;
+  if(PlotMan) delete PlotMan;
   return 0;
 }

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -409,8 +409,8 @@ void SampleHandlerFD::FillArray_MP() {
   const auto TotalBins = Binning->GetNBins();
   const unsigned int NumberOfEvents = GetNEvents();
 
-  double *MC_Array_for_reduction = SampleHandlerFD_array.data();
-  double *W2_array_for_reduction = SampleHandlerFD_array_w2.data();
+  double* _restrict_ MC_Array_for_reduction = SampleHandlerFD_array.data();
+  double* _restrict_ W2_array_for_reduction = SampleHandlerFD_array_w2.data();
 
   #pragma omp parallel for reduction(+:MC_Array_for_reduction[:TotalBins], W2_array_for_reduction[:TotalBins])
   for (unsigned int iEvent = 0; iEvent < NumberOfEvents; ++iEvent) {

--- a/Samples/SampleStructs.h
+++ b/Samples/SampleStructs.h
@@ -144,6 +144,25 @@ inline std::string TestStatistic_ToString(const TestStatistic TestStat) {
   return name;
 }
 
+// **************************************************
+/// @brief Convert a string to a TestStatistic enum
+inline TestStatistic TestStatFromString(const std::string& likelihood) {
+// **************************************************
+  for(int i = 0; i < kNTestStatistics; i++) {
+    if(likelihood == TestStatistic_ToString(TestStatistic(i))) {
+      return TestStatistic(i);
+    }
+  }
+
+  MACH3LOG_ERROR("Wrong form of test-statistic specified!");
+  MACH3LOG_ERROR("You gave {} and I only support:", likelihood);
+  for(int i = 0; i < kNTestStatistics; i++)
+  {
+    MACH3LOG_ERROR("{}", TestStatistic_ToString(TestStatistic(i)));
+  }
+  throw MaCh3Exception(__FILE__ , __LINE__ );
+}
+
 // ***************************
 /// @brief KS: Small struct used for applying kinematic cuts
 struct KinematicCut {

--- a/Splines/BinnedSplineHandler.cpp
+++ b/Splines/BinnedSplineHandler.cpp
@@ -195,9 +195,8 @@ void BinnedSplineHandler::InvestigateMissingSplines() const {
 }
 
 //****************************************
-void BinnedSplineHandler::TransferToMonolith()
+void BinnedSplineHandler::TransferToMonolith() {
 //****************************************
-{
   PrepForReweight(); 
   MonolithSize = CountNumberOfLoadedSplines(false, 1);
 
@@ -343,9 +342,8 @@ void BinnedSplineHandler::CalcSplineWeights() {
 //****************************************
 //Creates an array to be filled with monolith indexes for each sample (allows for indexing between 7D binning and 1D Vector)
 //Only need 1 indexing array everything else interfaces with this to get binning properties
-void BinnedSplineHandler::BuildSampleIndexingArray(const std::string& SampleTitle)
+void BinnedSplineHandler::BuildSampleIndexingArray(const std::string& SampleTitle) {
 //****************************************
-{  
   int iSample = GetSampleIndex(SampleTitle);
   int nSplineSysts = nSplineParams[iSample];
   int nOscChannels = nOscChans[iSample];
@@ -778,7 +776,7 @@ void BinnedSplineHandler::PrintArrayDetails(const std::string& SampleTitle) cons
 }
 
 //****************************************
-bool BinnedSplineHandler::isValidSplineIndex(const std::string& SampleTitle, int iOscChan, int iSyst, int iMode, int iVar1, int iVar2, int iVar3)
+bool BinnedSplineHandler::isValidSplineIndex(const std::string& SampleTitle, int iOscChan, int iSyst, int iMode, int iVar1, int iVar2, int iVar3) const
 //****************************************
 {
   int iSample = GetSampleIndex(SampleTitle);
@@ -829,9 +827,8 @@ void BinnedSplineHandler::PrintBinning(TAxis *Axis) const
 }
 
 //****************************************
-std::vector< std::vector<int> > BinnedSplineHandler::GetEventSplines(const std::string& SampleTitle, int iOscChan, int EventMode, double Var1Val, double Var2Val, double Var3Val)
+std::vector< std::vector<int> > BinnedSplineHandler::GetEventSplines(const std::string& SampleTitle, int iOscChan, int EventMode, double Var1Val, double Var2Val, double Var3Val) {
 //****************************************
-{
   std::vector<std::vector<int>> ReturnVec;
   int SampleIndex = GetSampleIndex(SampleTitle);
   int nSplineSysts = static_cast<int>(indexvec[SampleIndex][iOscChan].size());
@@ -848,27 +845,23 @@ std::vector< std::vector<int> > BinnedSplineHandler::GetEventSplines(const std::
     return ReturnVec;
   }
 
-  int Var1Bin = SplineBinning[SampleIndex][iOscChan][0]->FindBin(Var1Val)-1;
-  if (Var1Bin < 0 || Var1Bin >= SplineBinning[SampleIndex][iOscChan][0]->GetNbins()) {
-    return ReturnVec;
+  std::vector<int> bins;
+  std::vector<double> vars = {Var1Val, Var2Val, Var3Val};
+  for (size_t i = 0; i < vars.size(); ++i) {
+    int bin = SplineBinning[SampleIndex][iOscChan][i]->FindBin(vars[i]) - 1;
+    if (bin < 0 || bin >= SplineBinning[SampleIndex][iOscChan][i]->GetNbins()) {
+      return ReturnVec;
+    }
+    bins.push_back(bin);
   }
-
-  int Var2Bin = SplineBinning[SampleIndex][iOscChan][1]->FindBin(Var2Val)-1;
-  if (Var2Bin < 0 || Var2Bin >= SplineBinning[SampleIndex][iOscChan][1]->GetNbins()) {
-    return ReturnVec;
-  }
-
-  int Var3Bin = SplineBinning[SampleIndex][iOscChan][2]->FindBin(Var3Val)-1;
-  if (Var3Bin < 0 || Var3Bin >= SplineBinning[SampleIndex][iOscChan][2]->GetNbins()){
-    return ReturnVec;
-  }
+  int Var1Bin = bins[0]; int Var2Bin = bins[1]; int Var3Bin = bins[2];
 
   for(int iSyst=0; iSyst<nSplineSysts; iSyst++){
     std::vector<int> spline_modes = SplineModeVecs[SampleIndex][iSyst];
     int nSampleModes = static_cast<int>(spline_modes.size());
 
     //ETA - look here at the length of spline_modes and what you're actually comparing against
-    for(int iMode = 0; iMode<nSampleModes ; iMode++){
+    for(int iMode = 0; iMode<nSampleModes; iMode++){
       //Only consider if the event mode (Mode) matches ones of the spline modes
       if (Mode == spline_modes[iMode]) {
         int splineID=indexvec[SampleIndex][iOscChan][iSyst][iMode][Var1Bin][Var2Bin][Var3Bin];
@@ -883,9 +876,11 @@ std::vector< std::vector<int> > BinnedSplineHandler::GetEventSplines(const std::
   return ReturnVec;
 }
 
+//****************************************
 // checks if there are multiple modes with the same SplineSuffix
 // (for example if CCRES and CCCoherent are treated as one spline mode)
-std::vector< std::vector<int> > BinnedSplineHandler::StripDuplicatedModes(const std::vector< std::vector<int> >& InputVector) {
+std::vector< std::vector<int> > BinnedSplineHandler::StripDuplicatedModes(const std::vector< std::vector<int> >& InputVector) const {
+//****************************************
   //ETA - this is of size nPars from the xsec model
   size_t InputVectorSize = InputVector.size();
   std::vector< std::vector<int> > ReturnVec(InputVectorSize);

--- a/Splines/BinnedSplineHandler.h
+++ b/Splines/BinnedSplineHandler.h
@@ -37,7 +37,7 @@ class BinnedSplineHandler : public SplineBase {
     virtual void FillSampleArray(std::string SampleTitle, std::vector<std::string> OscChanFileNames);
     /// @brief Check if there are any repeated modes. This is used to reduce the number
     /// of modes in case many interaction modes get averaged into one spline
-    std::vector< std::vector<int> > StripDuplicatedModes(const std::vector< std::vector<int> >& InputVector);
+    std::vector< std::vector<int> > StripDuplicatedModes(const std::vector< std::vector<int> >& InputVector) const;
     /// @brief Return the splines which affect a given event
     std::vector< std::vector<int> > GetEventSplines(const std::string& SampleTitle, int iOscChan, int EventMode, double Var1Val, double Var2Val, double Var3Val);
     /// @brief KS: After calculations are done on GPU we copy memory to CPU. This operation is asynchronous meaning while memory is being copied some operations are being carried. Memory must be copied before actual reweight. This function make sure all has been copied.
@@ -51,7 +51,7 @@ class BinnedSplineHandler : public SplineBase {
     /// @param SampleTitle The title of the sample to search for.
     int GetSampleIndex(const std::string& SampleTitle) const;
     /// @brief Ensure we have spline for a given bin
-    bool isValidSplineIndex(const std::string& SampleTitle, int iSyst, int iOscChan, int iMode, int iVar1, int iVar2, int iVar3);
+    bool isValidSplineIndex(const std::string& SampleTitle, int iSyst, int iOscChan, int iMode, int iVar1, int iVar2, int iVar3) const;
 
     void BuildSampleIndexingArray(const std::string& SampleTitle);
     void PrepForReweight();

--- a/Splines/SplineMonolith.cpp
+++ b/Splines/SplineMonolith.cpp
@@ -52,7 +52,6 @@ SMonolith::SMonolith(std::vector<std::vector<TResponseFunction_red*> > &MasterSp
 // The shared initialiser from constructors of TSpline3 and TSpline3_red
 void SMonolith::PrepareForGPU(std::vector<std::vector<TResponseFunction_red*> > &MasterSpline, const std::vector<RespFuncType> &SplineType) {
 // *****************************************
-
   // Scan for the max number of knots, the number of events (number of splines), and number of parameters
   int maxnSplines = 0;
   ScanMasterSpline(MasterSpline,


### PR DESCRIPTION
# Pull request description
The ability to get test stat from string has been moved to some general struct rather than being in manager.
In addition, minor tidy to reduce duplicate in multiple places.



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
