### PR TITLE
bugfix: Remove individual step scale printing from set indiv scale

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -1149,9 +1149,8 @@ void ParameterHandlerBase::SetIndivStepScaleForSkippedAdaptParams() {
       _fIndivStepScale[i] = _fIndivStepScaleInitial[i] * _fGlobalStepScaleInitial / _fGlobalStepScale;
     }
   }
-  MACH3LOG_INFO("Updating individual step scales for non-adapting parameters to cancel global step scale change.");
-  MACH3LOG_INFO("Global step scale initial: {}, current: {}", _fGlobalStepScaleInitial, _fGlobalStepScale);
-  PrintIndivStepScale();
+  MACH3LOG_DEBUG("Updating individual step scales for non-adapting parameters to cancel global step scale change.");
+  MACH3LOG_DEBUG("Global step scale initial: {}, current: {}", _fGlobalStepScaleInitial, _fGlobalStepScale);
 }
 
 // ********************************************


### PR DESCRIPTION
# Pull request description
`ParameterHandlerGeneric::SetIndivStepScaleForSkippedAdaptParams` had print out that made Robbins-Monro too verbose; remove the full xsec printout and demote global step scale setting to DEBUG

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
