### PR TITLE
breaking: Stop Hardcdoding NSplines and RetPointer float/double

### DIFF
--- a/Fitters/DelayedMR2T2.h
+++ b/Fitters/DelayedMR2T2.h
@@ -52,10 +52,10 @@ class DelayedMR2T2 : public MR2T2 {
 
  protected:
      /// @brief Step acceptance probability
-    double AcceptanceProbability() override;
+    double AcceptanceProbability() override final;
 
     /// @brief The MCMC step proposal
-    void DoStep() override;
+    void DoStep() override final;
 
     /// @brief Store information about the current proposed step
     void StoreCurrentStep();

--- a/Fitters/MCMCBase.h
+++ b/Fitters/MCMCBase.h
@@ -15,11 +15,11 @@ class MCMCBase : public FitterBase {
     virtual ~MCMCBase() = default;
 
     /// @brief Actual implementation of MCMC fitting algorithm
-    void RunMCMC() override;
+    void RunMCMC() override final;
 
     /// @brief Allow to start from previous fit/chain
     /// @param FitName Name of previous chain
-    void StartFromPreviousFit(const std::string &FitName) override;
+    void StartFromPreviousFit(const std::string &FitName) override final;
 
     /// @brief Set how long chain should be
     /// @param L new chain length

--- a/Fitters/MR2T2.h
+++ b/Fitters/MR2T2.h
@@ -36,7 +36,7 @@ class MR2T2 : public MCMCBase {
     /// @brief The MCMC step proposal and acceptance
     void DoStep() override;
     /// @brief Propose a step
-    void ProposeStep() override;
+    void ProposeStep() override final;
     /// @brief Step acceptance probability
     double AcceptanceProbability() override;
 };

--- a/Fitters/MinuitFit.h
+++ b/Fitters/MinuitFit.h
@@ -21,7 +21,7 @@ class MinuitFit : public LikelihoodFit {
   virtual ~MinuitFit();
 
   /// @brief Actual implementation of Minuit Fit algorithm
-  void RunMCMC() override;
+  void RunMCMC() override final;
  private:
   /// Pointer to minimizer, which most often is Minuit
   std::unique_ptr<ROOT::Math::Minimizer> minuit;

--- a/Fitters/PSO.h
+++ b/Fitters/PSO.h
@@ -98,8 +98,8 @@ class PSO : public LikelihoodFit {
     void run();
     void WriteOutput();
     /// @brief Actual implementation of PSO Fit algorithm
-    void RunMCMC() override;
-    double CalcChi2(const double* x) override;
+    void RunMCMC() override final;
+    double CalcChi2(const double* x) override final;
     /// @brief Evaluates the Rastrigin function for a given parameter values.
     double rastriginFunc(const double* x);
     double swarmIterate();

--- a/Manager/gpuUtils.cu
+++ b/Manager/gpuUtils.cu
@@ -42,15 +42,13 @@ void __cudaCheckError( const char *file, const int line ) {
 // KS: Get some fancy info about VRAM usage
 void checkGpuMem() {
 // *******************************************
-  float free_m, total_m,used_m;
   size_t free_t, total_t;
-
   cudaMemGetInfo(&free_t, &total_t);
   CudaCheckError();
 
-  free_m = static_cast<uint>(free_t)/1048576.0;
-  total_m = static_cast<uint>(total_t)/1048576.0;
-  used_m = total_m - free_m;
+  double free_m = static_cast<double>(free_t) / 1024.0 / 1024.0;
+  double total_m = static_cast<double>(total_t) / 1024.0 / 1024.0;
+  double used_m = total_m - free_m;
 
   printf("  Memory free %f MB, total memory %f MB, memory used %f MB\n", free_m, total_m, used_m);
 }

--- a/Manager/gpuUtils.cuh
+++ b/Manager/gpuUtils.cuh
@@ -1,6 +1,5 @@
 #pragma once
 
-
 // C i/o  for printf and others
 #include <stdio.h>
 #include <vector>
@@ -23,7 +22,6 @@
 
 /// KS: Need it for shared memory, there is way to use dynamic shared memory but I am lazy right now
 #define _BlockSize_ 1024
-
 
 /// @file gpuUtils.cuh
 /// @brief Common CUDA utilities and definitions for shared GPU functionality.
@@ -89,3 +87,12 @@ size_t GetMaxTexture1DSize(const int device = 0);
 /// @param device CUDA device ID (default = 0)
 /// @return Maximum shared memory per block in bytes
 size_t GetSharedMemoryPerBlock(const int device = 0);
+
+
+namespace M3 {
+#ifdef _LOW_MEMORY_STRUCTS_
+  using float_t = float;
+#else
+  using float_t = double;
+#endif
+}

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -564,7 +564,7 @@ void SampleHandlerFD::ApplyShifts(const int iEvent) {
 
 // ***************************************************************************
 // Calculate the spline weight for one event
-M3::float_t SampleHandlerFD::CalcWeightTotal(const EventInfo* _restrict_ MCEvent) const {
+M3::float_t SampleHandlerFD::CalcWeightTotal(const EventInfo* _restrict_ MCEvent) const _noexcept_ {
 // ***************************************************************************
   M3::float_t TotalWeight = 1.0;
   const int nNorms = static_cast<int>(MCEvent->norm_pointers.size());

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -1252,7 +1252,7 @@ void SampleHandlerFD::SetSplinePointers() {
           continue;
         }
         //Event Splines indexed as: sample name, oscillation channel, syst, mode, etrue, var1, var2 (var2 is a dummy 0 for 1D splines)
-        w_pointers.push_back(BinnedSpline->retPointer(EventSplines[spline][0], EventSplines[spline][1],
+        w_pointers.push_back(BinnedSpline->RetPointer(EventSplines[spline][0], EventSplines[spline][1],
                                                       EventSplines[spline][2], EventSplines[spline][3],
                                                       EventSplines[spline][4], EventSplines[spline][5],
                                                       EventSplines[spline][6]));
@@ -1260,16 +1260,9 @@ void SampleHandlerFD::SetSplinePointers() {
       w_pointers.shrink_to_fit();
     } // end loop over events
   } else if (auto UnbinnedSpline = dynamic_cast<SMonolith*>(SplineHandler.get())) {
-    /// @todo Fix this mess :(
-    #ifdef _LOW_MEMORY_STRUCTS_
     for (unsigned int iEvent = 0; iEvent < GetNEvents(); ++iEvent) {
-      MCEvents[iEvent].total_weight_pointers.push_back(UnbinnedSpline->retPointer(iEvent));
+      MCEvents[iEvent].total_weight_pointers.push_back(UnbinnedSpline->RetPointer(iEvent));
     }
-    #else
-    (void) UnbinnedSpline;
-    MACH3LOG_ERROR("Unbinned splines only for float :(");
-    throw MaCh3Exception(__FILE__, __LINE__);
-    #endif
   } else {
     MACH3LOG_ERROR("Not supported splines");
     throw MaCh3Exception(__FILE__, __LINE__);

--- a/Samples/SampleHandlerFD.h
+++ b/Samples/SampleHandlerFD.h
@@ -30,14 +30,14 @@ class SampleHandlerFD :  public SampleHandlerBase
   virtual ~SampleHandlerFD();
 
   /// @brief DB Function to differentiate 1D or 2D binning
-  int GetNDim(const int Sample) const override { return SampleDetails[Sample].nDimensions; }
-  std::string GetName() const override;
-  std::string GetSampleTitle(const int Sample) const override {return SampleDetails[Sample].SampleTitle;}
+  int GetNDim(const int Sample) const override final { return SampleDetails[Sample].nDimensions; }
+  std::string GetName() const override final;
+  std::string GetSampleTitle(const int Sample) const override final {return SampleDetails[Sample].SampleTitle;}
 
   /// @brief Return Kinematic Variable name for specified sample and dimension for example "Reconstructed_Neutrino_Energy"
   /// @param iSample Sample index
   /// @param Dimension Dimension index
-  std::string GetKinVarName(const int iSample, const int Dimension) const override;
+  std::string GetKinVarName(const int iSample, const int Dimension) const override final;
 
   std::string GetXBinVarName(const int Sample) const {return GetKinVarName(Sample, 0);}
   std::string GetYBinVarName(const int Sample) const {return GetKinVarName(Sample, 1);}
@@ -56,7 +56,7 @@ class SampleHandlerFD :  public SampleHandlerBase
 
   /// @brief Helper function to print rates for the samples with LLH
   /// @param DataOnly whether to print data only rates
-  void PrintRates(const bool DataOnly = false) override;
+  void PrintRates(const bool DataOnly = false) override final;
   /// @brief DB Multi-threaded GetLikelihood
   double GetLikelihood() const override;
   /// @brief Get likelihood for single sample
@@ -68,17 +68,17 @@ class SampleHandlerFD :  public SampleHandlerBase
   int GetSampleIndex(const std::string& SampleTitle) const;
 
   /// @brief Get Data histogram
-  TH1* GetDataHist(const int Sample) override;
+  TH1* GetDataHist(const int Sample) override final;
   TH1* GetDataHist(const std::string& Sample);
 
   /// @brief Get MC histogram
-  TH1* GetMCHist(const int Sample) override;
+  TH1* GetMCHist(const int Sample) override final;
   TH1* GetMCHist(const std::string& Sample);
 
   /// @brief Get W2 histogram
-  TH1* GetW2Hist(const int Sample) override;
+  TH1* GetW2Hist(const int Sample) override final;
   TH1* GetW2Hist(const std::string& Sample);
-
+  /// @brief main routine modifying MC prediction based on proposed parameter values
   void Reweight() override;
   M3::float_t GetEventWeight(const int iEntry);
 
@@ -90,9 +90,9 @@ class SampleHandlerFD :  public SampleHandlerBase
   void ReadConfig();
   void LoadSingleSample(const int iSample, const YAML::Node& Settings);
 
-  int GetNOscChannels(const int iSample) const override {return static_cast<int>(SampleDetails[iSample].OscChannels.size());};
+  int GetNOscChannels(const int iSample) const override final {return static_cast<int>(SampleDetails[iSample].OscChannels.size());};
 
-  std::string GetFlavourName(const int iSample, const int iChannel) const override {
+  std::string GetFlavourName(const int iSample, const int iChannel) const override final {
     if (iChannel < 0 || iChannel > GetNOscChannels(iSample)) {
       MACH3LOG_ERROR("Invalid Channel Requested: {}", iChannel);
       throw MaCh3Exception(__FILE__ , __LINE__);
@@ -105,11 +105,11 @@ class SampleHandlerFD :  public SampleHandlerBase
                                                                  const std::vector<KinematicCut>& ExtraCuts);
   TH1 *Get1DVarHist(const int iSample, const std::string &ProjectionVar,
                     const std::vector<KinematicCut> &EventSelectionVec = {}, int WeightStyle = 0,
-                    TAxis *Axis = nullptr, const std::vector<KinematicCut> &SubEventSelectionVec = {}) override;
+                    TAxis *Axis = nullptr, const std::vector<KinematicCut> &SubEventSelectionVec = {}) override final;
   TH2* Get2DVarHist(const int iSample, const std::string& ProjectionVarX, const std::string& ProjectionVarY,
                     const std::vector< KinematicCut >& EventSelectionVec = {},
                     int WeightStyle = 0, TAxis* AxisX = nullptr, TAxis* AxisY = nullptr,
-                    const std::vector< KinematicCut >& SubEventSelectionVec = {}) override;
+                    const std::vector< KinematicCut >& SubEventSelectionVec = {}) override final;
   std::vector<KinematicCut> BuildModeChannelSelection(const int iSample, const int kModeToFill, const int kChannelToFill) const;
 
   void Fill1DSubEventHist(const int iSample, TH1D* _h1DVar, const std::string& ProjectionVar,
@@ -119,11 +119,11 @@ class SampleHandlerFD :  public SampleHandlerBase
                           const std::vector< KinematicCut >& SubEventSelectionVec = {}, int WeightStyle = 0);
 
   TH1* Get1DVarHistByModeAndChannel(const int iSample, const std::string& ProjectionVar_Str,
-                                    int kModeToFill = -1, int kChannelToFill = -1, int WeightStyle = 0, TAxis* Axis = nullptr) override;
+                                    int kModeToFill = -1, int kChannelToFill = -1, int WeightStyle = 0, TAxis* Axis = nullptr) override final;
   TH2* Get2DVarHistByModeAndChannel(const int iSample, const std::string& ProjectionVar_StrX,
                                     const std::string& ProjectionVar_StrY, int kModeToFill = -1,
                                     int kChannelToFill = -1, int WeightStyle = 0,
-                                    TAxis* AxisX = nullptr, TAxis* AxisY = nullptr) override;
+                                    TAxis* AxisX = nullptr, TAxis* AxisY = nullptr) override final;
 
   TH1 *GetModeHist1D(const int iSample, int s, int m, int style = 0) {
     return Get1DVarHistByModeAndChannel(iSample, GetXBinVarName(iSample), m, s, style);
@@ -149,7 +149,7 @@ class SampleHandlerFD :  public SampleHandlerBase
   std::string ReturnStringFromKinematicParameter(const int KinematicVariable) const;
 
   /// @brief Store additional info in a chan
-  void SaveAdditionalInfo(TDirectory* Dir) override;
+  void SaveAdditionalInfo(TDirectory* Dir) override final;
 
   // === JM declare the same functions for kinematic vectors ===
   int ReturnKinematicVectorFromString(const std::string& KinematicStr) const;
@@ -282,7 +282,7 @@ class SampleHandlerFD :  public SampleHandlerBase
   void CalcNormsBins(std::vector<NormParameter>& norm_parameters, std::vector< std::vector< int > >& norms_bins);
   template <typename ParT> bool PassesSelection(const ParT& Par, std::size_t iEvent);
   /// @brief Calculate the total weight weight for a given event
-  M3::float_t CalcWeightTotal(const EventInfo* _restrict_ MCEvent) const;
+  M3::float_t CalcWeightTotal(const EventInfo* _restrict_ MCEvent) const _noexcept_;
 
   /// @brief Calculate weights for function parameters
   ///
@@ -305,7 +305,7 @@ class SampleHandlerFD :  public SampleHandlerBase
   // ===========================================================
 
   /// @brief Return the binning used to draw a kinematic parameter
-  std::vector<double> ReturnKinematicParameterBinning(const int Sample, const std::string &KinematicParameter) const override;
+  std::vector<double> ReturnKinematicParameterBinning(const int Sample, const std::string &KinematicParameter) const override final;
 
   const double* GetPointerToKinematicParameter(const std::string& KinematicParameter, int iEvent) {
     return GetPointerToKinematicParameter(ReturnKinematicParameterFromString(KinematicParameter), iEvent);

--- a/Splines/BinnedSplineHandler.cpp
+++ b/Splines/BinnedSplineHandler.cpp
@@ -11,13 +11,13 @@ _MaCh3_Safe_Include_Start_ //{
 _MaCh3_Safe_Include_End_ //}
 
 //****************************************
-BinnedSplineHandler::BinnedSplineHandler(ParameterHandlerGeneric *xsec_, MaCh3Modes *Modes_) : SplineBase() {
+BinnedSplineHandler::BinnedSplineHandler(ParameterHandlerGeneric *ParHandler_, MaCh3Modes *Modes_) : SplineBase() {
 //****************************************
-  if (!xsec_) {
+  if (!ParHandler_) {
     MACH3LOG_ERROR("Trying to create BinnedSplineHandler with uninitialized covariance object");
     throw MaCh3Exception(__FILE__, __LINE__);
   }
-  xsec = xsec_;
+  ParHandler = ParHandler_;
 
   if (!Modes_) {
     MACH3LOG_ERROR("Trying to create BinnedSplineHandler with uninitialized MaCh3Modes object");
@@ -76,23 +76,23 @@ void BinnedSplineHandler::AddSample(const std::string& SampleName,
   Dimensions.push_back(static_cast<int>(SplineVarNames.size()));
   DimensionLabels.push_back(SplineVarNames);
 
-  int nSplineParam = xsec->GetNumParamsFromSampleName(SampleName, SystType::kSpline);
+  int nSplineParam = ParHandler->GetNumParamsFromSampleName(SampleName, SystType::kSpline);
   nSplineParams.push_back(nSplineParam);
 
   //This holds the global index of the spline i.e. 0 -> _fNumPar
-  std::vector<int> GlobalSystIndex_Sample = xsec->GetGlobalSystIndexFromSampleName(SampleName, SystType::kSpline);
+  std::vector<int> GlobalSystIndex_Sample = ParHandler->GetGlobalSystIndexFromSampleName(SampleName, SystType::kSpline);
   //Keep track of this for all the samples
   GlobalSystIndex.push_back(GlobalSystIndex_Sample);
 
-  std::vector<SplineInterpolation> SplineInterpolation_Sample = xsec->GetSplineInterpolationFromSampleName(SampleName);
+  std::vector<SplineInterpolation> SplineInterpolation_Sample = ParHandler->GetSplineInterpolationFromSampleName(SampleName);
   // Keep track of this for all samples
   SplineInterpolationTypes.push_back(SplineInterpolation_Sample);
 
-  std::vector<std::string> SplineFileParPrefixNames_Sample = xsec->GetSplineParsNamesFromSampleName(SampleName);
+  std::vector<std::string> SplineFileParPrefixNames_Sample = ParHandler->GetSplineParsNamesFromSampleName(SampleName);
   SplineFileParPrefixNames.push_back(SplineFileParPrefixNames_Sample);
 
   MACH3LOG_INFO("Create SplineModeVecs_Sample");
-  std::vector<std::vector<int>> SplineModeVecs_Sample = StripDuplicatedModes(xsec->GetSplineModeVecFromSampleName(SampleName));
+  std::vector<std::vector<int>> SplineModeVecs_Sample = StripDuplicatedModes(ParHandler->GetSplineModeVecFromSampleName(SampleName));
   MACH3LOG_INFO("SplineModeVecs_Sample is of size {}", SplineModeVecs_Sample.size());
   SplineModeVecs.push_back(SplineModeVecs_Sample);
 
@@ -130,7 +130,7 @@ void BinnedSplineHandler::InvestigateMissingSplines() const {
 
     // Get list of systematic names for this sample
     std::vector<std::string> SplineFileParPrefixNames_Sample =
-    xsec->GetParsNamesFromSampleName(SampleName, kSpline);
+    ParHandler->GetParsNamesFromSampleName(SampleName, kSpline);
 
     for (unsigned int iOscChan = 0; iOscChan < indexvec[iSample].size(); iOscChan++) {
       for (unsigned int iSyst = 0; iSyst < indexvec[iSample][iOscChan].size(); iSyst++) {
@@ -174,7 +174,7 @@ void BinnedSplineHandler::InvestigateMissingSplines() const {
   // KS: Let's print this atrocious mess...
   for (const auto& samplePair : systZeroCounts) {
     unsigned int iSample = samplePair.first;
-    std::vector<std::string> SplineFileParPrefixNames_Sample = xsec->GetParsNamesFromSampleName(SampleNames[iSample], kSpline);
+    std::vector<std::string> SplineFileParPrefixNames_Sample = ParHandler->GetParsNamesFromSampleName(SampleNames[iSample], kSpline);
     for (const auto& systPair : samplePair.second) {
       unsigned int iSyst = systPair.first;
       const auto& systName = SplineFileParPrefixNames_Sample[iSyst];
@@ -373,9 +373,8 @@ void BinnedSplineHandler::BuildSampleIndexingArray(const std::string& SampleTitl
 }
 
 //****************************************
-std::vector<TAxis *> BinnedSplineHandler::FindSplineBinning(const std::string& FileName, const std::string& SampleTitle)
+std::vector<TAxis *> BinnedSplineHandler::FindSplineBinning(const std::string& FileName, const std::string& SampleTitle) {
 //****************************************
-{
   int iSample = GetSampleIndex(SampleTitle);
 
   //Try declaring these outside of TFile so they aren't owned by File
@@ -476,9 +475,8 @@ std::vector<TAxis *> BinnedSplineHandler::FindSplineBinning(const std::string& F
 }
 
 //****************************************
-int BinnedSplineHandler::CountNumberOfLoadedSplines(bool NonFlat, int Verbosity)
+int BinnedSplineHandler::CountNumberOfLoadedSplines(bool NonFlat, int Verbosity) {
 //****************************************
-{
   int SampleCounter_NonFlat = 0;
   int SampleCounter_All = 0;
   int FullCounter_NonFlat = 0;
@@ -616,7 +614,7 @@ void BinnedSplineHandler::PrepForReweight() {
   {
     SplineInfoArray[iSpline].nPts = static_cast<M3::int_t>(UniqueSystSplines[iSpline]->GetNp());
     SplineInfoArray[iSpline].xPts.resize(SplineInfoArray[iSpline].nPts);
-    SplineInfoArray[iSpline].splineParsPointer = xsec->RetPointer(UniqueSystIndices[iSpline]);
+    SplineInfoArray[iSpline].splineParsPointer = ParHandler->RetPointer(UniqueSystIndices[iSpline]);
     for (int iKnot = 0; iKnot < SplineInfoArray[iSpline].nPts; iKnot++)
     {
       M3::float_t xPoint;
@@ -677,7 +675,7 @@ void BinnedSplineHandler::PrepForReweight() {
 
 //****************************************
 // Rather work with spline coefficients in the splines, let's copy ND and use coefficient arrays
-void BinnedSplineHandler::getSplineCoeff_SepMany(int splineindex, M3::float_t* &xArray, M3::float_t* &manyArray){
+void BinnedSplineHandler::getSplineCoeff_SepMany(int splineindex, M3::float_t* &xArray, M3::float_t* &manyArray) {
 //****************************************
   //No point evaluating a flat spline
   int nPoints = splinevec_Monolith[splineindex]->GetNp();
@@ -881,7 +879,7 @@ std::vector< std::vector<int> > BinnedSplineHandler::GetEventSplines(const std::
 // (for example if CCRES and CCCoherent are treated as one spline mode)
 std::vector< std::vector<int> > BinnedSplineHandler::StripDuplicatedModes(const std::vector< std::vector<int> >& InputVector) const {
 //****************************************
-  //ETA - this is of size nPars from the xsec model
+  //ETA - this is of size nPars from the syst model
   size_t InputVectorSize = InputVector.size();
   std::vector< std::vector<int> > ReturnVec(InputVectorSize);
 
@@ -890,7 +888,7 @@ std::vector< std::vector<int> > BinnedSplineHandler::StripDuplicatedModes(const 
     std::vector<int> TmpVec;
     std::vector<std::string> TestVec;
 
-    //Loop over the modes that we've listed in xsec cov
+    //Loop over the modes that we've listed in ParHandler
     for (unsigned int iMode = 0 ; iMode < InputVector[iSyst].size() ; iMode++) {
       int Mode = InputVector[iSyst][iMode];
       std::string ModeName = Modes->GetSplineSuffixFromMaCh3Mode(Mode);
@@ -914,7 +912,7 @@ std::vector< std::vector<int> > BinnedSplineHandler::StripDuplicatedModes(const 
   return ReturnVec;
 }
 
-void BinnedSplineHandler::FillSampleArray(std::string SampleTitle, std::vector<std::string> OscChanFileNames)
+void BinnedSplineHandler::FillSampleArray(const std::string& SampleTitle, const std::vector<std::string>& OscChanFileNames)
 {
   int iSample = GetSampleIndex(SampleTitle);
   int nOscChannels = nOscChans[iSample];
@@ -1021,7 +1019,7 @@ void BinnedSplineHandler::FillSampleArray(std::string SampleTitle, std::vector<s
           splinevec_Monolith.push_back(nullptr);
           delete mySpline;
         } else {
-          ApplyKnotWeightCapTSpline3(mySpline, SystNum, xsec);
+          ApplyKnotWeightCapTSpline3(mySpline, SystNum, ParHandler);
           Spline = new TSpline3_red(mySpline, SplineInterpolationTypes[iSample][SystNum]);
           if(mySpline) delete mySpline;
 
@@ -1063,7 +1061,7 @@ void BinnedSplineHandler::LoadSplineFile(std::string FileName) {
   // Config which was in MCMC from which we are starting
   YAML::Node CovSettings = TMacroToYAML(*ConfigCov);
   // Config from currently used cov object
-  YAML::Node ConfigCurrent = xsec->GetConfig();
+  YAML::Node ConfigCurrent = ParHandler->GetConfig();
 
   if (!compareYAMLNodes(CovSettings, ConfigCurrent))
   {
@@ -1077,7 +1075,7 @@ void BinnedSplineHandler::LoadSplineFile(std::string FileName) {
   LoadFastSplineInfoDir(SplineFile);
 
   for (int iSpline = 0; iSpline < nParams; iSpline++) {
-    SplineInfoArray[iSpline].splineParsPointer = xsec->RetPointer(UniqueSystIndices[iSpline]);
+    SplineInfoArray[iSpline].splineParsPointer = ParHandler->RetPointer(UniqueSystIndices[iSpline]);
   }
   SplineFile->Close();
 }
@@ -1260,7 +1258,7 @@ void BinnedSplineHandler::PrepareSplineFile(std::string FileName) {
   }
   // Save ROOT File
   auto SplineFile = std::make_unique<TFile>(FileName.c_str(), "recreate");
-  YAML::Node ConfigCurrent = xsec->GetConfig();
+  YAML::Node ConfigCurrent = ParHandler->GetConfig();
   TMacro ConfigSave = YAMLtoTMacro(ConfigCurrent, "ParameterHandler");
   ConfigSave.Write();
 

--- a/Splines/BinnedSplineHandler.h
+++ b/Splines/BinnedSplineHandler.h
@@ -20,7 +20,7 @@ class BinnedSplineHandler : public SplineBase {
     /// @brief CW: This Eval should be used when using two separate x,{y,a,b,c,d} arrays
     /// to store the weights; probably the best one here! Same thing but pass parameter
     /// spline segments instead of variations
-    void Evaluate() override;
+    void Evaluate() override final;
 
     /// @brief add oscillation channel to spline monolith
     void AddSample(const std::string& SampleName,
@@ -34,14 +34,14 @@ class BinnedSplineHandler : public SplineBase {
 
     /// @brief Loads and processes splines from ROOT files for a given sample.
     /// @note DB Add virtual so it can be overridden in experiment specific (if needed)
-    virtual void FillSampleArray(std::string SampleTitle, std::vector<std::string> OscChanFileNames);
+    virtual void FillSampleArray(const std::string& SampleTitle, const std::vector<std::string>& OscChanFileNames);
     /// @brief Check if there are any repeated modes. This is used to reduce the number
     /// of modes in case many interaction modes get averaged into one spline
     std::vector< std::vector<int> > StripDuplicatedModes(const std::vector< std::vector<int> >& InputVector) const;
     /// @brief Return the splines which affect a given event
     std::vector< std::vector<int> > GetEventSplines(const std::string& SampleTitle, int iOscChan, int EventMode, double Var1Val, double Var2Val, double Var3Val);
     /// @brief KS: After calculations are done on GPU we copy memory to CPU. This operation is asynchronous meaning while memory is being copied some operations are being carried. Memory must be copied before actual reweight. This function make sure all has been copied.
-    void SynchroniseMemTransfer() const override {return;}
+    void SynchroniseMemTransfer() const override final {return;}
     /// @brief Grab histograms with spline binning
     std::vector<TAxis*> FindSplineBinning(const std::string& FileName, const std::string& SampleTitle);
 
@@ -62,22 +62,22 @@ class BinnedSplineHandler : public SplineBase {
     void PrintArrayDetails(const std::string& SampleTitle) const;
 
     /// @brief get pointer to spline weight based on bin variables
-    const M3::float_t* retPointer(const int sample, const int oscchan, const int syst, const int mode,
-                                  const int var1bin, const int var2bin, const int var3bin) const{
+    const M3::float_t* RetPointer(const int sample, const int oscchan, const int syst, const int mode,
+                                  const int var1bin, const int var2bin, const int var3bin) const {
       int index = indexvec[sample][oscchan][syst][mode][var1bin][var2bin][var3bin];
       return &weightvec_Monolith[index];
     }
     /// @brief KS: Prepare spline file that can be used for fast loading
-    void PrepareSplineFile(std::string FileName) override;
+    void PrepareSplineFile(std::string FileName) override final;
     /// @brief KS: Load preprocessed spline file
     /// @param FileName Path to ROOT file with predefined reduced Spline Monolith
-    void LoadSplineFile(std::string FileName) override;
+    void LoadSplineFile(std::string FileName) override final;
 
   protected:
     /// @brief CPU based code which eval weight for each spline
-    void CalcSplineWeights() override;
+    void CalcSplineWeights() override final;
     /// Pointer to covariance from which we get information about spline params
-    ParameterHandlerGeneric* xsec;
+    ParameterHandlerGeneric* ParHandler;
 
     //And now the actual member variables
     std::vector<std::string> SampleNames;
@@ -134,7 +134,7 @@ class BinnedSplineHandler : public SplineBase {
     /// pointer to MaCh3 Mode from which we get spline suffix
     MaCh3Modes* Modes;
     enum TokenOrdering{kSystToken,kModeToken,kVar1BinToken,kVar2BinToken,kVar3BinToken,kNTokens};
-    virtual std::vector<std::string> GetTokensFromSplineName(std::string FullSplineName) = 0;
+    virtual std::vector<std::string> GetTokensFromSplineName(const std::string& FullSplineName) = 0;
 
   private:
     /// @brief This function will find missing splines in file

--- a/Splines/SplineCommon.h
+++ b/Splines/SplineCommon.h
@@ -6,6 +6,11 @@
 /// @details This file includes macros and enums for defining spline coefficients.
 /// It is designed to be compatible with older CUDA versions, so be cautious
 /// when adding new features or including other headers.
+///
+/// @warning KS: Please add stuff here with super caution. This header is being added to gpuSplineUtils.cu. Right now we support most of CUDA even super old.
+/// If you add some header with fancy templates it will not compile for older CUDA.
+/// This header is a way to use common macros or Enum in CPU and GPU code. For more sophisticated structs please use SplineStructs.h
+///
 /// @author Clarence Wret
 /// @author Kamil Skwarczynski
 
@@ -29,7 +34,8 @@ enum SplineSegmentCoeffs
 /// the number of knots per spline, and the number of points per spline on the CPU.
 struct SplineMonoStruct {
 // *******************
-  virtual ~SplineMonoStruct() {};
+  /// @brief destructor
+  virtual ~SplineMonoStruct() = default;
 
   /// KS: CPU arrays to hold X coefficient
   std::vector<float> coeff_x;
@@ -49,5 +55,3 @@ struct SplineMonoStruct {
   #endif
 };
 
-
-// WARNING KS: Please add stuff here with super caution. This header is being added to gpuSplineUtils.cu. Right now we support most of CUDA even super old. If you add some header with fancy templates it will not compile for older CUDA. This header is a way to use common macros or Enum in CPU and GPU code. For more sophisticated structs please use SplineStructs.h

--- a/Splines/SplineMonolith.cpp
+++ b/Splines/SplineMonolith.cpp
@@ -74,23 +74,6 @@ void SMonolith::PrepareForGPU(std::vector<std::vector<TResponseFunction_red*> > 
   MACH3LOG_INFO("Found total {} coeffs in all TF1", nTF1coeff);
   MACH3LOG_INFO("Number of TF1 = {}", NTF1_valid);
 
-  // Can pass the spline segments to the GPU instead of the values
-  // Make these here and only refill them for each loop, avoiding unnecessary new/delete on each reconfigure
-  //KS: Since we are going to copy it each step use fancy CUDA memory allocation
-  #ifdef MaCh3_CUDA
-  gpu_spline_handler->InitGPU_Segments(&SplineSegments);
-  gpu_spline_handler->InitGPU_Vals(&ParamValues);
-  #else
-  SplineSegments = new short int[nParams];
-  ParamValues = new float[nParams];
-  #endif
-
-  for (M3::int_t j = 0; j < nParams; j++)
-  {
-    SplineSegments[j] = 0;
-    ParamValues[j] = -999;
-  }
-
   unsigned int event_size_max = _max_knots * nParams;
   // Declare the {x}, {y,b,c,d} arrays for all possible splines which the event has
   // We'll filter off the flat and "disabled" (e.g. CCQE event should not have MARES spline) ones in the next for loop, but need to declare these beasts here
@@ -236,7 +219,7 @@ void SMonolith::PrepareForGPU(std::vector<std::vector<TResponseFunction_red*> > 
   MACH3LOG_WARN("Found in total {} BAD X", BadXCounter);
   //KS: This is tricky as this variable use both by CPU and GPU, however if use CUDA we use cudaMallocHost
   #ifndef MaCh3_CUDA
-  cpu_total_weights = new float[NEvents]();
+  cpu_total_weights = new M3::float_t[NEvents]();
   cpu_weights_spline_var = new float[NSplines_valid]();
   cpu_weights_tf1_var = new float[NTF1_valid]();
   #endif
@@ -246,6 +229,10 @@ void SMonolith::PrepareForGPU(std::vector<std::vector<TResponseFunction_red*> > 
   if(SaveSplineFile) PrepareSplineFile(FastSplineName);
 
   MoveToGPU();
+
+  // Can pass the spline segments to the GPU instead of the values
+  // Make these here and only refill them for each loop, avoiding unnecessary new/delete on each reconfigure
+  SetupSegments();
 }
 
 // *****************************************
@@ -267,7 +254,7 @@ void SMonolith::MoveToGPU() {
   //                                1 coefficient array of size coeff_array_size*4, holding y,b,c,d in order (y11,b11,c11,d11; y12,b12,c12,d12;...) where ynm is n = spline number, m = spline point. Should really make array so that order is (y11,b11,c11,d11; y21,b21,c21,d21;...) because it will optimise cache hits I think; try this if you have time
   //                                return gpu_weights
 
-  gpu_spline_handler = new SMonolithGPU();
+  gpu_spline_handler = new SplineMonolithGPU();
 
   // The gpu_XY arrays don't actually need initialising, since they are only placeholders for what we'll move onto the GPU. As long as we cudaMalloc the size of the arrays correctly there shouldn't be any problems
   // Can probably make this a bit prettier but will do for now
@@ -485,22 +472,13 @@ void SMonolith::LoadSplineFile(std::string FileName) {
   NTF1_valid = nTF1Valid_temp;
   nTF1coeff = nTF1coeff_temp;
 
-  //KS: Since we are going to copy it each step use fancy CUDA memory allocation
-#ifdef MaCh3_CUDA
-  gpu_spline_handler->InitGPU_Segments(&SplineSegments);
-  gpu_spline_handler->InitGPU_Vals(&ParamValues);
-#else
-  SplineSegments = new short int[nParams]();
-  ParamValues = new float[nParams]();
-#endif
-
   cpu_nParamPerEvent.resize(2*NEvents);
   cpu_nParamPerEvent_tf1.resize(2*NEvents);
   cpu_coeff_TF1_many.resize(nTF1coeff);
 
   //KS: This is tricky as this variable use both by CPU and GPU, however if use CUDA we use cudaMallocHost
 #ifndef MaCh3_CUDA
-  cpu_total_weights = new float[NEvents]();
+  cpu_total_weights = new M3::float_t[NEvents]();
   cpu_weights_spline_var = new float[NSplines_valid]();
   cpu_weights_tf1_var = new float[NTF1_valid]();
 #endif
@@ -536,6 +514,26 @@ void SMonolith::LoadSplineFile(std::string FileName) {
   PrintInitialsiation();
 
   MoveToGPU();
+
+  SetupSegments();
+}
+
+// *****************************************
+void SMonolith::SetupSegments() {
+// *****************************************
+  //KS: Since we are going to copy it each step use fancy CUDA memory allocation
+  #ifdef MaCh3_CUDA
+  gpu_spline_handler->InitGPU_Segments(&SplineSegments);
+  gpu_spline_handler->InitGPU_Vals(&ParamValues);
+  #else
+  SplineSegments = new short int[nParams]();
+  ParamValues = new float[nParams]();
+  #endif
+  for (M3::int_t j = 0; j < nParams; j++)
+  {
+    SplineSegments[j] = 0;
+    ParamValues[j] = -999;
+  }
 }
 
 // *****************************************
@@ -618,10 +616,8 @@ void SMonolith::PrepareSplineFile(std::string FileName) {
 SMonolith::~SMonolith() {
 // *****************************************
   #ifdef MaCh3_CUDA
-  gpu_spline_handler->CleanupGPU_SplineMonolith(cpu_total_weights);
   //KS: Since we declared them using CUDA alloc we have to free memory using also cuda functions
-  gpu_spline_handler->CleanupGPU_Segments(SplineSegments, ParamValues);
-
+  gpu_spline_handler->CleanupPinnedMemory(cpu_total_weights, SplineSegments, ParamValues);
   delete gpu_spline_handler;
   #else
   if(SplineSegments != nullptr) delete[] SplineSegments;
@@ -701,9 +697,7 @@ void SMonolith::Evaluate() {
   gpu_spline_handler->RunGPU_SplineMonolith(
           cpu_total_weights,
           ParamValues,
-          SplineSegments,
-          NSplines_valid,
-          NTF1_valid);
+          SplineSegments);
 }
 #else
 //If CUDA is not enabled do the same on CPU
@@ -824,7 +818,7 @@ void SMonolith::CalcTotalEventWeight() {
     }
 
     // Store the total weight for the current event
-    cpu_total_weights[EventNum] = totalWeight;
+    cpu_total_weights[EventNum] = static_cast<M3::float_t>(totalWeight);
   }
 }
 
@@ -851,5 +845,6 @@ void SMonolith::SynchroniseMemTransfer() const {
 //*********************************************************
   #ifdef MaCh3_CUDA
   SynchroniseSplines();
+  CudaCheckError();
   #endif
 }

--- a/Splines/SplineMonolith.h
+++ b/Splines/SplineMonolith.h
@@ -3,7 +3,7 @@
 #include "Splines/SplineBase.h"
 
 //KS: Joy of forward declaration https://gieseanw.wordpress.com/2018/02/25/the-joys-of-forward-declarations-results-from-the-real-world/
-class SMonolithGPU;
+class SplineMonolithGPU;
 
 /// @brief Even-by-event class calculating response for spline parameters. It is possible to use GPU acceleration
 /// @author Clarence Wret
@@ -26,18 +26,18 @@ class SMonolith : public SplineBase {
     virtual ~SMonolith();
 
     /// @brief  CW: This Eval should be used when using two separate x,{y,a,b,c,d} arrays to store the weights; probably the best one here! Same thing but pass parameter spline segments instead of variations
-    void Evaluate() override;
+    void Evaluate() override final;
 
     /// @brief Get class name
     std::string GetName() const override {return "SplineMonolith";};
 
     /// @brief KS: After calculations are done on GPU we copy memory to CPU. This operation is asynchronous meaning while memory is being copied some operations are being carried. Memory must be copied before actual reweight. This function make sure all has been copied.
-    void SynchroniseMemTransfer() const override;
+    void SynchroniseMemTransfer() const override final;
 
     /// @brief KS: Get pointer to total weight to make fit faster wrooom!
     /// @param event Name event number in used MC
     /// @return Pointer to the total weight
-    const float* retPointer(const int event) const {return &cpu_total_weights[event];}
+    const M3::float_t* RetPointer(const int event) const {return &cpu_total_weights[event];}
     
     /// @brief KS: Set pointers to spline params
     /// @param spline_ParsPointers Vector of pointers to spline params
@@ -46,15 +46,10 @@ class SMonolith : public SplineBase {
     };
     
     /// @brief KS: Prepare spline file that can be used for fast loading
-    void PrepareSplineFile(std::string FileName) override;
+    void PrepareSplineFile(std::string FileName) override final;
     /// @brief KS: Load preprocessed spline file
     /// @param FileName Path to ROOT file with predefined reduced Spline Monolith
-    void LoadSplineFile(std::string FileName) override;
-
-    /// KS: This holds the total CPU weights that gets read in SampleHandler
-    /// @warning will become private member in future , please use SMonolith::retPointer
-    float* cpu_total_weights;
-
+    void LoadSplineFile(std::string FileName) override final;
   private:
     /// @brief KS: Set everything to null etc.
     void Initialise();
@@ -83,7 +78,8 @@ class SMonolith : public SplineBase {
     void PrepareForGPU(std::vector<std::vector<TResponseFunction_red*> > &MasterSpline, const std::vector<RespFuncType> &SplineType);
     /// @brief CW: The shared initialiser from constructors of TResponseFunction_red
     void MoveToGPU();
-        
+    void SetupSegments();
+
     /// @brief KS: Print info about how much knots etc has been initialised
     void PrintInitialsiation() const;
 
@@ -96,7 +92,7 @@ class SMonolith : public SplineBase {
     void GetSplineCoeff_SepMany(TSpline3_red* &spl, int &nPoints, float *&xArray, float *&manyArray) const;
 
     /// @brief CPU based code which eval weight for each spline
-    void CalcSplineWeights() override;
+    void CalcSplineWeights() override final;
     /// @brief Calc total event weight
     void CalcTotalEventWeight();
 
@@ -119,6 +115,8 @@ class SMonolith : public SplineBase {
     float *cpu_weights_spline_var;
     /// CPU arrays to hold weight for each TF1
     float *cpu_weights_tf1_var;
+    /// KS: This holds the total CPU weights that gets read in SampleHandler
+    M3::float_t* cpu_total_weights;
 
     /// KS: CPU map keeping track how many parameters applies to each event, we keep two numbers here {number of splines per event, index where splines start for a given event}
     std::vector<unsigned int> cpu_nParamPerEvent;
@@ -130,7 +128,7 @@ class SMonolith : public SplineBase {
     SplineMonoStruct* cpu_spline_handler;
 
     /// KS: Store info about Spline monolith, this allow to obtain better step time. As all necessary information for spline weight calculation are here meaning better cache hits.
-    SMonolithGPU* gpu_spline_handler;
+    SplineMonolithGPU* gpu_spline_handler;
 
     /// CPU arrays to hold TF1 coefficients
     std::vector<float> cpu_coeff_TF1_many;

--- a/Splines/gpuSplineUtils.cu
+++ b/Splines/gpuSplineUtils.cu
@@ -1,10 +1,6 @@
 //MaCh3 included
 #include "Splines/gpuSplineUtils.cuh"
 
-/// Hard code the number of splines
-/// Not entirely necessary: only used for val_gpu and segment_gpu being device constants. Could move them to not being device constants
-#define _N_SPLINES_ NSplines_GPU
-
 // KS: Forgive me father, for I have sinned.
 #if defined(__CUDA_ARCH__)
   #if __CUDA_ARCH__ >= 1200
@@ -48,23 +44,6 @@
   #endif
 #endif
 
-// ******************************************
-// CONSTANTS
-// ******************************************
-
-// d_NAME declares DEVICE constants (live on GPU)
-/// Number of splines living on GPU
-__device__ __constant__ unsigned int d_n_splines;
-/// Number of tf1 living on GPU
-__device__ __constant__ unsigned int d_n_TF1;
-/// Size of splines living on GPU
-__device__ __constant__ short int d_spline_size;
-/// Number of events living on GPU
-__device__ __constant__ int d_n_events;
-
-/// CW: Constant memory needs to be hard-coded on compile time. Could make this texture memory instead, but don't care enough right now...
-__device__ __constant__ float val_gpu[_N_SPLINES_];
-__device__ __constant__ short int segment_gpu[_N_SPLINES_];
 
 // *****************************************
 // Make sure all Cuda threads finished execution
@@ -76,10 +55,13 @@ __host__ void SynchroniseSplines() {
 //              INITIALISE GPU
 // *******************************************
 
-SMonolithGPU::SMonolithGPU() {
-  h_n_params     = -1;
+SplineMonolithGPU::SplineMonolithGPU() {
   /// Number of events living on CPU
-  h_n_events = -1;
+  cpu_n_params = -1;
+  cpu_n_events = -1;
+  cpu_n_TF1 = 0;
+  cpu_n_splines = 0;
+  cpu_spline_size = 0;
 
   gpu_weights = nullptr;
   gpu_total_weights = nullptr;
@@ -95,13 +77,38 @@ SMonolithGPU::SMonolithGPU() {
   gpu_weights_tf1 = nullptr;
 }
 
-SMonolithGPU::~SMonolithGPU() {
+// *******************************************
+SplineMonolithGPU::~SplineMonolithGPU() {
+// *******************************************
+  cudaFree(gpu_paramNo_arr);
+  cudaFree(gpu_nKnots_arr);
+
+  // free the coefficient arrays
+  cudaDestroyTextureObject(text_coeff_x);
+  cudaFree(gpu_coeff_x);
+  cudaFree(gpu_coeff_many);
+
+  cudaFree(gpu_par_val);
+  cudaFree(gpu_spline_segment);
+
+  cudaFree(gpu_coeff_TF1_many);
+  cudaFree(gpu_paramNo_TF1_arr);
+  // free weights on the gpu
+  cudaFree(gpu_weights);
+  cudaFree(gpu_weights_tf1);
+  cudaFree(gpu_total_weights);
+  //KS: Before removing variable let's destroy texture
+  cudaDestroyTextureObject(text_nParamPerEvent);
+  cudaDestroyTextureObject(text_nParamPerEvent_TF1);
+
+  cudaFree(gpu_nParamPerEvent);
+  cudaFree(gpu_nParamPerEvent_TF1);
 }
 
 // *******************************************
 // Initialiser when using the x array and combined y,b,c,d array
-__host__ void SMonolithGPU::InitGPU_SplineMonolith(
-                          float **cpu_total_weights,
+__host__ void SplineMonolithGPU::InitGPU_SplineMonolith(
+                          M3::float_t **cpu_total_weights,
                           int n_events,
                           unsigned int total_nknots,
                           unsigned int n_splines,
@@ -136,11 +143,11 @@ __host__ void SMonolithGPU::InitGPU_SplineMonolith(
   CudaCheckError();
 
   //KS: Rather than allocate memory in standard way this fancy cuda tool allows to pin host memory which make memory transfer faster
-  cudaMallocHost((void **) cpu_total_weights, n_events*sizeof(float));
+  cudaMallocHost((void **) cpu_total_weights, n_events*sizeof(M3::float_t));
   CudaCheckError();
 
   //KS: Allocate memory for the array of total weights to be returned to CPU
-  cudaMalloc((void **) &gpu_total_weights, n_events*sizeof(float));
+  cudaMalloc((void **) &gpu_total_weights, n_events*sizeof(M3::float_t));
   CudaCheckError();
   
   //KS: Allocate memory for the map keeping track how many splines each parameter has
@@ -150,7 +157,7 @@ __host__ void SMonolithGPU::InitGPU_SplineMonolith(
   //KS: Allocate memory for the map keeping track how many TF1 each parameter has
   cudaMalloc((void **) &gpu_nParamPerEvent_TF1, 2*n_events*sizeof(unsigned int));
   CudaCheckError();
-  
+
   // Print allocation info to user
   printf("Allocated %i entries for paramNo and nKnots arrays, size = %f MB\n",
          n_splines, static_cast<double>(sizeof(short int) * n_splines + sizeof(unsigned int) * n_splines) / 1.0e6);
@@ -168,22 +175,21 @@ __host__ void SMonolithGPU::InitGPU_SplineMonolith(
 
 // *******************************************
 // Allocate memory for spline segments
-__host__ void SMonolithGPU::InitGPU_Segments(short int **segment) {
+__host__ void SplineMonolithGPU::InitGPU_Segments(short int **segment) {
 // *******************************************
   //KS: Rather than allocate memory in standard way this fancy cuda tool allows to pin host memory which make memory transfer faster
-  cudaMallocHost((void **) segment, _N_SPLINES_*sizeof(short int));
+  cudaMallocHost((void **) segment, cpu_n_params*sizeof(short int));
   CudaCheckError();
 }
 
 // *******************************************
 // Allocate memory for spline segments
-__host__ void SMonolithGPU::InitGPU_Vals(float **vals) {
+__host__ void SplineMonolithGPU::InitGPU_Vals(float **vals) {
 // *******************************************
   //KS: Rather than allocate memory in standard way this fancy cuda tool allows to pin host memory which make memory transfer faster
-  cudaMallocHost((void **) vals, _N_SPLINES_*sizeof(float));
+  cudaMallocHost((void **) vals, cpu_n_params*sizeof(float));
   CudaCheckError();
 }
-
 
 // ******************************************************
 //                START COPY TO GPU
@@ -191,50 +197,37 @@ __host__ void SMonolithGPU::InitGPU_Vals(float **vals) {
 
 // ******************************************************
 // Copy to GPU for x array and separate ybcd array
-__host__ void SMonolithGPU::CopyToGPU_SplineMonolith(
-                            SplineMonoStruct* cpu_spline_handler,
+__host__ void SplineMonolithGPU::CopyToGPU_SplineMonolith(
+                            const SplineMonoStruct* cpu_spline_handler,
 
                             // TFI related now
-                            std::vector<float> cpu_many_array_TF1,
-                            std::vector<short int> cpu_paramNo_arr_TF1,
-                            int n_events,
-                            std::vector<unsigned int> cpu_nParamPerEvent,
+                            const std::vector<float>& cpu_many_array_TF1,
+                            const std::vector<short int>& cpu_paramNo_arr_TF1,
+                            const int n_events,
+                            const std::vector<unsigned int>& cpu_nParamPerEvent,
                             // TFI related now
-                            std::vector<unsigned int> cpu_nParamPerEvent_TF1,
+                            const std::vector<unsigned int>& cpu_nParamPerEvent_TF1,
 
-                            int n_params, 
-                            unsigned int n_splines,
-                            short int spline_size,
-                            unsigned int total_nknots,
-                            unsigned int n_tf1) {
+                            const int n_params,
+                            const unsigned int n_splines,
+                            const short int spline_size,
+                            const unsigned int total_nknots,
+                            const unsigned int n_tf1) {
 // ******************************************************
-  if (n_params != _N_SPLINES_) {
-    printf("Number of splines not equal to %i, GPU code for event-by-event splines will fail\n", _N_SPLINES_);
-    printf("n_params = %i\n", n_params);
-    printf("%s : %i\n", __FILE__, __LINE__);
-    throw;
-  }
-
   // Write to the global statics (h_* denotes host stored variable)
-  h_n_params = n_params;
-  h_n_events    = n_events;
-
-  // Copy the constants
-  // Total number of valid splines for all loaded events
-  cudaMemcpyToSymbol(d_n_splines, &n_splines, sizeof(n_splines));
-  CudaCheckError();
-
-  // Total number of valid TF1 for all loaded events
-  cudaMemcpyToSymbol(d_n_TF1,   &n_tf1, sizeof(n_tf1));
-  CudaCheckError();
-
-  // Total spline size per spline; i.e. just the number of points or knots in the spline
-  cudaMemcpyToSymbol(d_spline_size, &spline_size, sizeof(spline_size));
-  CudaCheckError();
-
+  cpu_n_params  = n_params;
   // Number of events
-  cudaMemcpyToSymbol(d_n_events, &h_n_events, sizeof(h_n_events));
-  CudaCheckError();
+  cpu_n_events  = n_events;
+  // Total number of valid TF1 for all loaded events
+  cpu_n_TF1     = n_tf1;
+  // Total number of valid splines for all loaded events
+  cpu_n_splines = n_splines;
+  /// Size of splines living
+  cpu_spline_size = spline_size;
+
+  //CW: Allocate memory for the frequently copied objects
+  cudaMalloc(&gpu_par_val, n_params * sizeof(float));
+  cudaMalloc(&gpu_spline_segment, n_params * sizeof(short int));
 
   // Copy the coefficient arrays to the GPU; this only happens once per entire Markov Chain so is OK to do multiple extensive memory copies
   cudaMemcpy(gpu_coeff_many, cpu_spline_handler->coeff_many.data(), sizeof(float)*total_nknots*_nCoeff_, cudaMemcpyHostToDevice);
@@ -335,9 +328,13 @@ __host__ void SMonolithGPU::CopyToGPU_SplineMonolith(
 // Should be most efficient at cache hitting and memory coalescence
 // But using spline segments rather than the parameter value: avoids doing binary search on GPU
 __global__ void EvalOnGPU_Splines(
+  const unsigned int gpu_n_splines,
+  const short int gpu_spline_size,
   const short int* __restrict__ gpu_paramNo_arr,
   const unsigned int* __restrict__ gpu_nKnots_arr,
   const float* __restrict__ gpu_coeff_many,
+  const float* __restrict__ gpu_par_val,
+  const short int* __restrict__ gpu_spline_segment,
   float* __restrict__ gpu_weights,
   const cudaTextureObject_t __restrict__ text_coeff_x) {
 //*********************************************************
@@ -345,7 +342,7 @@ __global__ void EvalOnGPU_Splines(
   const unsigned int splineNum = (blockIdx.x * blockDim.x + threadIdx.x);
 
   // this is the stopping condition!
-  if (splineNum < d_n_splines) {
+  if (splineNum < gpu_n_splines) {
     // This is the segment we want for this parameter variation
     // for this particular splineNum; 0 = MACCQE, 1 = pFC, 2 = EBC, etc
 
@@ -353,22 +350,22 @@ __global__ void EvalOnGPU_Splines(
     const short int Param = gpu_paramNo_arr[splineNum];
 
     //CW: Avoids doing costly binary search on GPU
-    const short int segment = segment_gpu[Param];
+    const short int segment = gpu_spline_segment[Param];
 
     //KS: Segment for coeff_x is simply parameter*max knots + segment as each parmeters has the same spacing
-    const short int segment_X = Param*d_spline_size+segment;
+    const short int segment_X = Param*gpu_spline_size+segment;
 
     //KS: Find knot position in out monolitical structure
     const unsigned int CurrentKnotPos = gpu_nKnots_arr[splineNum]*_nCoeff_+segment*_nCoeff_;
 
-    // We've read the segment straight from CPU and is saved in segment_gpu
+    // We've read the segment straight from CPU and is saved in gpu_spline_segment
     // polynomial parameters from the monolithic splineMonolith
     const float fY = gpu_coeff_many[CurrentKnotPos];
     const float fB = gpu_coeff_many[CurrentKnotPos + 1];
     const float fC = gpu_coeff_many[CurrentKnotPos + 2];
     const float fD = gpu_coeff_many[CurrentKnotPos + 3];
     // The is the variation itself (needed to evaluate variation - stored spline point = dx)
-    const float dx = val_gpu[Param] - tex1Dfetch<float>(text_coeff_x, segment_X);
+    const float dx = gpu_par_val[Param] - tex1Dfetch<float>(text_coeff_x, segment_X);
 
     //CW: Wooow, let's use some fancy intrinsics and pull down the processing time by <1% from normal multiplication! HURRAY
     gpu_weights[splineNum] = fmaf(dx, fmaf(dx, fmaf(dx, fD, fC), fB), fY);
@@ -376,7 +373,7 @@ __global__ void EvalOnGPU_Splines(
     //gpu_weights[splineNum] = (fY+dx*(fB+dx*(fC+dx*fD)));
 
     //#ifdef DEBUG
-    //printf("splineNum = %i/%i, paramNo = %i, variation = %f, segment = %i, fX = %f, fX+1 = %f, dx = %f, d_n_splines = %i, d_spline_size = %i, weight = %f \n", splineNum, d_n_splines, gpu_paramNo_arr[splineNum], val_gpu[Param], segment, tex1Dfetch<float>(text_coeff_x, segment_X), tex1Dfetch<float>(text_coeff_x, segment_X+1), dx, d_n_splines, d_spline_size, gpu_weights[splineNum]);
+    //printf("splineNum = %i/%i, paramNo = %i, variation = %f, segment = %i, fX = %f, fX+1 = %f, dx = %f, gpu_n_splines = %i, gpu_spline_size = %i, weight = %f \n", splineNum, gpu_n_splines, gpu_paramNo_arr[splineNum], gpu_par_val[Param], segment, tex1Dfetch<float>(text_coeff_x, segment_X), tex1Dfetch<float>(text_coeff_x, segment_X+1), dx, gpu_n_splines, gpu_spline_size, gpu_weights[splineNum]);
     //#endif
   }
 }
@@ -384,16 +381,18 @@ __global__ void EvalOnGPU_Splines(
 //*********************************************************
 // Evaluate the TF1 on the GPU Using 5th order polynomial
 __global__ void EvalOnGPU_TF1(
+    const unsigned int gpu_n_TF1,
     const float* __restrict__ gpu_coeffs_tf1,
     const short int* __restrict__ gpu_paramNo_arr_tf1,
+    const float* __restrict__ gpu_par_val,
     float* __restrict__ gpu_weights_tf1) {
 //*********************************************************
   // points per spline is the offset to skip in the index to move between splines
   const unsigned int tf1Num = (blockIdx.x * blockDim.x + threadIdx.x);
 
-  if (tf1Num < d_n_TF1) {
+  if (tf1Num < gpu_n_TF1) {
     // The is the variation itself (needed to evaluate variation - stored spline point = dx)
-    const float x = val_gpu[gpu_paramNo_arr_tf1[tf1Num]];
+    const float x = gpu_par_val[gpu_paramNo_arr_tf1[tf1Num]];
 
     // Read the coefficients
     const unsigned int TF1_Index = tf1Num * _nTF1Coeff_;
@@ -401,26 +400,26 @@ __global__ void EvalOnGPU_TF1(
     const float b = gpu_coeffs_tf1[TF1_Index+1];
 
     gpu_weights_tf1[tf1Num] = fmaf(a, x, b);
-
     // gpu_weights_tf1[tf1Num] = a*x + b;
-    //gpu_weights_tf1[tf1Num] = 1 + a*x + b*x*x + c*x*x*x + d*x*x*x*x + e*x*x*x*x*x;
+    // gpu_weights_tf1[tf1Num] = 1 + a*x + b*x*x + c*x*x*x + d*x*x*x*x + e*x*x*x*x*x;
   }
 }
 
 //*********************************************************
 // KS: Evaluate the total spline event weight on the GPU, as in most cases GPU is faster, even more this significant reduce memory transfer from GPU to CPU
 __global__ void EvalOnGPU_TotWeight(
+  const int gpu_n_events,
   const float* __restrict__ gpu_weights,
   const float* __restrict__ gpu_weights_tf1,
 
-  float* __restrict__ gpu_total_weights,
+  M3::float_t* __restrict__ gpu_total_weights,
 
   const cudaTextureObject_t __restrict__ text_nParamPerEvent,
   const cudaTextureObject_t __restrict__ text_nParamPerEvent_TF1) {
 //*********************************************************
   const unsigned int EventNum = (blockIdx.x * blockDim.x + threadIdx.x);
 
-  if(EventNum < d_n_events) //stopping condition
+  if(EventNum < gpu_n_events) //stopping condition
   {
     float local_total_weight = 1.f;
 
@@ -433,7 +432,7 @@ __global__ void EvalOnGPU_TotWeight(
     for (unsigned int id = 0; id < tex1Dfetch<unsigned int>(text_nParamPerEvent_TF1, EventOffset); ++id) {
       local_total_weight *= gpu_weights_tf1[tex1Dfetch<unsigned int>(text_nParamPerEvent_TF1, EventOffset+1) + id];
     }
-    gpu_total_weights[EventNum] = local_total_weight;
+    gpu_total_weights[EventNum] = static_cast<M3::float_t>(local_total_weight);
   }
 }
 
@@ -441,55 +440,58 @@ __global__ void EvalOnGPU_TotWeight(
 // Run the GPU code for the separate many arrays. As in separate {x}, {y,b,c,d} arrays
 // Pass the segment and the parameter values
 // (binary search already performed in SplineBase::FindSplineSegment()
-__host__ void SMonolithGPU::RunGPU_SplineMonolith(
-    float* cpu_total_weights,
+__host__ void SplineMonolithGPU::RunGPU_SplineMonolith(
+    M3::float_t* cpu_total_weights,
     // Holds the changes in parameters
     float *vals,
     // Holds the segments for parameters
-    short int *segment,
-    const unsigned int h_n_splines,
-    const unsigned int h_n_tf1) {
+    short int *segment) {
 // *****************************************
   dim3 block_size;
   dim3 grid_size;
 
   block_size.x = _BlockSize_;
-  grid_size.x = (h_n_splines / block_size.x) + 1;
+  grid_size.x = (cpu_n_splines / block_size.x) + 1;
 
-  // Copy the segment values to the GPU (segment_gpu), which is h_n_params long
-  cudaMemcpyToSymbol(segment_gpu, segment, h_n_params*sizeof(short int));
+  // Copy the segment values to the GPU (segment_gpu), which is cpu_n_params long
+  cudaMemcpy(gpu_spline_segment, segment, cpu_n_params * sizeof(short int), cudaMemcpyHostToDevice);
   CudaCheckError();
 
-  // Copy the parameter values values to the GPU (vals_gpu), which is h_n_params long
-  cudaMemcpyToSymbol(val_gpu, vals, h_n_params*sizeof(float));
+  // Copy the parameter values values to the GPU (vals_gpu), which is cpu_n_params long
+  cudaMemcpy(gpu_par_val, vals, cpu_n_params * sizeof(float), cudaMemcpyHostToDevice);
   CudaCheckError();
 
   // KS: Consider asynchronous kernel call, this might help EvalOnGPU_Splines and EvalOnGPU_TF1 are independent
   // Set the cache config to prefer L1 for the kernel
   //cudaFuncSetCacheConfig(EvalOnGPU_Splines, cudaFuncCachePreferL1);
   EvalOnGPU_Splines<<<grid_size, block_size>>>(
+    cpu_n_splines,
+    cpu_spline_size,
     gpu_paramNo_arr,
     gpu_nKnots_arr,
-
     gpu_coeff_many,
+    gpu_par_val,
+    gpu_spline_segment,
 
     gpu_weights,
     text_coeff_x
   );
   CudaCheckError();
 
-  grid_size.x = (h_n_tf1 / block_size.x) + 1;
+  grid_size.x = (cpu_n_TF1 / block_size.x) + 1;
   EvalOnGPU_TF1<<<grid_size, block_size>>>(
+    cpu_n_TF1,
     gpu_coeff_TF1_many,
     gpu_paramNo_TF1_arr,
-
+    gpu_par_val,
     gpu_weights_tf1
   );
   CudaCheckError();
 
-  grid_size.x = (h_n_events / block_size.x) + 1;
+  grid_size.x = (cpu_n_events / block_size.x) + 1;
 
   EvalOnGPU_TotWeight<<<grid_size, block_size>>>(
+      cpu_n_events,
       gpu_weights,
       gpu_weights_tf1,
 
@@ -502,7 +504,7 @@ __host__ void SMonolithGPU::RunGPU_SplineMonolith(
 
   //KS: Here we have to make a somewhat large GPU->CPU transfer because it is proportional to number of events
   //KS: Normally code wait for memory transfer to finish before moving further cudaMemcpyAsync means we will continue to execute code and in a meantime keep copying stuff.
-  cudaMemcpyAsync(cpu_total_weights, gpu_total_weights, h_n_events * sizeof(float), cudaMemcpyDeviceToHost, 0);
+  cudaMemcpyAsync(cpu_total_weights, gpu_total_weights, cpu_n_events * sizeof(M3::float_t), cudaMemcpyDeviceToHost, 0);
   CudaCheckError();
 
   #ifdef DEBUG
@@ -511,47 +513,16 @@ __host__ void SMonolithGPU::RunGPU_SplineMonolith(
   #endif
 }
 
-// *********************************
-// CLEANING
-// *********************************
-
-// *********************************
-// Clean up the {x},{ybcd} arrays
-__host__ void SMonolithGPU::CleanupGPU_SplineMonolith(
-    float *cpu_total_weights){
-// *********************************
-  cudaFree(gpu_paramNo_arr);
-  cudaFree(gpu_nKnots_arr);
-
-  // free the coefficient arrays
-  cudaDestroyTextureObject(text_coeff_x);
-
-  cudaFree(gpu_coeff_x);
-  cudaFree(gpu_coeff_many);
-
-  cudaFree(gpu_coeff_TF1_many);
-  cudaFree(gpu_paramNo_TF1_arr);
-  // free weights on the gpu
-  cudaFree(gpu_weights);
-  cudaFree(gpu_weights_tf1);
-  cudaFree(gpu_total_weights);
-  //KS: Before removing variable let's destroy texture
-  cudaDestroyTextureObject(text_nParamPerEvent);
-  cudaDestroyTextureObject(text_nParamPerEvent_TF1);
-
-  cudaFree(gpu_nParamPerEvent);
-  cudaFree(gpu_nParamPerEvent_TF1);
-  cudaFreeHost(cpu_total_weights);
-  cpu_total_weights = nullptr;
-}
-
 // *******************************************
 /// Clean up pinned variables at CPU
-__host__ void SMonolithGPU::CleanupGPU_Segments(short int *segment, float *vals) {
+__host__ void SplineMonolithGPU::CleanupPinnedMemory(M3::float_t *cpu_total_weights,
+                                                     short int *segment, float *vals) {
 // *******************************************
+  cudaFreeHost(cpu_total_weights);
   cudaFreeHost(segment);
   cudaFreeHost(vals);
 
+  cpu_total_weights = nullptr;
   segment = nullptr;
   vals = nullptr;
 }

--- a/Splines/gpuSplineUtils.cuh
+++ b/Splines/gpuSplineUtils.cuh
@@ -19,39 +19,50 @@ __host__ void SynchroniseSplines();
 /// @brief Evaluate the spline on the GPU Using one {y,b,c,d} array and one {x} array
 /// Should be most efficient at cache hitting and memory coalescence
 /// But using spline segments rather than the parameter value: avoids doing binary search on GPU
+/// @param gpu_n_splines Total number of splines to evaluate (one thread per spline)
+/// @param gpu_spline_size Max number of knots per spline (shared across all splines)
 /// @param gpu_paramNo_arr has length = spln_counter (keeps track of which parameter we're using on this thread)
 /// @param gpu_nKnots_arr has length = spln_counter (keeps track where current spline starts)
 /// @param gpu_coeff_many has length = nKnots * 4, stores all coefficients for all splines and knots
 /// @param gpu_weights has length = spln_counter * spline_size
 /// @param text_coeff_x array storing info about X coeff, uses texture memory. Has length = n_params * spline_size,
 __global__ void EvalOnGPU_Splines(
+    const unsigned int gpu_n_splines,
+    const short int gpu_spline_size,
     const short int* __restrict__ gpu_paramNo_arr,
     const unsigned int* __restrict__ gpu_nKnots_arr,
     const float* __restrict__ gpu_coeff_many,
+    const float* __restrict__ gpu_par_val,
+    const short int* __restrict__ gpu_spline_segment,
     float* __restrict__ gpu_weights,
     const cudaTextureObject_t __restrict__ text_coeff_x);
 
-/// @brief Evaluate the TF1 on the GPU Using 5th order polynomial
+/// @brief Evaluate the TF1 on the GPU Using first order polynomial
+/// Polynomial form:
+///     w(x) = a0 + a1·x
+/// @param gpu_n_TF1 Total number of TF1 functions to evaluate (one thread per TF1)
 /// @param gpu_coeffs_tf1 coefficients of TF1, has length = tf1 coeef counter
 /// @param gpu_paramNo_arr_tf1 has length = spln_counter (keeps track of which parameter we're using on this thread)
 /// @param gpu_weights_tf1 has length = spln_counter * spline_size
 __global__ void EvalOnGPU_TF1(
+  const unsigned int gpu_n_TF1,
   const float* __restrict__ gpu_coeffs_tf1,
   const short int* __restrict__ gpu_paramNo_arr_tf1,
+  const float* __restrict__ gpu_par_val,
   float* __restrict__ gpu_weights_tf1);
 
 /// @brief KS: Evaluate the total spline event weight on the GPU, as in most cases GPU is faster, even more this significant reduce memory transfer from GPU to CPU
+/// @param gpu_n_events Total number of events to process (one thread per event)
 /// @param gpu_weights Weight for each spline object
 /// @param gpu_weights_tf1 Weight for each TF1 object
 /// @param gpu_total_weights Total weight for each event
 /// @param text_nParamPerEvent map keeping track how many parameters applies to each event, we keep two numbers here {number of splines per event, index where splines start for a given event}
 /// @param text_nParamPerEvent_TF1 map keeping track how many parameters applies to each event, we keep two numbers here {number of splines per event, index where splines start for a given event}
 __global__ void EvalOnGPU_TotWeight(
+  const int gpu_n_events,
   const float* __restrict__ gpu_weights,
   const float* __restrict__ gpu_weights_tf1,
-
-  float* __restrict__ gpu_total_weights,
-
+  M3::float_t* __restrict__ gpu_total_weights,
   const cudaTextureObject_t __restrict__ text_nParamPerEvent,
   const cudaTextureObject_t __restrict__ text_nParamPerEvent_TF1);
 
@@ -60,13 +71,14 @@ __global__ void EvalOnGPU_TotWeight(
 /// @author Asher Kaboth
 /// @author Clarence Wret
 /// @author Kamil Skwarczynski
-class SMonolithGPU
+class SplineMonolithGPU
 {
   public:
     /// @brief constructor
-    SMonolithGPU();
-    /// @brief destructor
-    virtual ~SMonolithGPU();
+    SplineMonolithGPU();
+    /// @brief This function deallocates the resources allocated for the
+    /// separate {x} and {ybcd} arrays in the and TF1 stuff at GPU.
+    virtual ~SplineMonolithGPU();
 
     /// @brief Allocate memory on gpu for spline monolith
     /// @param cpu_total_weights KS: Rather than allocate memory in standard way this fancy cuda tool allows to pin host memory which make memory transfer faster
@@ -75,7 +87,7 @@ class SMonolithGPU
     /// @param n_splines Total number of spline objects, not knots
     /// @param n_tf1 Total number of TF1 objects, not coefficients
     __host__ void InitGPU_SplineMonolith(
-      float **cpu_total_weights,
+      M3::float_t **cpu_total_weights,
       int n_events,
       unsigned int total_nknots,
       unsigned int n_splines,
@@ -100,20 +112,20 @@ class SMonolithGPU
     /// @param total_nknots Total number of knots across all splines.
     /// @param n_tf1 Total number of TF1 objects.
     __host__ void CopyToGPU_SplineMonolith(
-      SplineMonoStruct* cpu_spline_handler,
+      const SplineMonoStruct* cpu_spline_handler,
 
       // TFI related now
-      std::vector<float> cpu_many_array_TF1,
-      std::vector<short int> cpu_paramNo_arr_TF1,
-      int n_events,
-      std::vector<unsigned int> cpu_nParamPerEvent,
+      const std::vector<float>& cpu_many_array_TF1,
+      const std::vector<short int>& cpu_paramNo_arr_TF1,
+      const int n_events,
+      const std::vector<unsigned int>& cpu_nParamPerEvent,
       // TFI related now
-      std::vector<unsigned int> cpu_nParamPerEvent_TF1,
-      int n_params,
-      unsigned int n_splines,
-      short int spline_size,
-      unsigned int total_nknots,
-      unsigned int n_tf1);
+      const std::vector<unsigned int>& cpu_nParamPerEvent_TF1,
+      const int n_params,
+      const unsigned int n_splines,
+      const short int spline_size,
+      const unsigned int total_nknots,
+      const unsigned int n_tf1);
 
     /// @brief Allocate memory for spline segments
     /// @param segment Found spline segment for each parameter
@@ -142,31 +154,21 @@ class SMonolithGPU
     ///        `Weight_On_SplineBySpline_Basis` is not defined).
     /// @param vals Pointer to an array holding the parameter values to be processed.
     /// @param segment Pointer to an array containing segment indices for parameters.
-    /// @param h_n_splines Total number of spline objects in the GPU context.
-    /// @param h_n_tf1 Total number of TF1 objects in the GPU context.
     __host__ void RunGPU_SplineMonolith(
-      float* cpu_total_weights,
+      M3::float_t* cpu_total_weights,
       // Holds the changes in parameters
       float *vals,
       // Holds the segments for parameters
-      short int *segment,
-      const unsigned int h_n_splines,
-      const unsigned int h_n_tf1);
+      short int *segment);
 
-    /// @brief This function deallocates the resources allocated for the
-    /// separate {x} and {ybcd} arrays in the and TF1 stuff at GPU.
-    ///
+    /// @brief Clean up pinned variables at CPU
     /// @param cpu_total_weights Pointer to the total weights array
     ///        on the CPU (used if `Weight_On_SplineBySpline_Basis`
     ///        is not defined).
-    __host__ void CleanupGPU_SplineMonolith(
-      float *cpu_total_weights
-      );
-
-    /// @brief Clean up pinned variables at CPU
     /// @param segment Found spline segment for each parameter
     /// @param vals Value to which we want reweight for each parameter
-    __host__ void CleanupGPU_Segments(short int *segment, float *vals);
+    __host__ void CleanupPinnedMemory(M3::float_t *cpu_total_weights,
+                                      short int *segment, float *vals);
 
   private:
     /// KS: GPU map keeping track how many parameters applies to each event, we keep two numbers here {number of splines per event, index where splines start for a given event}
@@ -193,18 +195,28 @@ class SMonolithGPU
     /// CW: GPU array with the number of points per TF1 object
     short int *gpu_paramNo_TF1_arr;
 
+    /// CW: parameter value on GPU
+    float* gpu_par_val;
+    /// CW: Spline segment on GPU
+    short int* gpu_spline_segment;
+
     /// GPU arrays to hold weight for event
-    float *gpu_total_weights;
+    M3::float_t *gpu_total_weights;
     /// GPU arrays to hold weight for each spline
     float *gpu_weights;
     /// GPU arrays to hold weight for each TF1
     float *gpu_weights_tf1;
 
-    // h_NAME declares HOST constants (live on CPU)
+    /// Size of splines living on CPU
+    short int cpu_spline_size;
+    /// Number of splines living on CPU
+    unsigned int cpu_n_splines;
+    /// Number of tf1 living on CPU
+    unsigned int cpu_n_TF1;
     /// Number of params living on CPU
-    int h_n_params;
+    int cpu_n_params;
     /// Number of events living on CPU
-    int h_n_events;
+    int cpu_n_events;
 
     // ******************************************
     // TEXTURES

--- a/python/splines.cpp
+++ b/python/splines.cpp
@@ -185,7 +185,7 @@ void initSplines(py::module &m) {
 
         .def(
             "get_event_weight",
-            &SMonolith::retPointer,
+            &SMonolith::RetPointer,
             py::return_value_policy::reference,
             "Get the weight of a particular event. \n"
             ":param event: The index of the event whose weight you would like.",


### PR DESCRIPTION
# Pull request description
Previously, SMonolith assumed that final weigh is always float. This made problems for total weight pointer in sample Handler.
This is now fixed and weight is M3::float_t both CPU and GPU.

In addition, previously terribly hard-coded N_Splines is removed. We no longer have any global variables because it was unstainable in a longer run.

## Changes or fixes
- retPointer->RetPointer
- Introduced final keyworld
- SMonolithGPU ->SplineMonolithGPU
- all d_ -> gpu_ and h_ -> cpu_ (even if not CUDA convention this should be easier for casual developers)

## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
