### PR TITLE
bugfix: FLOAT_T M3::float_t conversion

### DIFF
--- a/Samples/OscillationHandler.cpp
+++ b/Samples/OscillationHandler.cpp
@@ -80,9 +80,15 @@ void OscillationHandler::AddSample(const std::string& NuOscillatorConfigFile, co
 // ************************************************
 void OscillationHandler::Evaluate() {
 // ************************************************
-  std::vector<M3::float_t> OscVec(OscParams.size());
+  // NuOscillator is using FLOAT_T while MaCh3 M3::float_t
+  // Moslty they are same however it is possible to have double on M3
+  // but float on NuOsc hence we need conversion
+  std::vector<FLOAT_T> OscVec(OscParams.size());
   for (size_t iPar = 0; iPar < OscParams.size(); ++iPar) {
-    OscVec[iPar] = *OscParams[iPar];
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wuseless-cast"
+    OscVec[iPar] = static_cast<M3::float_t>(*OscParams[iPar]);
+    #pragma GCC diagnostic pop
   }
 
   if (EqualBinningPerOscChannel) {

--- a/Samples/OscillationHandler.cpp
+++ b/Samples/OscillationHandler.cpp
@@ -87,7 +87,7 @@ void OscillationHandler::Evaluate() {
   for (size_t iPar = 0; iPar < OscParams.size(); ++iPar) {
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wuseless-cast"
-    OscVec[iPar] = static_cast<M3::float_t>(*OscParams[iPar]);
+    OscVec[iPar] = static_cast<FLOAT_T>(*OscParams[iPar]);
     #pragma GCC diagnostic pop
   }
 


### PR DESCRIPTION
# Pull request description
After this https://github.com/mach3-software/MaCh3/pull/836 in 99% of cases M::float_t and FLOAT_T are same.
However MaCh3 should support to use float but have NuOsc use float.
This is important as not every engine supports float..

This PR sorts out this issue

## Changes or fixes


## Examples



---
- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
