### PR TITLE
breaking: Namespace Conisteancy

### DIFF
--- a/Diagnostics/CombineMaCh3Chains.cpp
+++ b/Diagnostics/CombineMaCh3Chains.cpp
@@ -411,7 +411,7 @@ void ParseArg(int argc, char *argv[]){
 int main(int argc, char *argv[])
 {
   SetMaCh3LoggerFormat();
-  MaCh3Utils::MaCh3Welcome();
+  M3::Utils::MaCh3Welcome();
   ParseArg(argc, argv);
   CombineChain();
   return 0;

--- a/Diagnostics/GetPenaltyTerm.cpp
+++ b/Diagnostics/GetPenaltyTerm.cpp
@@ -64,7 +64,7 @@ void ReadCovFile(const std::string& inputFile,
   if(CovPos.back() == "none")
   {
     MACH3LOG_WARN("Couldn't find Cov branch in output");
-    MaCh3Utils::PrintConfig(Settings);
+    M3::Utils::PrintConfig(Settings);
     throw MaCh3Exception(__FILE__ , __LINE__ );
   }
 
@@ -272,7 +272,7 @@ void GetPenaltyTerm(const std::string& inputFile, const std::string& configFile)
   std::vector<double> logL(NSets, 0.0);
   for(int n = 0; n < AllEvents; ++n)
   {
-    if(n%10000 == 0) MaCh3Utils::PrintProgressBar(n, AllEvents);
+    if(n%10000 == 0) M3::Utils::PrintProgressBar(n, AllEvents);
       
     Chain->GetEntry(n);
 
@@ -381,7 +381,7 @@ void GetPenaltyTerm(const std::string& inputFile, const std::string& configFile)
 int main(int argc, char *argv[])
 {
   SetMaCh3LoggerFormat();
-  MaCh3Utils::MaCh3Welcome();
+  M3::Utils::MaCh3Welcome();
   if (argc != 3 )
   {
     MACH3LOG_WARN("Something went wrong ");

--- a/Diagnostics/PlotLLHMap.cpp
+++ b/Diagnostics/PlotLLHMap.cpp
@@ -62,7 +62,7 @@ std::vector<std::string> GetParams(std::vector<std::string> &PoIs, ROOT::RDataFr
 int main(int argc, char *argv[]) {
 // *******************
   SetMaCh3LoggerFormat();
-  MaCh3Utils::MaCh3Welcome();
+  M3::Utils::MaCh3Welcome();
 
   if(argc < 3)
   {
@@ -147,7 +147,7 @@ int main(int argc, char *argv[]) {
     {
       const int count = int(double(hprof1d->GetNbinsX())/double(5));
       if (bidx % count == 0)
-        MaCh3Utils::PrintProgressBar(bidx, hprof1d->GetNbinsX());
+        M3::Utils::PrintProgressBar(bidx, hprof1d->GetNbinsX());
 
       auto b_lo = hprof1d->GetXaxis()->GetBinLowEdge(bidx);
       auto b_hi = b_lo + hprof1d->GetXaxis()->GetBinWidth(bidx);
@@ -206,7 +206,7 @@ int main(int argc, char *argv[]) {
         {
           const int count = int(double(hprof2d->GetNbinsX()*hprof2d->GetNbinsY())/double(5));
           if ( ((bidx-1)*hprof2d->GetNbinsY() + bidy) % count == 0)
-            MaCh3Utils::PrintProgressBar((bidx-1)*hprof2d->GetNbinsY() + bidy, hprof2d->GetNbinsX()*hprof2d->GetNbinsY());
+            M3::Utils::PrintProgressBar((bidx-1)*hprof2d->GetNbinsY() + bidy, hprof2d->GetNbinsX()*hprof2d->GetNbinsY());
 
           auto bx_lo = hprof2d->GetXaxis()->GetBinLowEdge(bidx);
           auto bx_hi = bx_lo + hprof2d->GetXaxis()->GetBinWidth(bidx);

--- a/Diagnostics/RHat.cpp
+++ b/Diagnostics/RHat.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[]) {
 // *******************
 
   SetMaCh3LoggerFormat();
-  MaCh3Utils::MaCh3Welcome();
+  M3::Utils::MaCh3Welcome();
 
   Mean = nullptr;
   StandardDeviation = nullptr;
@@ -304,7 +304,7 @@ void PrepareChains() {
 
       // Output some info for the user
       if (Ntoys_requested[m] > 10 && i % (Ntoys_requested[m]/10) == 0) {
-        MaCh3Utils::PrintProgressBar(i+m*Ntoys_requested[m], static_cast<Long64_t>(Ntoys_requested[m])*Nchains);
+        M3::Utils::PrintProgressBar(i+m*Ntoys_requested[m], static_cast<Long64_t>(Ntoys_requested[m])*Nchains);
         MACH3LOG_DEBUG("Getting random entry {}", entry);
       }
 

--- a/Diagnostics/RHat_HighMem.cpp
+++ b/Diagnostics/RHat_HighMem.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[]) {
 // *******************
 
   SetMaCh3LoggerFormat();
-  MaCh3Utils::MaCh3Welcome();
+  M3::Utils::MaCh3Welcome();
 
   Draws = nullptr;
   Mean = nullptr;
@@ -314,7 +314,7 @@ void PrepareChains() {
 
       // Output some info for the user
       if (Ntoys > 10 && i % (Ntoys/10) == 0) {
-        MaCh3Utils::PrintProgressBar(i+m*Ntoys, static_cast<Long64_t>(Ntoys)*Nchains);
+        M3::Utils::PrintProgressBar(i+m*Ntoys, static_cast<Long64_t>(Ntoys)*Nchains);
         MACH3LOG_DEBUG("Getting random entry {}", entry);
       }
 

--- a/Diagnostics/ReweightMCMC.cpp
+++ b/Diagnostics/ReweightMCMC.cpp
@@ -441,7 +441,7 @@ void ReweightMCMC(const std::string& configFile, const std::string& inputFile)
         MACH3LOG_INFO("MCMCProcessor has reweighted, skipping duplicate reweighting");
     } else {
         for (Long64_t i = 0; i < nEntries; ++i) {
-            if(i % (nEntries/20) == 0) MaCh3Utils::PrintProgressBar(i, nEntries);
+            if(i % (nEntries/20) == 0) M3::Utils::PrintProgressBar(i, nEntries);
         
             inTree->GetEntry(i);
             

--- a/Doc/MaCh3Web/Definitions.dox
+++ b/Doc/MaCh3Web/Definitions.dox
@@ -59,7 +59,8 @@
   /// @namespace M3
   /// @brief Main namespace for MaCh3 software
 
-
+  /// @namespace M3::Utils
+  /// @brief Utility helpers used across MaCh3
 
   /// @defgroup MaCh3Plotting MaCh3 Plotting
   /// @brief Flexible, experiment-agnostic plotting utilities for MaCh3.

--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -126,8 +126,8 @@ void FitterBase::SaveSettings() {
 
   fitMan->SaveSettings(outputFile);
 
-  MACH3LOG_WARN("\033[0;31mCurrent Total RAM usage is {:.2f} GB\033[0m", MaCh3Utils::getValue("VmRSS") / 1048576.0);
-  MACH3LOG_WARN("\033[0;31mOut of Total available RAM {:.2f} GB\033[0m", MaCh3Utils::getValue("MemTotal") / 1048576.0);
+  MACH3LOG_WARN("\033[0;31mCurrent Total RAM usage is {:.2f} GB\033[0m", M3::Utils::getValue("VmRSS") / 1048576.0);
+  MACH3LOG_WARN("\033[0;31mOut of Total available RAM {:.2f} GB\033[0m", M3::Utils::getValue("MemTotal") / 1048576.0);
 
   MACH3LOG_INFO("#####Current Setup#####");
   MACH3LOG_INFO("Number of covariances: {}", systematics.size());
@@ -741,7 +741,7 @@ void FitterBase::RunLLHScan() {
       for (int j = 0; j < n_points; ++j)
       {
         if (j % countwidth == 0)
-          MaCh3Utils::PrintProgressBar(j, n_points);
+          M3::Utils::PrintProgressBar(j, n_points);
 
         // For PCA we have to do it differently
         if (IsPCA) {
@@ -999,7 +999,7 @@ void FitterBase::Run2DLLHScan() {
         for (int x = 0; x < n_points; ++x)
         {
           if (x % countwidth == 0)
-            MaCh3Utils::PrintProgressBar(x, n_points);
+            M3::Utils::PrintProgressBar(x, n_points);
 
           for (int y = 0; y < n_points; ++y)
           {
@@ -1288,7 +1288,7 @@ void FitterBase::RunLLHMap() {
     LLHMap->Fill();
 
     if (sp % countwidth == 0)
-      MaCh3Utils::PrintProgressBar(sp, TotalPoints);
+      M3::Utils::PrintProgressBar(sp, TotalPoints);
   }
 
   outputFile->cd();

--- a/Fitters/MCMCProcessor.cpp
+++ b/Fitters/MCMCProcessor.cpp
@@ -21,7 +21,7 @@ MCMCProcessor::MCMCProcessor(const std::string &InputFile) :
   MCMCFile = InputFile;
 
   SetMaCh3LoggerFormat();
-  MaCh3Utils::MaCh3Welcome();
+  M3::Utils::MaCh3Welcome();
   MACH3LOG_INFO("Making post-fit processor for: {}", MCMCFile);
 
   ParStep = nullptr;
@@ -259,7 +259,7 @@ void MCMCProcessor::MakePostfit(const std::map<std::string, std::pair<double, do
   for (int i = 0; i < nDraw; ++i)
   {
     if (i % (nDraw/5) == 0) {
-      MaCh3Utils::PrintProgressBar(i, nDraw);
+      M3::Utils::PrintProgressBar(i, nDraw);
     }
     OutputFile->cd();
     TString Title = "";
@@ -972,7 +972,7 @@ void MCMCProcessor::MakeCovariance() {
   for (int i = 0; i < nDraw; ++i)
   {
     if (i % (nDraw/5) == 0)
-      MaCh3Utils::PrintProgressBar(i, nDraw);
+      M3::Utils::PrintProgressBar(i, nDraw);
 
     TString Title_i = "";
     double Prior_i, PriorError;
@@ -1120,8 +1120,8 @@ void MCMCProcessor::CacheSteps() {
   for (Long64_t j = 0; j < nEntries; ++j) 
   {
     if (j % countwidth == 0) {
-        MaCh3Utils::PrintProgressBar(j, nEntries);
-        MaCh3Utils::EstimateDataTransferRate(Chain, j);
+        M3::Utils::PrintProgressBar(j, nEntries);
+        M3::Utils::EstimateDataTransferRate(Chain, j);
     } else {
       Chain->GetEntry(j);
     }
@@ -2484,7 +2484,7 @@ void MCMCProcessor::FindInputFiles() {
   } else {
     CovConfig[kXSecPar] = TMacroToYAML(*XsecConfig);
   }
-  if(InputNotFound) MaCh3Utils::PrintConfig(Settings);
+  if(InputNotFound) M3::Utils::PrintConfig(Settings);
 
   for(size_t i = 0; i < CovPos[kXSecPar].size(); i++)
     M3::AddPath(CovPos[kXSecPar][i]);
@@ -2504,7 +2504,7 @@ void MCMCProcessor::FindInputFiles() {
     } else {
       MACH3LOG_WARN("Found reweight config but without field ''Weight''");
     }
-    MaCh3Utils::PrintConfig(ReweightSettings);
+    M3::Utils::PrintConfig(ReweightSettings);
   }
 
   // Delete the MCMCFile pointer we're reading
@@ -3109,7 +3109,7 @@ void MCMCProcessor::ReweightPrior(const std::vector<std::string>& Names,
 
   for (int i = 0; i < nEntries; ++i)
   {
-    if(i % (nEntries/10) == 0) MaCh3Utils::PrintProgressBar(i, nEntries);
+    if(i % (nEntries/10) == 0) M3::Utils::PrintProgressBar(i, nEntries);
     post->GetEntry(i);
     Weight = 1.;
 
@@ -3472,7 +3472,7 @@ void MCMCProcessor::PrepareDiagMCMC() {
     Chain->GetEntry(i);
 
     if (i % countwidth == 0)
-      MaCh3Utils::PrintProgressBar(i, nEntries);
+      M3::Utils::PrintProgressBar(i, nEntries);
 
     // Set the branch addresses for params
     for (int j = 0; j < nDraw; ++j) {

--- a/Fitters/OscProcessor.cpp
+++ b/Fitters/OscProcessor.cpp
@@ -265,8 +265,8 @@ void OscProcessor::PerformJarlskogAnalysis() {
 
   for(int i = 0; i < nEntries; ++i) {
     if (i % countwidth == 0) {
-      MaCh3Utils::PrintProgressBar(i, nEntries);
-      MaCh3Utils::EstimateDataTransferRate(Chain, i);
+      M3::Utils::PrintProgressBar(i, nEntries);
+      M3::Utils::EstimateDataTransferRate(Chain, i);
     } else {
       Chain->GetEntry(i);
     }

--- a/Fitters/PredictiveThrower.cpp
+++ b/Fitters/PredictiveThrower.cpp
@@ -564,7 +564,7 @@ void PredictiveThrower::ProduceToys() {
   for(int i = 0; i < Ntoys; i++)
   {
     if(Ntoys >= 10 && i % (Ntoys/10) == 0) {
-      MaCh3Utils::PrintProgressBar(i, Ntoys);
+      M3::Utils::PrintProgressBar(i, Ntoys);
     }
     if(!Is_PriorPredictive){
       int entry = 0;
@@ -1022,8 +1022,8 @@ void PredictiveThrower::RunPredictiveAnalysis() {
   SanitiseInputs();
 
   MACH3LOG_INFO("Starting {}", __func__);
-  MACH3LOG_WARN("\033[0;31mCurrent Total RAM usage is {:.2f} GB\033[0m", MaCh3Utils::getValue("VmRSS") / 1048576.0);
-  MACH3LOG_WARN("\033[0;31mOut of Total available RAM {:.2f} GB\033[0m", MaCh3Utils::getValue("MemTotal") / 1048576.0);
+  MACH3LOG_WARN("\033[0;31mCurrent Total RAM usage is {:.2f} GB\033[0m", M3::Utils::getValue("VmRSS") / 1048576.0);
+  MACH3LOG_WARN("\033[0;31mOut of Total available RAM {:.2f} GB\033[0m", M3::Utils::getValue("MemTotal") / 1048576.0);
 
   TStopwatch TempClock;
   TempClock.Start();

--- a/Fitters/SampleSummary.cpp
+++ b/Fitters/SampleSummary.cpp
@@ -1147,7 +1147,7 @@ void SampleSummary::MakeChi2Hists() {
   for (unsigned int i = 0; i < nThrows; ++i)
   {
     if (i % (nThrows/10) == 0) {
-      MaCh3Utils::PrintProgressBar(i, nThrows);
+      M3::Utils::PrintProgressBar(i, nThrows);
     }
 
     // Set the total LLH to zero to initialise

--- a/Fitters/StatisticalUtils.cpp
+++ b/Fitters/StatisticalUtils.cpp
@@ -521,7 +521,7 @@ void ThinningMCMC(const std::string& FilePath, const int ThinningCut) {
   MACH3LOG_INFO("Thinning will retain {:.2f}% of chains", retainedPercentage);
   for (Long64_t i = 0; i < nEntries; i++) {
     if (i % (nEntries/10) == 0) {
-      MaCh3Utils::PrintProgressBar(i, nEntries);
+      M3::Utils::PrintProgressBar(i, nEntries);
     }
     if (i % ThinningCut == 0) {
       inTree->GetEntry(i);

--- a/Manager/Manager.cpp
+++ b/Manager/Manager.cpp
@@ -27,12 +27,12 @@ Manager::Manager(const YAML::Node ConfigNode) {
 void Manager::Initialise() {
 // *************************
   SetMaCh3LoggerFormat();
-  MaCh3Utils::MaCh3Welcome();
+  M3::Utils::MaCh3Welcome();
 
   MACH3LOG_INFO("Setting config to be: {}", FileName);
 
   MACH3LOG_INFO("Config is now: ");
-  MaCh3Utils::PrintConfig(config);
+  M3::Utils::PrintConfig(config);
 }
 
 
@@ -90,7 +90,7 @@ void Manager::SaveSettings(TFile* const OutputFile) const {
 void Manager::Print() const {
 // *************************
   MACH3LOG_INFO("---------------------------------");
-  MaCh3Utils::PrintConfig(config);
+  M3::Utils::PrintConfig(config);
   MACH3LOG_INFO("---------------------------------");
 }
 

--- a/Manager/Monitor.cpp
+++ b/Manager/Monitor.cpp
@@ -6,7 +6,8 @@
 #include "Manager/gpuUtils.cuh"
 #endif
 
-namespace MaCh3Utils {
+namespace M3 {
+namespace Utils {
 
 // *************************
 void MaCh3Welcome() {
@@ -365,9 +366,8 @@ void MaCh3Usage(int argc, char **argv) {
     throw MaCh3Exception(__FILE__, __LINE__);
   }
 }
-} //end namespace
+} //end utils namespace
 
-namespace M3 {
 // ***************************************************************************
 int GetNThreads() {
 // ***************************************************************************
@@ -395,5 +395,5 @@ void AddPath(std::string& FilePath) {
     FilePath.insert(0, MaCh3Path);
   }
 }
-} //end namespace
+} //end M3 namespace
 

--- a/Manager/Monitor.h
+++ b/Manager/Monitor.h
@@ -26,7 +26,8 @@ _MaCh3_Safe_Include_End_ //}
 /// @brief System and monitoring utilities for printing system information and status updates.
 /// @author Kamil Skwarczynski
 
-namespace MaCh3Utils {
+namespace M3 {
+namespace Utils {
   /// @brief KS: Prints welcome message with MaCh3 logo
   void MaCh3Welcome();
   /// @brief KS: Find out more about operational system
@@ -74,9 +75,8 @@ namespace MaCh3Utils {
   /// @param argv The array of command-line arguments.
   /// @details This function prints a simple usage guide for MaCh3 executables, typically called when incorrect arguments are passed.
   void MaCh3Usage(int argc, char **argv);
-}
+} // end Utils namespace
 
-namespace M3 {
   /// @brief number of threads which we need for example for TRandom3
   int GetNThreads();
   /// @brief Prepends the MACH3 environment path to FilePath if it is not already present.
@@ -90,4 +90,4 @@ namespace M3 {
     return 0;
     #endif
   }
-}
+} // end M3 namespace

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -1439,7 +1439,7 @@ void ParameterHandlerBase::SaveUpdatedMatrixConfig() {
   for (YAML::Node param : copyNode["Systematics"])
   {
     //KS: Feel free to update it, if you need updated prefit value etc
-    param["Systematic"]["StepScale"]["MCMC"] = MaCh3Utils::FormatDouble(_fIndivStepScale[i], 4);
+    param["Systematic"]["StepScale"]["MCMC"] = M3::Utils::FormatDouble(_fIndivStepScale[i], 4);
     i++;
   }
   // Save the modified node to a file

--- a/Parameters/ParameterHandlerUtils.h
+++ b/Parameters/ParameterHandlerUtils.h
@@ -227,7 +227,7 @@ inline void AddTuneValues(YAML::Node& root,
             MACH3LOG_ERROR("Missing 'ParameterValues' for matched FancyName '{}'", FancyNames[i]);
             throw MaCh3Exception(__FILE__, __LINE__);
           }
-          systematicNode["ParameterValues"][Tune] = MaCh3Utils::FormatDouble(Values[i], 4);
+          systematicNode["ParameterValues"][Tune] = M3::Utils::FormatDouble(Values[i], 4);
           matched = true;
           break;
         }
@@ -244,7 +244,7 @@ inline void AddTuneValues(YAML::Node& root,
         MACH3LOG_ERROR("Missing 'Systematic' or 'ParameterValues' entry at index {}", i);
         throw MaCh3Exception(__FILE__, __LINE__);
       }
-      systematicNode["ParameterValues"][Tune] = MaCh3Utils::FormatDouble(Values[i], 4);
+      systematicNode["ParameterValues"][Tune] = M3::Utils::FormatDouble(Values[i], 4);
     }
   }
 
@@ -322,7 +322,7 @@ inline void MakeCorrelationMatrix(YAML::Node& root,
       }
       YAML::Node& syst_i = it_i->second;
 
-      syst_i["ParameterValues"]["PreFitValue"] = MaCh3Utils::FormatDouble(Values[i], 4);
+      syst_i["ParameterValues"]["PreFitValue"] = M3::Utils::FormatDouble(Values[i], 4);
       syst_i["Error"] = std::round(Errors[i] * 100.0) / 100.0;
 
       YAML::Node correlationsNode = YAML::Node(YAML::NodeType::Sequence);
@@ -331,7 +331,7 @@ inline void MakeCorrelationMatrix(YAML::Node& root,
         // KS: Skip if value close to 0
         if (std::abs(Correlation[i][j]) < 1e-8) continue;
         YAML::Node singleEntry;
-        singleEntry[FancyNames[j]] = MaCh3Utils::FormatDouble(Correlation[i][j], 4);
+        singleEntry[FancyNames[j]] = M3::Utils::FormatDouble(Correlation[i][j], 4);
         correlationsNode.push_back(singleEntry);
       }
       syst_i["Correlations"] = correlationsNode;
@@ -350,7 +350,7 @@ inline void MakeCorrelationMatrix(YAML::Node& root,
         throw MaCh3Exception(__FILE__, __LINE__);
       }
 
-      syst["ParameterValues"]["PreFitValue"] = MaCh3Utils::FormatDouble(Values[i], 4);
+      syst["ParameterValues"]["PreFitValue"] = M3::Utils::FormatDouble(Values[i], 4);
       syst["Error"] = std::round(Errors[i] * 100.0) / 100.0;
 
       YAML::Node correlationsNode = YAML::Node(YAML::NodeType::Sequence);
@@ -360,7 +360,7 @@ inline void MakeCorrelationMatrix(YAML::Node& root,
         if (std::abs(Correlation[i][j]) < 1e-8) continue;
         YAML::Node singleEntry;
         const std::string& otherName = systematics[j]["Systematic"]["Names"]["FancyName"].as<std::string>();
-        singleEntry[otherName] = MaCh3Utils::FormatDouble(Correlation[i][j], 4);
+        singleEntry[otherName] = M3::Utils::FormatDouble(Correlation[i][j], 4);
         correlationsNode.push_back(singleEntry);
       }
       syst["Correlations"] = correlationsNode;

--- a/Plotting/GetPostfitParamPlots.cpp
+++ b/Plotting/GetPostfitParamPlots.cpp
@@ -150,7 +150,7 @@ bool ReadSettings(const std::shared_ptr<TFile>& File1)
   if (!Settings) return false;
 
   MACH3LOG_DEBUG("Got settings tree");
-  MaCh3Utils::Print(Settings);
+  M3::Utils::Print(Settings);
 
   Settings->SetBranchAddress("NDParameters", &NDParameters);
   Settings->SetBranchAddress("NDParametersStartingPos", &NDParametersStartingPos);

--- a/Plotting/PlotLLH.cpp
+++ b/Plotting/PlotLLH.cpp
@@ -51,7 +51,7 @@ void getSplitSampleStack(int fileIdx, std::string parameterName, TH1D LLH_allSam
                          std::vector<float> &cumSums, std::vector<bool> &drawLabel,
                          THStack *sampleStack, TLegend *splitSamplesLegend,
                          float baselineLLH_main = 0.00001) 
-  {
+{
   std::vector<std::string> sampNames = PlotMan->input().getTaggedSamples(PlotMan->getOption<std::vector<std::string>>("sampleTags"));
   size_t nSamples = sampNames.size();
 
@@ -468,7 +468,7 @@ int PlotLLH() {
 
 int main(int argc, char **argv) {
   SetMaCh3LoggerFormat();
-  MaCh3Utils::MaCh3Welcome();
+  M3::Utils::MaCh3Welcome();
 
   PlotMan = new MaCh3Plotting::PlottingManager();
   PlotMan->parseInputs(argc, argv);

--- a/Samples/HistogramUtils.cpp
+++ b/Samples/HistogramUtils.cpp
@@ -571,7 +571,7 @@ void FastViolinFill(TH2D* violin, TH1D* hist_1d){
 double returnCherenkovThresholdMomentum(const int PDG) {
 // ****************
   constexpr double refractiveIndex = 1.334; //DB From https://github.com/fiTQun/fiTQun/blob/646cf9c8ba3d4f7400bcbbde029d5ca15513a3bf/fiTQun_shared.cc#L757
-  double mass =  MaCh3Utils::GetMassFromPDG(PDG)*1e3;
+  double mass =  M3::Utils::GetMassFromPDG(PDG)*1e3;
   double momentumThreshold = mass/sqrt(refractiveIndex*refractiveIndex-1.);
   return momentumThreshold;
 }

--- a/Samples/SampleHandlerFD.cpp
+++ b/Samples/SampleHandlerFD.cpp
@@ -1137,8 +1137,8 @@ const M3::float_t* SampleHandlerFD::GetNuOscillatorPointers(const int iEvent) co
     int InitFlav = M3::_BAD_INT_;
     int FinalFlav = M3::_BAD_INT_;
 
-    InitFlav =  MaCh3Utils::PDGToNuOscillatorFlavour(MCEvents[iEvent].nupdgUnosc);
-    FinalFlav = MaCh3Utils::PDGToNuOscillatorFlavour(MCEvents[iEvent].nupdg);
+    InitFlav =  M3::Utils::PDGToNuOscillatorFlavour(MCEvents[iEvent].nupdgUnosc);
+    FinalFlav = M3::Utils::PDGToNuOscillatorFlavour(MCEvents[iEvent].nupdg);
 
     if (InitFlav == M3::_BAD_INT_ || FinalFlav == M3::_BAD_INT_) {
       MACH3LOG_ERROR("Something has gone wrong in the mapping between MCEvents.nutype and the enum used within NuOscillator");

--- a/Samples/SampleStructs.h
+++ b/Samples/SampleStructs.h
@@ -737,7 +737,8 @@ inline int GetLocalBinFromGlobalBin(const std::vector<SampleBinningInfo>& Binnin
 
 // ***************************
 // A handy namespace for variables extraction
-namespace MaCh3Utils {
+namespace M3 {
+namespace Utils {
 // ***************************
   // *****************************
   /// @brief Return mass for given PDG
@@ -835,5 +836,5 @@ namespace MaCh3Utils {
     oss << std::fixed << std::setprecision(precision) << value;
     return oss.str();
   }
-
-} // end MaCh3Utils namespace
+} // end Utils namespace
+} // end M3 namespace


### PR DESCRIPTION
# Pull request description
Follow more modern standards and use M3::Utils rather MaCh3Utils namespace.
In future we might have more namespace with M3:: being global one.

Need to merge this first: https://github.com/mach3-software/MaCh3Tutorial/pull/234
## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
