### PR TITLE
bugfix: SampleHandlerBase::Selection is left empty by initialize

### DIFF
--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -161,6 +161,7 @@ void SampleHandlerBase::LoadSingleSample(const int iSample, const YAML::Node& Sa
     MACH3LOG_INFO("Adding cut on {} with bounds {} to {}", SelectionCuts["KinematicStr"].as<std::string>(), TempBoundsVec[0], TempBoundsVec[1]);
     StoredSelection[iSample].emplace_back(CutObj);
   }
+  Selection = StoredSelection;
   /// Add new sample
   SampleDetails[iSample] = std::move(SingleSample);
 }


### PR DESCRIPTION
- Currently the 'main' Selection vector is only set the first time FillArray is called, which means that IsEventSelected cannot be used before FillArray is used (e.g. to interrogate spline applicability.)

# Pull request description


## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
