### PR TITLE
tidy: NuDock to dependancy graph

### DIFF
--- a/.github/workflows/WeeklyValgrind.yml
+++ b/.github/workflows/WeeklyValgrind.yml
@@ -45,7 +45,7 @@ jobs:
           git clone --branch develop https://github.com/mach3-software/MaCh3.git MaCh3Cmake
           cd MaCh3Cmake
           mkdir build && cd build
-          cmake ../ -DMaCh3_DependancyGraph=ON
+          cmake ../ -DMaCh3_DependancyGraph=ON -DMaCh3_NUDOCK_ENABLED=ON
           make -j4 install
 
       - name: Checkout different branch and push plot

--- a/Doc/MaCh3Web/DoxygenLayout.xml
+++ b/Doc/MaCh3Web/DoxygenLayout.xml
@@ -50,7 +50,7 @@
       <tab type="globals" visible="yes" title="" intro=""/>
     </tab>
     <tab type="examples" visible="yes" title="" intro=""/>
-    <tab type="pages" visible="yes" title="" intro=""/>
+    <tab type="pages" visible="no" title="" intro=""/>
 
     <tab type="user" visible="yes" title="pyMaCh3" url="./pyMaCh3/mainpage.html"/>
 

--- a/NuDock/CMakeLists.txt
+++ b/NuDock/CMakeLists.txt
@@ -18,7 +18,7 @@ set_target_properties(MaCh3NuDock PROPERTIES
 CPMAddPackage(
     NAME NuDock
     GITHUB_REPOSITORY "NuDock/nudock"
-    GIT_TAG mach3_branch
+    GIT_TAG "0eef1a49df06b3a714ed2a9fc1cbed6f3151144d"
     GIT_SHALLOW NO
     GIT_SUBMODULES_RECURSE ON
 )


### PR DESCRIPTION
# Pull request description
Now NuDock will be added to dependency graph:
https://github.com/mach3-software/MaCh3/blob/gh-profiling/Graph.png

NuDock now usess commit rather than branch which should be more stable.

In addition, remove AdditionalPages from Doxygen documentation
## Changes or fixes


## Examples
<img width="1224" height="222" alt="image" src="https://github.com/user-attachments/assets/85f2f074-fbe4-4330-98f0-48d5fd06aaed" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
