### PR TITLE
feat: NonUniform binning to 2DVarHist

### DIFF
--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -10,7 +10,7 @@
 
 // ************************************************
 SampleHandlerBase::SampleHandlerBase(std::string ConfigFileName, ParameterHandlerGeneric* xsec_cov,
-                                 const std::shared_ptr<OscillationHandler>& OscillatorObj_) : SampleHandlerInterface() {
+                                     const std::shared_ptr<OscillationHandler>& OscillatorObj_) : SampleHandlerInterface() {
 // ************************************************
   MACH3LOG_INFO("-------------------------------------------------------------------");
   MACH3LOG_INFO("Creating SampleHandlerBase object");
@@ -1504,9 +1504,16 @@ std::unique_ptr<TH2> SampleHandlerBase::Get2DVarHist(const int iSample,
   auto tmp_Selection = ApplyTemporarySelection(iSample, EventSelectionVec);
 
   //DB Define the histogram which will be returned
-  std::vector<double> xBinEdges = ReturnKinematicParameterBinning(iSample, ProjectionVar_StrX);
-  std::vector<double> yBinEdges = ReturnKinematicParameterBinning(iSample, ProjectionVar_StrY);
-  auto _h2DVar = std::make_unique<TH2D>("", "", int(xBinEdges.size())-1, xBinEdges.data(), int(yBinEdges.size())-1, yBinEdges.data());
+  //KS: If we use 2D non uniform binning and wanting to plot fit variables use TH2Poly everything else uses TH2D with binning from config
+  std::unique_ptr<TH2> _h2DVar;
+  if(GetNDim(iSample) == 2 && !Binning->IsUniform(iSample) &&
+     ProjectionVar_StrX == GetKinVarName(iSample, 0) && ProjectionVar_StrY == GetKinVarName(iSample, 1) ) {
+    _h2DVar = std::unique_ptr<TH2>(static_cast<TH2*>(M3::Clone(GetMCHist(iSample)).release()));
+  } else {
+    std::vector<double> xBinEdges = ReturnKinematicParameterBinning(iSample, ProjectionVar_StrX);
+    std::vector<double> yBinEdges = ReturnKinematicParameterBinning(iSample, ProjectionVar_StrY);
+    _h2DVar = std::make_unique<TH2D>("", "", int(xBinEdges.size())-1, xBinEdges.data(), int(yBinEdges.size())-1, yBinEdges.data());
+  }
   _h2DVar->SetDirectory(nullptr);
   _h2DVar->GetXaxis()->SetTitle(ProjectionVar_StrX.c_str());
   _h2DVar->GetYaxis()->SetTitle(ProjectionVar_StrY.c_str());
@@ -1541,7 +1548,7 @@ std::unique_ptr<TH2> SampleHandlerBase::Get2DVarHist(const int iSample,
 }
 
 // ************************************************
-void SampleHandlerBase::Fill2DSubEventHist(const int iSample, TH2D* _h2DVar,
+void SampleHandlerBase::Fill2DSubEventHist(const int iSample, TH2* _h2DVar,
                                          const std::string& ProjectionVar_StrX,
                                          const std::string& ProjectionVar_StrY,
                                          const std::vector< KinematicCut >& SubEventSelectionVec,

--- a/Samples/SampleHandlerBase.h
+++ b/Samples/SampleHandlerBase.h
@@ -105,7 +105,7 @@ class SampleHandlerBase :  public SampleHandlerInterface
   void Fill1DSubEventHist(const int iSample, TH1D* _h1DVar, const std::string& ProjectionVar,
                           const std::vector< KinematicCut >& SubEventSelectionVec = {},
                           int WeightStyle=0);
-  void Fill2DSubEventHist(const int iSample, TH2D* _h2DVar, const std::string& ProjectionVarX, const std::string& ProjectionVarY,
+  void Fill2DSubEventHist(const int iSample, TH2* _h2DVar, const std::string& ProjectionVarX, const std::string& ProjectionVarY,
                           const std::vector< KinematicCut >& SubEventSelectionVec = {}, int WeightStyle = 0);
 
   std::unique_ptr<TH1> Get1DVarHistByModeAndChannel(const int iSample, const std::string& ProjectionVar_Str,


### PR DESCRIPTION
# Pull request description
Now 2DVar Hist can produce plots with non-uniform using TH2Poly


## Examples
<img width="1360" height="1334" alt="image" src="https://github.com/user-attachments/assets/688b4cbb-a2ec-407e-9959-17a3e8299c68" />
<img width="2559" height="1527" alt="image" src="https://github.com/user-attachments/assets/cdeaeefa-9523-4bc4-88d6-a5906fef98ce" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
