### PR TITLE
tidy: Remove deprecated Cmake Settings

### DIFF
--- a/cmake/Modules/CUDASetup.cmake
+++ b/cmake/Modules/CUDASetup.cmake
@@ -67,17 +67,6 @@ if(MaCh3_DEBUG_ENABLED)
   include(${CMAKE_CURRENT_LIST_DIR}/CUDASamples.cmake)
 endif()
 
-#KS: We need it to be defined on compiler level,
-if(NOT DEFINED NSplines_GPU)
-   #EM: for OA2024: 160
-  set(NSplines_GPU 160)
-endif()
-
-# Pass NSplines_GPU as a preprocessor definition to the compiler
-target_compile_definitions(MaCh3GPUCompilerOptions INTERFACE NSplines_GPU=${NSplines_GPU})
-cmessage(STATUS "Using \"${NSplines_GPU}\" for GPU EventByEvent Splines")
-
-
 #KS: Keep this for backward compatibility
 
 #-Xptxas "-dlcm=ca -v --allow-expensive-optimizations=true -fmad=true"


### PR DESCRIPTION
# Pull request description
Since https://github.com/mach3-software/MaCh3/pull/838
NSplines_GPU is no longer needed, thus removing it.

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
