### PR TITLE
breaking: Fully unify weight pointers

### DIFF
--- a/Fitters/PredictiveThrower.cpp
+++ b/Fitters/PredictiveThrower.cpp
@@ -110,7 +110,7 @@ void PredictiveThrower::SetupSampleInformation() {
 // Produce MaCh3 toys:
 void PredictiveThrower::SetupToyGeneration(std::vector<std::string>& ParameterGroupsNotVaried,
                                            std::unordered_set<int>& ParameterOnlyToVary,
-                                           std::vector<const double*>& BoundValuePointer,
+                                           std::vector<const M3::float_t*>& BoundValuePointer,
                                            std::vector<std::pair<double, double>>& ParamBounds) {
 // *************************
   int counter = 0;
@@ -423,7 +423,7 @@ void PredictiveThrower::WriteToy(TDirectory* ToyDirectory,
 }
 
 // *************************
-bool CheckBounds(const std::vector<const double*>& BoundValuePointer,
+bool CheckBounds(const std::vector<const M3::float_t*>& BoundValuePointer,
                  const std::vector<std::pair<double,double>>& ParamBounds) {
 // *************************
   for (size_t i = 0; i < BoundValuePointer.size(); ++i) {
@@ -452,7 +452,7 @@ void PredictiveThrower::ProduceToys() {
   /// KS: Index of parameters that will be varied
   std::unordered_set<int> ParameterOnlyToVary;
   // For study where one would like to apply bounds
-  std::vector<const double*> BoundValuePointer;
+  std::vector<const M3::float_t*> BoundValuePointer;
   std::vector<std::pair<double, double>> ParamBounds;
 
   // Setup useful information for toy generation
@@ -475,7 +475,7 @@ void PredictiveThrower::ProduceToys() {
 
   // KS: define branches so we can keep track of what params we are throwing
   std::vector<double> ParamValues(NModelParams);
-  std::vector<const double*> ParampPointers(NModelParams);
+  std::vector<const M3::float_t*> ParampPointers(NModelParams);
   int ParamCounter = 0;
   for (size_t iSys = 0; iSys < systematics.size(); iSys++)
   {

--- a/Fitters/PredictiveThrower.h
+++ b/Fitters/PredictiveThrower.h
@@ -63,7 +63,7 @@ class PredictiveThrower : public FitterBase {
   /// @brief Setup useful variables etc before stating toy generation
   void SetupToyGeneration(std::vector<std::string>& ParameterGroupsNotVaried,
                           std::unordered_set<int>& ParameterOnlyToVary,
-                          std::vector<const double*>& BoundValuePointer,
+                          std::vector<const M3::float_t*>& BoundValuePointer,
                           std::vector<std::pair<double, double>>& ParamBounds);
 
   /// @brief Load existing toys

--- a/Parameters/AdaptiveMCMCHandler.cpp
+++ b/Parameters/AdaptiveMCMCHandler.cpp
@@ -1,7 +1,5 @@
 #include "Parameters/AdaptiveMCMCHandler.h"
 
-namespace adaptive_mcmc{
-
 // ********************************************
 AdaptiveMCMCHandler::AdaptiveMCMCHandler() {
 // ********************************************
@@ -574,5 +572,3 @@ void AdaptiveMCMCHandler::UpdateRobbinsMonroScale(){
     adaption_scale -= target_acceptance * scale_factor;
   }
 }
-
-} //end adaptive_mcmc

--- a/Parameters/AdaptiveMCMCHandler.h
+++ b/Parameters/AdaptiveMCMCHandler.h
@@ -8,315 +8,313 @@ _MaCh3_Safe_Include_Start_ //{
 #include "Math/DistFunc.h"
 _MaCh3_Safe_Include_End_ //}
 
-namespace adaptive_mcmc
+
+/// @brief Contains information about adaptive covariance matrix
+/// @cite haario2001adaptive
+/// @cite Garthwaite01092016
+/// @author Henry Wallace
+/// @author Hank Hua
+/// @details Adaptation can be performed in two ways:
+/// - **Haario/Roberts-Rosenthal style**: Uses a constant scale factor of
+/// \f[
+/// \frac{2.38}{\sqrt{\text{num\_params}}}
+/// \f]
+/// - **Robbins-Monro style**: Dynamically updates the scale factor to target
+///   a specific acceptance rate, potentially improving mixing.
+///
+class AdaptiveMCMCHandler
 {
-  /// @brief Contains information about adaptive covariance matrix
-  /// @cite haario2001adaptive
-  /// @cite Garthwaite01092016
-  /// @author Henry Wallace
-  /// @author Hank Hua
-  /// @details Adaptation can be performed in two ways:
-  /// - **Haario/Roberts-Rosenthal style**: Uses a constant scale factor of
-  /// \f[
-  /// \frac{2.38}{\sqrt{\text{num\_params}}}
-  /// \f]
-  /// - **Robbins-Monro style**: Dynamically updates the scale factor to target
-  ///   a specific acceptance rate, potentially improving mixing.
+ public:
+  /// @brief Constructor
+  AdaptiveMCMCHandler();
+
+  /// @brief Destructor
+  virtual ~AdaptiveMCMCHandler();
+
+  /// @brief Print all class members
+  void Print() const;
+
+  /// @brief Read initial values from config file
   ///
-  class AdaptiveMCMCHandler
+  /// @param adapt_manager YAML node containing the configuration (`AdaptionOptions`).
+  /// @param matrix_name_str Name of the covariance matrix block to configure.
+  /// @param parameters Pointer to a vector of parameter values (nominal values).
+  /// @param fixed Pointer to a vector of fixed parameter values.
+  /// @return True if adaptive MCMC configuration was successfully initialized, false otherwise.
+  bool InitFromConfig(const YAML::Node &adapt_manager, const std::string &matrix_name_str,
+                      const std::vector<std::string> *parameter_names,
+                      const std::vector<double> *parameters,
+                      const std::vector<double> *fixed,
+                      const std::vector<bool> *param_skip_adapt_flags,
+                      const TMatrixDSym* throwMatrix,
+                      const double initial_scale_);
+
+  /// @brief If we don't have a covariance matrix to start from for adaptive tune we need to make one!
+  void CreateNewAdaptiveCovariance();
+
+  /// @brief HW: sets adaptive block matrix
+  /// @param block_indices Values for sub-matrix blocks
+  void SetAdaptiveBlocks(const std::vector<std::vector<int>> &block_indices);
+
+  /// @brief HW: Save adaptive throw matrix to file
+  void SaveAdaptiveToFile(const std::string &outFileName, const std::string &systematicName, const bool is_final = false);
+
+  /// @brief sets throw matrix from a file
+  /// @param matrix_file_name name of file matrix lives in
+  /// @param matrix_name name of matrix in file
+  /// @param means_name name of means vec in file
+  void SetThrowMatrixFromFile(const std::string &matrix_file_name,
+                              const std::string &matrix_name,
+                              const std::string &means_name,
+                              bool &use_adaptive);
+
+  /// @brief Check if there are structures in matrix that could result in failure of adaption fits.
+  /// this mostly cover cases of highly correlated block which seem to results in adaption failure
+  /// @param covMatrix covariance matrix which we convert into correlation matrix
+  void CheckMatrixValidityForAdaption(const TMatrixDSym *covMatrix) const;
+
+  /// @brief Method to update adaptive MCMC
+  /// @cite haario2001adaptive
+  /// @param _fCurrVal Value of each parameter necessary for updating throw matrix
+  void UpdateAdaptiveCovariance();
+
+  /// @brief Tell whether we want reset step scale or not
+  bool IndivStepScaleAdapt() const;
+
+  /// @brief Tell whether matrix should be updated
+  bool UpdateMatrixAdapt();
+
+  /// @brief To be fair not a clue...
+  bool AdaptionUpdate() const;
+
+  /// @brief Tell if we are Skipping Adaption
+  bool SkipAdaption() const;
+
+  /// @brief Get the index of the parameter given its name
+  /// @param name Name of the parameter
+  /// @return Index of the parameter
+  int GetParIndex(const std::string& name) const {
+    // HH: Adapted from ParameterHandlerBase.cpp
+    int index = M3::_BAD_INT_;
+    for (size_t i = 0; i < _ParamNames->size(); i++) {
+      if(name == _ParamNames->at(i)) {
+        index = static_cast<int>(i);
+        break;
+      }
+    }
+    return index;
+  }
+
+  /// @brief Convert vector of parameter names to indices
+  /// @param param_names Vector of parameter names
+  /// @return Vector of parameter indices
+  std::vector<int> GetParIndicesFromNames(const std::vector<std::string>& param_names) const {
+    std::vector<int> indices;
+    for (const auto& name : param_names) {
+      int index = GetParIndex(name);
+      if (index != M3::_BAD_INT_) {
+        indices.push_back(index);
+      } else {
+        MACH3LOG_ERROR("Parameter name {} not found in parameter list", name);
+        throw MaCh3Exception(__FILE__, __LINE__);
+      }
+    }
+    return indices;
+  }
+
+  /// @brief Set the current values of the parameters
+  void SetParams(const std::vector<double> *params)
   {
-  public:
-    /// @brief Constructor
-    AdaptiveMCMCHandler();
+    _fCurrVal = params;
+  }
 
-    /// @brief Destructor
-    virtual ~AdaptiveMCMCHandler();
+  /// @brief Set the fixed parameters
+  void SetFixed(const std::vector<double> *fix)
+  {
+    _fFixedPars = fix;
+  }
 
-    /// @brief Print all class members
-    void Print() const;
-
-    /// @brief Read initial values from config file
-    ///
-    /// @param adapt_manager YAML node containing the configuration (`AdaptionOptions`).
-    /// @param matrix_name_str Name of the covariance matrix block to configure.
-    /// @param parameters Pointer to a vector of parameter values (nominal values).
-    /// @param fixed Pointer to a vector of fixed parameter values.
-    /// @return True if adaptive MCMC configuration was successfully initialized, false otherwise.
-    bool InitFromConfig(const YAML::Node &adapt_manager, const std::string &matrix_name_str,
-                        const std::vector<std::string> *parameter_names,
-                        const std::vector<double> *parameters, 
-                        const std::vector<double> *fixed,
-                        const std::vector<bool> *param_skip_adapt_flags,
-                        const TMatrixDSym* throwMatrix,
-                        const double initial_scale_);
-
-    /// @brief If we don't have a covariance matrix to start from for adaptive tune we need to make one!
-    void CreateNewAdaptiveCovariance();
-
-    /// @brief HW: sets adaptive block matrix
-    /// @param block_indices Values for sub-matrix blocks
-    void SetAdaptiveBlocks(const std::vector<std::vector<int>> &block_indices);
-
-    /// @brief HW: Save adaptive throw matrix to file
-    void SaveAdaptiveToFile(const std::string &outFileName, const std::string &systematicName, const bool is_final = false);
-
-    /// @brief sets throw matrix from a file
-    /// @param matrix_file_name name of file matrix lives in
-    /// @param matrix_name name of matrix in file
-    /// @param means_name name of means vec in file
-    void SetThrowMatrixFromFile(const std::string &matrix_file_name,
-                                const std::string &matrix_name,
-                                const std::string &means_name,
-                                bool &use_adaptive);
-
-    /// @brief Check if there are structures in matrix that could result in failure of adaption fits.
-    /// this mostly cover cases of highly correlated block which seem to results in adaption failure
-    /// @param covMatrix covariance matrix which we convert into correlation matrix
-    void CheckMatrixValidityForAdaption(const TMatrixDSym *covMatrix) const;
-
-    /// @brief Method to update adaptive MCMC
-    /// @cite haario2001adaptive
-    /// @param _fCurrVal Value of each parameter necessary for updating throw matrix
-    void UpdateAdaptiveCovariance();
-
-    /// @brief Tell whether we want reset step scale or not
-    bool IndivStepScaleAdapt() const;
-
-    /// @brief Tell whether matrix should be updated
-    bool UpdateMatrixAdapt();
-
-    /// @brief To be fair not a clue...
-    bool AdaptionUpdate() const;
-
-    /// @brief Tell if we are Skipping Adaption
-    bool SkipAdaption() const;
-
-    /// @brief Get the index of the parameter given its name
-    /// @param name Name of the parameter
-    /// @return Index of the parameter
-    int GetParIndex(const std::string& name) const {
-      // HH: Adapted from ParameterHandlerBase.cpp
-      int index = M3::_BAD_INT_;
-      for (size_t i = 0; i < _ParamNames->size(); i++) {
-        if(name == _ParamNames->at(i)) {
-          index = static_cast<int>(i);
-          break;
-        }
-      }
-      return index;
-    }
-
-    /// @brief Convert vector of parameter names to indices
-    /// @param param_names Vector of parameter names
-    /// @return Vector of parameter indices
-    std::vector<int> GetParIndicesFromNames(const std::vector<std::string>& param_names) const {
-      std::vector<int> indices;
-      for (const auto& name : param_names) {
-        int index = GetParIndex(name);
-        if (index != M3::_BAD_INT_) {
-          indices.push_back(index);
-        } else {
-          MACH3LOG_ERROR("Parameter name {} not found in parameter list", name);
-          throw MaCh3Exception(__FILE__, __LINE__);
-        }
-      }
-      return indices;
-    }
-
-    /// @brief Set the current values of the parameters
-    void SetParams(const std::vector<double> *params)
+  /// @brief Get the number of fixed parameters
+  /// @ingroup ParameterHandlerGetters
+  int GetNFixed() const
+  {
+    if (!_fFixedPars)
     {
-      _fCurrVal = params;
+      return 0;
     }
-
-    /// @brief Set the fixed parameters
-    void SetFixed(const std::vector<double> *fix)
+    int n_fixed = 0;
+    for (int i = 0; i < static_cast<int>(_fFixedPars->size()); i++)
     {
-      _fFixedPars = fix;
-    }
-
-    /// @brief Get the number of fixed parameters
-    /// @ingroup ParameterHandlerGetters
-    int GetNFixed() const
-    {
-      if (!_fFixedPars)
+      if ((*_fFixedPars)[i] < 0)
       {
-        return 0;
+        n_fixed++;
       }
-      int n_fixed = 0;
-      for (int i = 0; i < static_cast<int>(_fFixedPars->size()); i++)
-      {
-        if ((*_fFixedPars)[i] < 0)
-        {
-          n_fixed++;
-        }
-      }
-      return n_fixed;
     }
+    return n_fixed;
+  }
 
-    /// @brief Get the current values of the parameters
-    /// @ingroup ParameterHandlerGetters
-    int GetNumParams() const
+  /// @brief Get the current values of the parameters
+  /// @ingroup ParameterHandlerGetters
+  int GetNumParams() const
+  {
+    return static_cast<int>(_fCurrVal->size());
+  }
+
+  /// @brief Check if a parameter is fixed
+  bool IsFixed(const int ipar) const
+  {
+    if (!_fFixedPars)
     {
-      return static_cast<int>(_fCurrVal->size());
+      return false;
     }
+    return ((*_fFixedPars)[ipar] < 0);
+  }
 
-    /// @brief Check if a parameter is fixed
-    bool IsFixed(const int ipar) const
-    {
-      if (!_fFixedPars)
-      {
-        return false;
-      }
-      return ((*_fFixedPars)[ipar] < 0);
-    }
+  /// @brief Get Current value of parameter
+  double CurrVal(const int par_index) const;
 
-    /// @brief Get Current value of parameter
-    double CurrVal(const int par_index) const;
+  /// @brief Get Total Number of Steps
+  /// @ingroup ParameterHandlerGetters
+  int GetTotalSteps() const
+  {
+    return total_steps;
+  }
 
-    /// @brief Get Total Number of Steps
-    /// @ingroup ParameterHandlerGetters
-    int GetTotalSteps() const
-    {
-      return total_steps;
-    }
+  /// @brief Change Total Number of Steps to new value
+  void SetTotalSteps(const int nsteps)
+  {
+    total_steps = nsteps;
+  }
 
-    /// @brief Change Total Number of Steps to new value
-    void SetTotalSteps(const int nsteps)
-    {
-      total_steps = nsteps;
-    }
+  /// @brief Increase by one number of total steps
+  void IncrementNSteps()
+  {
+    total_steps++;
+  }
 
-    /// @brief Increase by one number of total steps
-    void IncrementNSteps()
-    {
-      total_steps++;
-    }
+  void IncrementAcceptedSteps()
+  {
+    prev_step_accepted = true;
+  }
 
-    void IncrementAcceptedSteps()
-    {
-      prev_step_accepted = true;
-    }
+  /// @brief Increase by one number of total steps
+  /// @ingroup ParameterHandlerGetters
+  TMatrixDSym *GetAdaptiveCovariance() const
+  {
+    return adaptive_covariance;
+  }
 
-    /// @brief Increase by one number of total steps
-    /// @ingroup ParameterHandlerGetters
-    TMatrixDSym *GetAdaptiveCovariance() const
-    {
-      return adaptive_covariance;
-    }
+  /// @brief Get the parameter means used in the adaptive handler
+  /// @ingroup ParameterHandlerGetters
+  std::vector<double> GetParameterMeans() const
+  {
+    return par_means;
+  }
 
-    /// @brief Get the parameter means used in the adaptive handler
-    /// @ingroup ParameterHandlerGetters
-    std::vector<double> GetParameterMeans() const
-    {
-      return par_means;
-    }
+  /// @brief Get Name of Output File
+  /// @ingroup ParameterHandlerGetters
+  std::string GetOutFileName() const
+  {
+    return output_file_name;
+  }
 
-    /// @brief Get Name of Output File
-    /// @ingroup ParameterHandlerGetters
-    std::string GetOutFileName() const
-    {
-      return output_file_name;
-    }
+  /// @brief Get the current adaption scale
+  double GetAdaptionScale()
+  {
+    return adaption_scale;
+  }
 
-    /// @brief Get the current adaption scale
-    double GetAdaptionScale()
-    {
-      return adaption_scale;
-    }
+  /// Use Robbins-Monro approach?
+  bool GetUseRobbinsMonro() const
+  {
+    return use_robbins_monro;
+  }
 
-    /// Use Robbins-Monro approach?
-    bool GetUseRobbinsMonro() const
-    {
-      return use_robbins_monro;
-    }
+  /// Update the scale factor for Robbins-Monro adaption
+  void UpdateRobbinsMonroScale();
 
-    /// Update the scale factor for Robbins-Monro adaption
-    void UpdateRobbinsMonroScale();
+private:
+  /// Calculate the constant step length for Robbins-Monro adaption
+  void CalculateRobbinsMonroStepLength();
 
-  private:
-    /// Calculate the constant step length for Robbins-Monro adaption
-    void CalculateRobbinsMonroStepLength();
+  /// Meta variables related to adaption run time
+  /// When do we start throwing
+  int start_adaptive_throw;
 
-    /// Meta variables related to adaption run time
-    /// When do we start throwing
-    int start_adaptive_throw;
+  /// When do we stop update the adaptive matrix
+  int start_adaptive_update;
 
-    /// When do we stop update the adaptive matrix
-    int start_adaptive_update;
+  /// Steps between changing throw matrix
+  int end_adaptive_update;
 
-    /// Steps between changing throw matrix
-    int end_adaptive_update;
+  /// Steps between changing throw matrix
+  int adaptive_update_step;
 
-    /// Steps between changing throw matrix
-    int adaptive_update_step;
+  /// If you don't want to save every adaption then
+  /// you can specify this here
+  int adaptive_save_n_iterations;
 
-    /// If you don't want to save every adaption then
-    /// you can specify this here
-    int adaptive_save_n_iterations;
+  /// Name of the file to save the adaptive matrices into
+  std::string output_file_name;
 
-    /// Name of the file to save the adaptive matrices into
-    std::string output_file_name;
+  /// Indices for block-matrix adaption
+  std::vector<int> adapt_block_matrix_indices;
 
-    /// Indices for block-matrix adaption
-    std::vector<int> adapt_block_matrix_indices;
+  /// Size of blocks for adaption
+  std::vector<int> adapt_block_sizes;
 
-    /// Size of blocks for adaption
-    std::vector<int> adapt_block_sizes;
+  // Variables directedly linked to adaption
+  /// Mean values for all parameters
+  std::vector<double> par_means;
 
-    // Variables directedly linked to adaption
-    /// Mean values for all parameters
-    std::vector<double> par_means;
+  /// Full adaptive covariance matrix
+  TMatrixDSym *adaptive_covariance;
 
-    /// Full adaptive covariance matrix
-    TMatrixDSym *adaptive_covariance;
+  /// Total number of MCMC steps
+  int total_steps;
 
-    /// Total number of MCMC steps
-    int total_steps;
+  /// Scaling factor
+  double adaption_scale;
 
-    /// Scaling factor
-    double adaption_scale;
+  /// Initial scaling factor
+  double initial_scale;
 
-    /// Initial scaling factor
-    double initial_scale;
+  /// Vector of fixed parameters
+  const std::vector<double> *_fFixedPars;
 
-    /// Vector of fixed parameters
-    const std::vector<double> *_fFixedPars;
+  /// Current values of parameters
+  const std::vector<double> *_fCurrVal;
 
-    /// Current values of parameters
-    const std::vector<double> *_fCurrVal;
+  /// Parameter names
+  const std::vector<std::string> *_ParamNames;
 
-    /// Parameter names
-    const std::vector<std::string> *_ParamNames;
+  /// Acceptance rate in the current batch
+  int acceptance_rate_batch_size;
 
-    /// Acceptance rate in the current batch
-    int acceptance_rate_batch_size;
+  /// Use Robbins Monro https://arxiv.org/pdf/1006.3690
+  bool use_robbins_monro;
 
-    /// Use Robbins Monro https://arxiv.org/pdf/1006.3690
-    bool use_robbins_monro;
+  /// Target acceptance rate for Robbins Monro
+  double target_acceptance;
 
-    /// Target acceptance rate for Robbins Monro
-    double target_acceptance;
+  /// Constant "step scaling" factor for Robbins-Monro
+  double c_robbins_monro;
 
-    /// Constant "step scaling" factor for Robbins-Monro
-    double c_robbins_monro;
+  /// Number of restarts for Robbins Monro (so far)
+  int n_rm_restarts;
 
-    /// Number of restarts for Robbins Monro (so far)
-    int n_rm_restarts;
+  /// Total number of restarts ALLOWED for Robbins Monro
+  int total_rm_restarts;
 
-    /// Total number of restarts ALLOWED for Robbins Monro
-    int total_rm_restarts;
+  /// Need to keep track of whether previous step was accepted for RM
+  bool prev_step_accepted;
 
-    /// Need to keep track of whether previous step was accepted for RM
-    bool prev_step_accepted;
+  /// Parameters to skip during adaption
+  const std::vector<bool>* _param_skip_adapt_flags;
 
-    /// Parameters to skip during adaption
-    const std::vector<bool>* _param_skip_adapt_flags;
+  /// Initial throw matrix
+  const TMatrixDSym* initial_throw_matrix;
 
-    /// Initial throw matrix
-    const TMatrixDSym* initial_throw_matrix;
-
-    /// Flag to check if initial throw matrix has been saved
-    bool initial_throw_matrix_saved = false;
-  };
-} // adaptive_mcmc namespace
+  /// Flag to check if initial throw matrix has been saved
+  bool initial_throw_matrix_saved = false;
+};

--- a/Parameters/PCAHandler.cpp
+++ b/Parameters/PCAHandler.cpp
@@ -15,7 +15,7 @@ PCAHandler::~PCAHandler() {
 
 // ********************************************
 void PCAHandler::SetupPointers(std::vector<double>* fCurr_Val,
-                               std::vector<double>* fProp_Val) {
+                               std::vector<M3::float_t>* fProp_Val) {
 // ********************************************
   _pCurrVal = fCurr_Val;
   _pPropVal = fProp_Val;
@@ -254,6 +254,8 @@ void PCAHandler::SetInitialParameters() {
 // Transfer a parameter variation in the eigen basis to the parameter basis
 void PCAHandler::TransferToParam() {
 // ********************************************
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wuseless-cast"
   // Make the temporary vectors
   TVectorD fParProp_vec = TransferMat*_fParPropPCA;
   TVectorD fParCurr_vec = TransferMat*_fParCurrPCA;
@@ -261,9 +263,10 @@ void PCAHandler::TransferToParam() {
   #pragma omp parallel for
   #endif
   for(int i = 0; i < static_cast<int>(_pCurrVal->size()); ++i) {
-    (*_pPropVal)[i] = fParProp_vec(i);
+    (*_pPropVal)[i] = static_cast<M3::float_t>(fParProp_vec(i));
     (*_pCurrVal)[i] = fParCurr_vec(i);
   }
+  #pragma GCC diagnostic pop
 }
 
 // ********************************************
@@ -324,6 +327,8 @@ void PCAHandler::ThrowParameters(const std::vector<std::unique_ptr<TRandom3>>& r
                                  const std::vector<double>& fUpBound,
                                  const int _fNumPar) {
 // ********************************************
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wuseless-cast"
   //KS: Do not multithread!
   for (int i = 0; i < NumParPCA; ++i) {
     // Check if parameter is fixed first: if so don't randomly throw
@@ -331,13 +336,13 @@ void PCAHandler::ThrowParameters(const std::vector<std::unique_ptr<TRandom3>>& r
 
     if(!IsParameterDecomposed(i))
     {
-      (*_pPropVal)[i] = fPreFitValue[i] + corr_throw[i];
+      (*_pPropVal)[i] = static_cast<M3::float_t>(fPreFitValue[i] + corr_throw[i]);
       int throws = 0;
       // Try again if we the initial parameter proposal falls outside of the range of the parameter
       while ((*_pPropVal)[i] > fUpBound[i] || (*_pPropVal)[i] < fLowBound[i]) {
         randParams[i] = random_number[M3::GetThreadIndex()]->Gaus(0, 1);
         const double corr_throw_single = M3::MatrixVectorMultiSingle(throwMatrixCholDecomp, randParams, _fNumPar, i);
-        (*_pPropVal)[i] = fPreFitValue[i] + corr_throw_single;
+        (*_pPropVal)[i] = static_cast<M3::float_t>(fPreFitValue[i] + corr_throw_single);
         if (throws > 10000)
         {
           //KS: Since we are multithreading there is danger that those messages
@@ -345,7 +350,7 @@ void PCAHandler::ThrowParameters(const std::vector<std::unique_ptr<TRandom3>>& r
           MACH3LOG_WARN("Tried {} times to throw parameter {} but failed", throws, i);
           MACH3LOG_WARN("Setting _fPropVal:  {} to {}", (*_pPropVal)[i], fPreFitValue[i]);
           MACH3LOG_WARN("I live at {}:{}", __FILE__, __LINE__);
-         (*_pPropVal)[i] = fPreFitValue[i];
+         (*_pPropVal)[i] = static_cast<M3::float_t>(fPreFitValue[i]);
         }
         throws++;
       }
@@ -360,9 +365,12 @@ void PCAHandler::ThrowParameters(const std::vector<std::unique_ptr<TRandom3>>& r
 
   /// @todo KS: We don't check if param is out of bounds. This is more problematic for PCA params.
   for (int i = 0; i < _fNumPar; ++i) {
-    (*_pPropVal)[i] = std::max(fLowBound[i], std::min((*_pPropVal)[i], fUpBound[i]));
+    auto low = static_cast<M3::float_t>(fLowBound[i]);
+    auto up  = static_cast<M3::float_t>(fUpBound[i]);
+    (*_pPropVal)[i] = std::max(up, std::min((*_pPropVal)[i], low));
     (*_pCurrVal)[i] = (*_pPropVal)[i];
   }
+  #pragma GCC diagnostic pop
 }
 
 #ifdef DEBUG_PCA

--- a/Parameters/PCAHandler.h
+++ b/Parameters/PCAHandler.h
@@ -72,7 +72,7 @@ class PCAHandler{
   /// @param fCurr_Val pointer to current position of parameter
   /// @param fProp_Val pointer to proposed position of parameter
   void SetupPointers(std::vector<double>* fCurr_Val,
-                     std::vector<double>* fProp_Val);
+                     std::vector<M3::float_t>* fProp_Val);
 
   /// @brief CW: Calculate eigen values, prepare transition matrices and remove param based on defined threshold
   /// @param CovMatrix       Symmetric covariance matrix used for eigen decomposition.
@@ -259,6 +259,6 @@ class PCAHandler{
   /// Pointer to current value of the parameter
   std::vector<double>* _pCurrVal;
   /// Pointer to proposed value of the parameter
-  std::vector<double>* _pPropVal;
+  std::vector<M3::float_t>* _pPropVal;
 };
 

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -478,7 +478,7 @@ void ParameterHandlerBase::ReserveMemory(const int SizeVec) {
   _fPreFitValue = std::vector<double>(SizeVec);
   _fError = std::vector<double>(SizeVec);
   _fCurrVal = std::vector<double>(SizeVec);
-  _fPropVal = std::vector<double>(SizeVec);
+  _fPropVal = std::vector<M3::float_t>(SizeVec);
   _fLowBound = std::vector<double>(SizeVec);
   _fUpBound = std::vector<double>(SizeVec);
   _fFlatPrior = std::vector<bool>(SizeVec);
@@ -514,7 +514,7 @@ void ParameterHandlerBase::SetPar(const int i , const double val) {
   MACH3LOG_DEBUG("Over-riding {}: _fPropVal ({}), _fCurrVal ({}), _fPreFitValue ({}) to ({})",
                  GetParFancyName(i), _fPropVal[i], _fCurrVal[i], _fPreFitValue[i], val);
 
-  _fPropVal[i] = val;
+  _fPropVal[i] = static_cast<M3::float_t>(val);
   _fCurrVal[i] = val;
   _fPreFitValue[i] = val;
 
@@ -539,7 +539,8 @@ void ParameterHandlerBase::ThrowParameters() {
   Randomize();
 
   M3::MatrixVectorMulti(corr_throw, throwMatrixCholDecomp, randParams, _fNumPar);
-
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wuseless-cast"
   // KS: We use PCA very rarely on top PCA functionality isn't implemented for this function.
   // Use __builtin_expect to give compiler a hint which option is more likely, which should help
   // with better optimisation. This isn't critical but more to have example
@@ -550,15 +551,14 @@ void ParameterHandlerBase::ThrowParameters() {
     for (int i = 0; i < _fNumPar; ++i) {
       // Check if parameter is fixed first: if so don't randomly throw
       if (IsParameterFixed(i)) continue;
-
-      _fPropVal[i] = _fPreFitValue[i] + corr_throw[i];
+      _fPropVal[i] = static_cast<M3::float_t>(_fPreFitValue[i] + corr_throw[i]);
 
       int throws = 0;
       // Try again if we the initial parameter proposal falls outside of the range of the parameter
       while (_fPropVal[i] > _fUpBound[i] || _fPropVal[i] < _fLowBound[i]) {
         randParams[i] = random_number[M3::GetThreadIndex()]->Gaus(0, 1);
         const double corr_throw_single = M3::MatrixVectorMultiSingle(throwMatrixCholDecomp, randParams, _fNumPar, i);
-        _fPropVal[i] = _fPreFitValue[i] + corr_throw_single;
+        _fPropVal[i] = static_cast<M3::float_t>(_fPreFitValue[i] + corr_throw_single);
         if (throws > 10000)
         {
           //KS: Since we are multithreading there is danger that those messages
@@ -568,7 +568,7 @@ void ParameterHandlerBase::ThrowParameters() {
           MACH3LOG_WARN("Param: {}", _fNames[i]);
           MACH3LOG_WARN("Setting _fPropVal:  {} to {}", _fPropVal[i], _fPreFitValue[i]);
           MACH3LOG_WARN("I live at {}:{}", __FILE__, __LINE__);
-          _fPropVal[i] = _fPreFitValue[i];
+          _fPropVal[i] = static_cast<M3::float_t>(_fPreFitValue[i]);
           //throw MaCh3Exception(__FILE__ , __LINE__ );
         }
         throws++;
@@ -582,7 +582,7 @@ void ParameterHandlerBase::ThrowParameters() {
                             randParams, corr_throw,
                             _fPreFitValue, _fLowBound, _fUpBound, _fNumPar);
   } // end if pca
-
+  #pragma GCC diagnostic pop
   // KS: At the end once we are happy with proposal do special proposal
   SpecialStepProposal();
 }
@@ -592,6 +592,8 @@ void ParameterHandlerBase::ThrowParameters() {
 // Used to start the chain in different states
 void ParameterHandlerBase::RandomConfiguration() {
 // *************************************
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wuseless-cast"
   // Have the 1 sigma for each parameter in each covariance class, sweet!
   // Don't want to change the prior array because that's what determines our likelihood
   // Want to change the _fPropVal, _fCurrVal, _fPreFitValue
@@ -606,7 +608,7 @@ void ParameterHandlerBase::RandomConfiguration() {
     double throwrange = sigma;
     if (paramrange < sigma) throwrange = paramrange;
 
-    _fPropVal[i] = _fPreFitValue[i] + random_number[0]->Gaus(0, 1)*throwrange;
+    _fPropVal[i] = static_cast<M3::float_t>(_fPreFitValue[i] + random_number[0]->Gaus(0, 1)*throwrange);
     // Try again if we the initial parameter proposal falls outside of the range of the parameter
     int throws = 0;
     while (_fPropVal[i] > _fUpBound[i] || _fPropVal[i] < _fLowBound[i]) {
@@ -616,12 +618,13 @@ void ParameterHandlerBase::RandomConfiguration() {
         MACH3LOG_WARN("Param: {}", _fNames[i]);
         throw MaCh3Exception(__FILE__ , __LINE__ );
       }
-      _fPropVal[i] = _fPreFitValue[i] + random_number[0]->Gaus(0, 1)*throwrange;
+      _fPropVal[i] = static_cast<M3::float_t>(_fPreFitValue[i] + random_number[0]->Gaus(0, 1)*throwrange);
       throws++;
     }
     MACH3LOG_INFO("Setting current step in {} param {} = {} from {}", matrixName, i, _fPropVal[i], _fCurrVal[i]);
     _fCurrVal[i] = _fPropVal[i];
   }
+  #pragma GCC diagnostic pop
   if (pca) PCAObj->TransferToPCA();
 
   // KS: At the end once we are happy with proposal do special proposal
@@ -632,7 +635,7 @@ void ParameterHandlerBase::RandomConfiguration() {
 // Set a single parameter
 void ParameterHandlerBase::SetSingleParameter(const int parNo, const double parVal) {
 // *************************************
-  _fPropVal[parNo] = parVal;
+  _fPropVal[parNo] = static_cast<M3::float_t>(parVal);
   _fCurrVal[parNo] = parVal;
   MACH3LOG_DEBUG("Setting {} (parameter {}) to {})", GetParFancyName(parNo),  parNo, parVal);
   if (pca) PCAObj->TransferToPCA();
@@ -641,7 +644,7 @@ void ParameterHandlerBase::SetSingleParameter(const int parNo, const double parV
 // ********************************************
 void ParameterHandlerBase::SetParCurrProp(const int parNo, const double parVal) {
 // ********************************************
-  _fPropVal[parNo] = parVal;
+  _fPropVal[parNo] = static_cast<M3::float_t>(parVal);
   _fCurrVal[parNo] = parVal;
   MACH3LOG_DEBUG("Setting {} (parameter {}) to {})", GetParFancyName(parNo),  parNo, parVal);
   if (pca) PCAObj->TransferToPCA();
@@ -735,7 +738,10 @@ void ParameterHandlerBase::CorrelateSteps() _noexcept_ {
     #endif
     for (int i = 0; i < _fNumPar; ++i) {
       if (!IsParameterFixed(i) > 0.) {
-        _fPropVal[i] = _fCurrVal[i] + corr_throw[i]*_fGlobalStepScale*_fIndivStepScale[i];
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wuseless-cast"
+        _fPropVal[i] = static_cast<M3::float_t>(_fCurrVal[i] + corr_throw[i]*_fGlobalStepScale*_fIndivStepScale[i]);
+        #pragma GCC diagnostic pop
       }
     }
     // If doing PCA throw uncorrelated in PCA basis (orthogonal basis by definition)
@@ -764,25 +770,30 @@ void ParameterHandlerBase::AcceptStep() _noexcept_ {
   }
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuseless-cast"
 // *************************************
 //HW: This method is a tad hacky but modular arithmetic gives me a headache.
 void ParameterHandlerBase::CircularParBounds(const int index, const double LowBound, const double UpBound) {
 // *************************************
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wuseless-cast"
   if(_fPropVal[index] > UpBound) {
-    _fPropVal[index] = LowBound + std::fmod(_fPropVal[index] - UpBound, UpBound - LowBound);
+    _fPropVal[index] = static_cast<M3::float_t>(LowBound + std::fmod(_fPropVal[index] - UpBound, UpBound - LowBound));
   } else if (_fPropVal[index] < LowBound) {
-    _fPropVal[index] = UpBound - std::fmod(LowBound - _fPropVal[index], UpBound - LowBound);
+    _fPropVal[index] = static_cast<M3::float_t>(UpBound - std::fmod(LowBound - _fPropVal[index], UpBound - LowBound));
   }
+  #pragma GCC diagnostic pop
 }
 
 // *************************************
 void ParameterHandlerBase::FlipParameterValue(const int index, const double FlipPoint) {
 // *************************************
   if(random_number[0]->Uniform() < 0.5) {
-    _fPropVal[index] = 2 * FlipPoint - _fPropVal[index];
+    _fPropVal[index] = static_cast<M3::float_t>(2 * FlipPoint - _fPropVal[index]);
   }
 }
-
+#pragma GCC diagnostic pop
 // ********************************************
 // Function to print the prior values
 void ParameterHandlerBase::PrintNominal() const {
@@ -870,11 +881,13 @@ double ParameterHandlerBase::GetLikelihood() {
 // Sets the proposed parameters to the prior values
 void ParameterHandlerBase::SetParameters(const std::vector<double>& pars) {
 // ********************************************
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wuseless-cast"
   // If empty, set the proposed to prior
   if (pars.empty()) {
     // For xsec this means setting to the prior (because prior is the prior)
     for (int i = 0; i < _fNumPar; i++) {
-      _fPropVal[i] = _fPreFitValue[i];
+      _fPropVal[i] = static_cast<M3::float_t>(_fPreFitValue[i]);
     }
     // If not empty, set the parameters to the specified
   } else {
@@ -889,7 +902,7 @@ void ParameterHandlerBase::SetParameters(const std::vector<double>& pars) {
         MACH3LOG_ERROR("Trying to set parameter value to a nan for parameter {} in matrix {}. This will not go well!", GetParName(i), matrixName);
         throw MaCh3Exception(__FILE__ , __LINE__ );
       } else {
-        _fPropVal[i] = pars[i];
+        _fPropVal[i] = static_cast<M3::float_t>(pars[i]);
       }
     }
   }
@@ -898,6 +911,7 @@ void ParameterHandlerBase::SetParameters(const std::vector<double>& pars) {
     PCAObj->TransferToPCA();
     PCAObj->TransferToParam();
   }
+  #pragma GCC diagnostic pop
 }
 
 // ********************************************
@@ -1122,7 +1136,9 @@ void ParameterHandlerBase::ResetIndivStepScale() {
   SetIndivStepScale(stepScales);
 }
 
+// ********************************************
 void ParameterHandlerBase::SetIndivStepScaleForSkippedAdaptParams() {
+// ********************************************
   if (!param_skip_adapt_flags.size()) {
     MACH3LOG_ERROR("Parameter skip adapt flags not set, cannot set individual step scales for skipped parameters.");
     throw MaCh3Exception(__FILE__ , __LINE__ );
@@ -1140,7 +1156,7 @@ void ParameterHandlerBase::SetIndivStepScaleForSkippedAdaptParams() {
 
 // ********************************************
 // HW: Code for throwing from separate throw matrix, needs to be set after init to ensure pos-def
-void ParameterHandlerBase::SetThrowMatrix(TMatrixDSym *cov){
+void ParameterHandlerBase::SetThrowMatrix(TMatrixDSym *cov) {
 // ********************************************
 
    if (cov == nullptr) {
@@ -1198,7 +1214,7 @@ void ParameterHandlerBase::SetSubThrowMatrix(int first_index, int last_index,
 }
 
 // ********************************************
-void ParameterHandlerBase::UpdateThrowMatrix(TMatrixDSym *cov){
+void ParameterHandlerBase::UpdateThrowMatrix(TMatrixDSym *cov) {
 // ********************************************
   delete throwMatrix;
   throwMatrix = nullptr;
@@ -1207,7 +1223,7 @@ void ParameterHandlerBase::UpdateThrowMatrix(TMatrixDSym *cov){
 
 // ********************************************
 // HW : Here be adaption
-void ParameterHandlerBase::InitialiseAdaption(const YAML::Node& adapt_manager){
+void ParameterHandlerBase::InitialiseAdaption(const YAML::Node& adapt_manager) {
 // ********************************************
   if(PCAObj){
     MACH3LOG_ERROR("PCA has been enabled and now trying to enable Adaption. Right now both configuration don't work with each other");
@@ -1217,7 +1233,7 @@ void ParameterHandlerBase::InitialiseAdaption(const YAML::Node& adapt_manager){
     MACH3LOG_ERROR("Adaptive Handler has already been initialise can't do it again so skipping.");
     return;
   }
-  AdaptiveHandler = std::make_unique<adaptive_mcmc::AdaptiveMCMCHandler>();
+  AdaptiveHandler = std::make_unique<AdaptiveMCMCHandler>();
 
   // HH: Backing up _fIndivStepScale and _fGlobalStepScale before adaption
   _fIndivStepScaleInitial = _fIndivStepScale;
@@ -1303,7 +1319,7 @@ void ParameterHandlerBase::InitialiseAdaption(const YAML::Node& adapt_manager){
 
 // ********************************************
 // Truely adaptive MCMC!
-void ParameterHandlerBase::UpdateAdaptiveCovariance(){
+void ParameterHandlerBase::UpdateAdaptiveCovariance() {
 // ********************************************
   // Updates adaptive matrix
   // First we update the total means

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -54,7 +54,7 @@ class ParameterHandlerBase {
   /// @param i Parameter index
   /// @param val new value which will be set
   void SetParProp(const int i, const double val) {
-    _fPropVal[i] = val;
+    _fPropVal[i] = static_cast<M3::float_t>(val);
     if (pca) PCAObj->TransferToPCA();
   }
   /// @brief Set parameter values using vector, it has to have same size as covariance class
@@ -151,10 +151,10 @@ class ParameterHandlerBase {
 
   /// @brief Get diagonal error for ith parameter
   /// @param i Parameter index
-  inline double GetDiagonalError(const int i) const { return std::sqrt((*covMatrix)(i,i)); }
+  double GetDiagonalError(const int i) const { return std::sqrt((*covMatrix)(i,i)); }
   /// @brief Get the error for the ith parameter
   /// @param i Parameter index
-  inline double GetError(const int i) const {return _fError[i];}
+  double GetError(const int i) const {return _fError[i];}
 
   /// @brief Adaptive Step Tuning Stuff
   void ResetIndivStepScale();
@@ -177,13 +177,13 @@ class ParameterHandlerBase {
   /// @brief Replaces old throw matrix with new one
   void UpdateThrowMatrix(TMatrixDSym *cov);
   /// @brief Set number of MCMC step, when running adaptive MCMC it is updated with given frequency. We need number of steps to determine frequency.
-  inline void SetNumberOfSteps(const int nsteps) {
+  void SetNumberOfSteps(const int nsteps) {
     AdaptiveHandler->SetTotalSteps(nsteps);
     if(AdaptiveHandler->AdaptionUpdate()) ResetIndivStepScale();
   }
 
   /// @brief Get matrix used for step proposal
-  inline TMatrixDSym *GetThrowMatrix() const {return throwMatrix;}
+  TMatrixDSym *GetThrowMatrix() const {return throwMatrix;}
   /// @brief Get matrix used for step proposal
   double GetThrowMatrix(const int i, const int j) const { return throwMatrixCholDecomp[i][j];}
 
@@ -202,11 +202,11 @@ class ParameterHandlerBase {
   /// push_back then the pointer is no longer valid... maybe need a better
   /// way to deal with this? It was fine before when the return was to an
   /// element of a new array. There must be a clever C++ way to be careful
-  inline const double* RetPointer(const int iParam) {return &(_fPropVal.data()[iParam]);}
+  const M3::float_t* RetPointer(const int iParam) {return &(_fPropVal.data()[iParam]);}
 
   /// @brief Get a reference to the proposed parameter values
   /// Can be useful if you want to track these without having to copy values using getProposed()
-  inline const std::vector<double> &GetParPropVec() {return _fPropVal;}
+  const std::vector<M3::float_t> &GetParPropVec() {return _fPropVal;}
 
   /// @brief Get total number of parameters
   int  GetNumParams() const {return _fNumPar;}
@@ -216,30 +216,30 @@ class ParameterHandlerBase {
   std::vector<double> GetProposed() const;
   /// @brief Get proposed parameter value
   /// @param i Parameter index
-  double GetParProp(const int i) const { return _fPropVal[i]; }
+  M3::float_t GetParProp(const int i) const { return _fPropVal[i]; }
   /// @brief Get current parameter value
   /// @param i Parameter index
-  inline double GetParCurr(const int i) const { return _fCurrVal[i]; }
+  double GetParCurr(const int i) const { return _fCurrVal[i]; }
   /// @brief Get vector of current parameter values
-  inline const std::vector<double> &GetParCurrVec() const { return _fCurrVal; }
+  const std::vector<double> &GetParCurrVec() const { return _fCurrVal; }
 
   /// @brief Get prior parameter value
   /// @param i Parameter index
-  inline double GetParInit(const int i) const { return _fPreFitValue[i]; }
+  double GetParInit(const int i) const { return _fPreFitValue[i]; }
   /// @brief Get upper parameter bound in which it is physically valid
   /// @param i Parameter index
-  inline double GetUpperBound(const int i) const { return _fUpBound[i];}
+  double GetUpperBound(const int i) const { return _fUpBound[i];}
   /// @brief Get lower parameter bound in which it is physically valid
   /// @param i Parameter index
-  inline double GetLowerBound(const int i) const { return _fLowBound[i]; }
+  double GetLowerBound(const int i) const { return _fLowBound[i]; }
   /// @brief Get individual step scale for selected parameter
   /// @param ParameterIndex Parameter index
-  inline double GetIndivStepScale(const int ParameterIndex) const {return _fIndivStepScale.at(ParameterIndex); }
+  double GetIndivStepScale(const int ParameterIndex) const {return _fIndivStepScale.at(ParameterIndex); }
   /// @brief Get global step scale for covariance object
-  inline double GetGlobalStepScale() const {return _fGlobalStepScale; }
+  double GetGlobalStepScale() const {return _fGlobalStepScale; }
 
   /// @brief Get number of params which will be different depending if using Eigen decomposition or not
-  inline int GetNParameters() const {
+  int GetNParameters() const {
     if (pca) return PCAObj->GetNumberPCAedParameters();
     else return _fNumPar;
   }
@@ -311,13 +311,13 @@ class ParameterHandlerBase {
   void ConstructPCA(const double eigen_threshold, int FirstPCAdpar, int LastPCAdpar);
 
   /// @brief is PCA, can use to query e.g. LLH scans
-  inline bool IsPCA() const { return pca; }
+  bool IsPCA() const { return pca; }
 
   /// @brief Getter to return a copy of the YAML node
   YAML::Node GetConfig() const { return _fYAMLDoc; }
 
   /// @brief Get pointer for AdaptiveHandler
-  inline adaptive_mcmc::AdaptiveMCMCHandler* GetAdaptiveHandler() const  {
+  AdaptiveMCMCHandler* GetAdaptiveHandler() const  {
     if (!use_adaptive) {
       MACH3LOG_ERROR("Am not running in Adaptive mode");
       throw MaCh3Exception(__FILE__ , __LINE__ );
@@ -440,7 +440,7 @@ protected:
   /// Current value of the parameter
   std::vector<double> _fCurrVal;
   /// Proposed value of the parameter
-  std::vector<double> _fPropVal;
+  std::vector<M3::float_t> _fPropVal;
   /// Prior error on the parameter
   std::vector<double> _fError;
   /// Lowest physical bound, parameter will not be able to go beyond it
@@ -476,7 +476,7 @@ protected:
   /// Struct containing information about PCA
   std::unique_ptr<PCAHandler> PCAObj;
   /// Struct containing information about adaption
-  std::unique_ptr<adaptive_mcmc::AdaptiveMCMCHandler> AdaptiveHandler;
+  std::unique_ptr<AdaptiveMCMCHandler> AdaptiveHandler;
   /// Struct containing information about adaption
   std::unique_ptr<ParameterTunes> Tunes;
 

--- a/Parameters/ParameterHandlerGeneric.cpp
+++ b/Parameters/ParameterHandlerGeneric.cpp
@@ -401,9 +401,12 @@ void ParameterHandlerGeneric::InitParams() {
         throw MaCh3Exception(__FILE__ , __LINE__ );
       }
     }
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wuseless-cast"
     // Set ParameterHandler parameters (Curr = current, Prop = proposed, Sigma = step)
     _fCurrVal[i] = _fPreFitValue[i];
-    _fPropVal[i] = _fCurrVal[i];
+    _fPropVal[i] = static_cast<M3::float_t>(_fCurrVal[i]);
+    #pragma GCC diagnostic pop
   }
   Randomize();
   //KS: Transfer the starting parameters to the PCA basis, you don't want to start with zero..
@@ -662,10 +665,12 @@ void ParameterHandlerGeneric::SetGroupOnlyParameters(const std::vector< std::str
 // Function to set to prior parameters of a given group
 void ParameterHandlerGeneric::SetGroupOnlyParameters(const std::string& Group, const std::vector<double>& Pars) {
 // ********************************************
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wuseless-cast"
   // If empty, set the proposed to prior
   if (Pars.empty()) {
     for (int i = 0; i < _fNumPar; i++) {
-      if(IsParFromGroup(i, Group)) _fPropVal[i] = _fPreFitValue[i];
+      if(IsParFromGroup(i, Group)) _fPropVal[i] = static_cast<M3::float_t>(_fPreFitValue[i]);
     }
   } else{
     const size_t ExpectedSize = static_cast<size_t>(GetNumParFromGroup(Group));
@@ -677,7 +682,7 @@ void ParameterHandlerGeneric::SetGroupOnlyParameters(const std::string& Group, c
     for (int i = 0; i < _fNumPar; i++) {
       // If belongs to group set value from parsed vector, otherwise use propose value
       if(IsParFromGroup(i, Group)){
-        _fPropVal[i] = Pars[Counter];
+        _fPropVal[i] = static_cast<M3::float_t>(Pars[Counter]);
         Counter++;
       }
     }
@@ -687,6 +692,7 @@ void ParameterHandlerGeneric::SetGroupOnlyParameters(const std::string& Group, c
     PCAObj->TransferToPCA();
     PCAObj->TransferToParam();
   }
+  #pragma GCC diagnostic pop
 }
 
 // ********************************************
@@ -763,9 +769,9 @@ int ParameterHandlerGeneric::GetNumParFromGroup(const std::string& Group) const 
 
 // ********************************************
 // DB Grab the Normalisation parameters for the relevant sample name
-std::vector<const double*> ParameterHandlerGeneric::GetOscParsFromSampleName(const std::string& SampleName) {
+std::vector<const M3::float_t*> ParameterHandlerGeneric::GetOscParsFromSampleName(const std::string& SampleName) {
 // ********************************************
-  std::vector<const double*> returnVec;
+  std::vector<const M3::float_t*> returnVec;
   for (const auto& pair : _fSystToGlobalSystIndexMap[SystType::kOsc]) {
     const auto& globalIndex = pair.second;
     if (AppliesToSample(globalIndex, SampleName)) {

--- a/Parameters/ParameterHandlerGeneric.h
+++ b/Parameters/ParameterHandlerGeneric.h
@@ -129,7 +129,7 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
     void DumpMatrixToFile(const std::string& Name);
 
     /// @brief Get pointers to Osc params from Sample name
-    std::vector<const double*> GetOscParsFromSampleName(const std::string& SampleName);
+    std::vector<const M3::float_t*> GetOscParsFromSampleName(const std::string& SampleName);
 
   protected:
     /// @brief Print information about the whole object once it is set

--- a/Parameters/ParameterStructs.h
+++ b/Parameters/ParameterStructs.h
@@ -133,7 +133,7 @@ struct NormParameter : public TypeParameterBase {
 };
 
 /// HH - a shorthand type for funcpar functions
-using FuncParFuncType = std::function<void (const double*, std::size_t)>;
+using FuncParFuncType = std::function<void (const M3::float_t*, std::size_t)>;
 // *******************
 /// @brief HH - Functional parameters
 /// Carrier for whether you want to apply a systematic to an event or not
@@ -144,7 +144,7 @@ struct FunctionalParameter : public TypeParameterBase {
   std::vector<int> modes;
 
   /// Parameter value pointer
-  const double* valuePtr = nullptr;
+  const M3::float_t* valuePtr = nullptr;
 
   /// Function pointer
   FuncParFuncType* funcPtr = nullptr;

--- a/Samples/FarDetectorCoreInfoStruct.h
+++ b/Samples/FarDetectorCoreInfoStruct.h
@@ -105,10 +105,7 @@ struct EventInfo {
   /// Pointer to true cosine zenith
   double coszenith_true = M3::_BAD_DOUBLE_;
 
-  /// Pointers to normalisation weights which are being taken from Parameter Handler
-  std::vector<const double*> norm_pointers;
-
-  /// Pointers to weights like oscillation spline etc
+  /// Pointers to weights like oscillation spline, normalisation etc
   std::vector<const M3::float_t*> total_weight_pointers;
 
   /// The x_var and y_vars and beyond that you're binning in

--- a/Samples/OscillationHandler.cpp
+++ b/Samples/OscillationHandler.cpp
@@ -7,7 +7,7 @@ _MaCh3_Safe_Include_End_ //}
 
 // ************************************************
 OscillationHandler::OscillationHandler(const std::string& NuOscillatorConfigFile, bool BinningPerOscChannel_,
-                                       std::vector<const double*> OscParams_, const int SubChannels) {
+                                       std::vector<const M3::float_t*> OscParams_, const int SubChannels) {
 // ************************************************
   EqualBinningPerOscChannel = BinningPerOscChannel_;
   OscParams = OscParams_;
@@ -82,10 +82,7 @@ void OscillationHandler::Evaluate() {
 // ************************************************
   std::vector<M3::float_t> OscVec(OscParams.size());
   for (size_t iPar = 0; iPar < OscParams.size(); ++iPar) {
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wuseless-cast"
-    OscVec[iPar] = static_cast<M3::float_t>(*OscParams[iPar]);
-    #pragma GCC diagnostic pop
+    OscVec[iPar] = *OscParams[iPar];
   }
 
   if (EqualBinningPerOscChannel) {

--- a/Samples/OscillationHandler.h
+++ b/Samples/OscillationHandler.h
@@ -18,7 +18,7 @@ class OscillationHandler
   /// @param SubChannels Number of oscillation channels
    /// @warning If @p EqualBinningPerChannel is true then argument @p SubChannels makes no difference
   OscillationHandler(const std::string& ConfigFile, bool EqualBinningPerChannel,
-                     std::vector<const double*> OscParams_, const int SubChannels);
+                     std::vector<const M3::float_t*> OscParams_, const int SubChannels);
   /// @brief Destructor
   virtual ~OscillationHandler();
 
@@ -47,5 +47,5 @@ class OscillationHandler
   std::vector<std::vector<std::unique_ptr<OscillatorBase>>> NuOscProbCalcers;
 
   /// pointer to osc params, since not all params affect every sample, we perform some operations before hand for speed
-  std::vector<const double*> OscParams;
+  std::vector<const M3::float_t*> OscParams;
 };

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -567,19 +567,6 @@ void SampleHandlerFD::ApplyShifts(const int iEvent) {
 M3::float_t SampleHandlerFD::CalcWeightTotal(const EventInfo* _restrict_ MCEvent) const {
 // ***************************************************************************
   M3::float_t TotalWeight = 1.0;
-  const int nNorms = static_cast<int>(MCEvent->norm_pointers.size());
-  //Loop over stored normalisation and function pointers
-  #ifdef MULTITHREAD
-  #pragma omp simd reduction(*:TotalWeight)
-  #endif
-  for (int iParam = 0; iParam < nNorms; ++iParam)
-  {
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wuseless-cast"
-    TotalWeight *= static_cast<M3::float_t>(*(MCEvent->norm_pointers[iParam]));
-    #pragma GCC diagnostic pop
-  }
-
   const int TotalWeights = static_cast<int>(MCEvent->total_weight_pointers.size());
   //DB Loop over stored pointers
   #ifdef MULTITHREAD
@@ -640,7 +627,7 @@ void SampleHandlerFD::SetupNormParameters() {
 
   std::vector<NormParameter> norm_parameters = ParHandler->GetNormParsFromSampleName(GetName());
 
-  if(!ParHandler){
+  if(!ParHandler) {
     MACH3LOG_ERROR("ParHandler is not setup!");
     throw MaCh3Exception(__FILE__ , __LINE__ );
   }
@@ -649,13 +636,13 @@ void SampleHandlerFD::SetupNormParameters() {
   CalcNormsBins(norm_parameters, norms_bins);
 
   //DB Attempt at reducing impact of SystematicHandlerGeneric::calcReweight()
-  int counter;
   for (unsigned int iEvent = 0; iEvent < GetNEvents(); ++iEvent) {
-    counter = 0;
-
-    MCEvents[iEvent].norm_pointers.resize(norms_bins[iEvent].size());
+    int counter = 0;
+    const size_t offset = MCEvents[iEvent].total_weight_pointers.size();
+    const size_t addSize = norms_bins[iEvent].size();
+    MCEvents[iEvent].total_weight_pointers.resize(offset + addSize);
     for(auto const & norm_bin: norms_bins[iEvent]) {
-      MCEvents[iEvent].norm_pointers[counter] = ParHandler->RetPointer(norm_bin);
+      MCEvents[iEvent].total_weight_pointers[offset + counter] = ParHandler->RetPointer(norm_bin);
       counter += 1;
     }
   }
@@ -1055,7 +1042,7 @@ void SampleHandlerFD::InitialiseNuOscillatorObjects() {
       EqualBinningPerOscChannel = false;
     }
   }
-  std::vector<const double*> OscParams = ParHandler->GetOscParsFromSampleName(SampleHandlerName);
+  std::vector<const M3::float_t*> OscParams = ParHandler->GetOscParsFromSampleName(SampleHandlerName);
   if (OscParams.empty()) {
     MACH3LOG_ERROR("OscParams is empty for sample '{}'.", GetName());
     MACH3LOG_ERROR("This likely indicates an error in your oscillation YAML configuration.");

--- a/Samples/SampleStructs.h
+++ b/Samples/SampleStructs.h
@@ -181,7 +181,7 @@ struct KinematicCut {
 struct FunctionalShifter {
 // ***************************
   /// Pointer to parameter value
-  const double* valuePtr = nullptr;
+  const M3::float_t* valuePtr = nullptr;
   /// Pointer to shifting function
   FuncParFuncType* funcPtr = nullptr;
 };

--- a/Splines/SplineMonolith.h
+++ b/Splines/SplineMonolith.h
@@ -41,7 +41,7 @@ class SMonolith : public SplineBase {
     
     /// @brief KS: Set pointers to spline params
     /// @param spline_ParsPointers Vector of pointers to spline params
-    void setSplinePointers(std::vector< const double* > spline_ParsPointers) {
+    void setSplinePointers(std::vector< const M3::float_t* > spline_ParsPointers) {
       for (M3::int_t i = 0; i < nParams; ++i) SplineInfoArray[i].splineParsPointer = spline_ParsPointers[i];
     };
     

--- a/Splines/SplineStructs.h
+++ b/Splines/SplineStructs.h
@@ -41,7 +41,7 @@ struct FastSplineInfo {
   M3::int_t CurrSegment;
 
   /// Array of the knots positions
-  const double* splineParsPointer;
+  const M3::float_t* splineParsPointer;
 };
 
 

--- a/python/parameters.cpp
+++ b/python/parameters.cpp
@@ -115,10 +115,10 @@ void initParameters(py::module &m) {
             "get_proposal_array",
             [](ParameterHandlerBase &self)
             {
-                return py::memoryview::from_buffer<double>(
+                return py::memoryview::from_buffer<M3::float_t>(
                     self.GetParPropVec().data(), // the data pointer
                     {self.GetNParameters()}, // shape
-                    {sizeof(double)} // shape
+                    {sizeof(M3::float_t)} // shape
                 ); 
             },
             "Bind a python array to the parameter proposal values for this ParameterHandler object. \n\

--- a/python/splines.cpp
+++ b/python/splines.cpp
@@ -196,7 +196,7 @@ void initSplines(py::module &m) {
             "set_param_value_array",
             // Wrap up the setSplinePointers method so that we can take in a numpy array and get 
             // pointers to it's sweet sweet data and use those pointers in the splineMonolith 
-            [](SMonolith &self, py::array_t<double, py::array::c_style> &array)
+            [](SMonolith &self, py::array_t<M3::float_t, py::array::c_style> &array)
             {
                 py::buffer_info bufInfo = array.request();
 
@@ -210,7 +210,7 @@ void initSplines(py::module &m) {
                     throw MaCh3Exception(__FILE__, __LINE__, "Number of entries in parameter array must equal the number of parameters!");
                 }
 
-                std::vector<const double *> paramVec;
+                std::vector<const M3::float_t *> paramVec;
                 paramVec.resize(self.GetNParams());
 
                 for( int idx = 0; idx < self.GetNParams(); idx++ )


### PR DESCRIPTION
# Pull request description
Now all weight pointers are in single vector.
This required a few static cast

In addition, removed namespace for AdaptiveHandler

Need to merge: https://github.com/mach3-software/MaCh3Tutorial/pull/233
## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
