### PR TITLE
feat: Implement usage for plotting manager

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -323,6 +323,27 @@ int parameter_counter; //Not par_count
 
 Please note that a lot of this has not been followed in MaCh3 but we are trying to improve the coding style so please bare this in mind when contributing!
 
+## Namespace
+Main MaCh3 namespace is `M3`. If possible, always use it.
+
+If you plan to use another namespace like `blarb`, please follow the rule below:
+
+### ✅ Correct
+```cpp
+M3::blarb
+```
+
+### ❌ Incorrect
+```cpp
+blarb
+```
+
+or
+
+```cpp
+MaCh3blarb
+```
+
 ## ROOT
 MaCh3 uses the CERN ROOT package for plotting and I/O operations. While MaCh3 does not require a specific ROOT version—ensuring compatibility across a wide range of scientific clusters used by different users—be aware that ROOT developers occasionally introduce bugs or breaking changes in new releases.
 To improve stability and portability, it is recommended to prefer standard C++ (STL) counterparts whenever possible.

--- a/Doc/MaCh3Web/Definitions.dox
+++ b/Doc/MaCh3Web/Definitions.dox
@@ -62,6 +62,9 @@
   /// @namespace M3::Utils
   /// @brief Utility helpers used across MaCh3
 
+  /// @namespace M3::Plotting
+  /// @brief Flexible, experiment-agnostic plotting utilities for MaCh3.
+
   /// @defgroup MaCh3Plotting MaCh3 Plotting
   /// @brief Flexible, experiment-agnostic plotting utilities for MaCh3.
   ///

--- a/Plotting/GetPostfitParamPlots.cpp
+++ b/Plotting/GetPostfitParamPlots.cpp
@@ -48,7 +48,7 @@ _MaCh3_Safe_Include_End_ //}
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
 #pragma GCC diagnostic ignored "-Wconversion"
 
-MaCh3Plotting::PlottingManager *PlotMan;
+M3::Plotting::PlottingManager *PlotMan = nullptr;
 
 int NDParameters;
 int NDParametersStartingPos;
@@ -63,7 +63,7 @@ void copyParToBlockHist(const int localBin, const std::string& paramName, TH1D* 
                         const std::string& type, const int fileId, const bool setLabels = true){
   // Set the values in the sub-histograms
   MACH3LOG_DEBUG("copying data from at local bin {}: for parameter {}", localBin, paramName);
-  MACH3LOG_DEBUG("  Fitter specific name: {}", PlotMan->input().translateName(fileId, MaCh3Plotting::kPostFit, paramName));
+  MACH3LOG_DEBUG("  Fitter specific name: {}", PlotMan->input().translateName(fileId, M3::Plotting::kPostFit, paramName));
   MACH3LOG_DEBUG("  value: {:.4f}", PlotMan->input().getPostFitValue(fileId, paramName, type));
   MACH3LOG_DEBUG("  error: {:.4f}", PlotMan->input().getPostFitError(fileId, paramName, type));
 
@@ -619,7 +619,7 @@ void MakeRidgePlots()
       while (TKey* key = static_cast<TKey*>(next())) {
         // check if the end of the param name matches with the MaCh3 name, do this so we exclude things like nds_ at the start of the name
         std::string str(key->GetTitle());
-        std::string name = PlotMan->input().translateName(0, MaCh3Plotting::kPostFit, paramName);
+        std::string name = PlotMan->input().translateName(0, M3::Plotting::kPostFit, paramName);
         uint pos = str.find(name);
         bool foundPar = (pos == str.length() - name.length());
 
@@ -1094,7 +1094,7 @@ int main(int argc, char *argv[])
   // Avoid Info in <TCanvas::Print>
   gErrorIgnoreLevel = kWarning;
 
-  PlotMan = new MaCh3Plotting::PlottingManager();
+  PlotMan = new M3::Plotting::PlottingManager();
   PlotMan->parseInputs(argc, argv);
   #ifdef MACH3_DEBUG
   PlotMan->input().getFile(0).file->ls();

--- a/Plotting/MatrixPlotter.cpp
+++ b/Plotting/MatrixPlotter.cpp
@@ -14,7 +14,7 @@
 std::unique_ptr<TH2D> GetSubMatrix(TH2D *MatrixFull,
                                    const std::string& Title,
                                    const std::vector<std::string>& Params,
-                                   const std::unique_ptr<MaCh3Plotting::PlottingManager>& man)
+                                   const std::unique_ptr<M3::Plotting::PlottingManager>& man)
 {
   std::vector<int> ParamIndex(Params.size(), M3::_BAD_INT_);
 
@@ -102,7 +102,7 @@ void SetupInfo(const std::string& Config, std::vector<std::string>& Title, std::
   }
 }
 
-void PlotMatrix(const std::unique_ptr<MaCh3Plotting::PlottingManager>& man, const std::string& Config, const std::string& File)
+void PlotMatrix(const std::unique_ptr<M3::Plotting::PlottingManager>& man, const std::string& Config, const std::string& File)
 {
   // Open the ROOT file
   TFile *file = M3::Open(File, "UPDATE", __FILE__, __LINE__);
@@ -171,7 +171,7 @@ void PlotMatrix(const std::unique_ptr<MaCh3Plotting::PlottingManager>& man, cons
   delete file;
 }
 
-void CompareMatrices(const std::unique_ptr<MaCh3Plotting::PlottingManager>& man,
+void CompareMatrices(const std::unique_ptr<M3::Plotting::PlottingManager>& man,
                      const std::string& Config, const std::string& File1, const std::string& Title1,
                      const std::string& File2, const std::string& Title2)
 {
@@ -248,7 +248,7 @@ int main(int argc, char *argv[])
 {
   SetMaCh3LoggerFormat();
 
-  auto man = std::make_unique<MaCh3Plotting::PlottingManager>();
+  auto man = std::make_unique<M3::Plotting::PlottingManager>();
   man->initialise();
 
   if (argc != 3 && argc != 6)

--- a/Plotting/PlotLLH.cpp
+++ b/Plotting/PlotLLH.cpp
@@ -24,7 +24,7 @@ bool sameAxis;
 double ratioLabelScaling;
 
 /// @warning KS: keep raw pointer or ensure manual delete of PlotMan. If spdlog in automatically deleted before PlotMan then destructor has some spdlog and this could cause segfault
-MaCh3Plotting::PlottingManager *PlotMan;
+M3::Plotting::PlottingManager *PlotMan;
 
 /// @brief TPad is SUPER FRAGILE, it is safer to just make raw pointer, while ROOT behave weirdly with smart pointers
 void SetTPads(TPad*& LLHPad, TPad*& ratioPad)
@@ -470,7 +470,7 @@ int main(int argc, char **argv) {
   SetMaCh3LoggerFormat();
   M3::Utils::MaCh3Welcome();
 
-  PlotMan = new MaCh3Plotting::PlottingManager();
+  PlotMan = new M3::Plotting::PlottingManager();
   PlotMan->parseInputs(argc, argv);
 
   PlotMan->setExec("PlotLLH");

--- a/Plotting/PlotSigmaVariation.cpp
+++ b/Plotting/PlotSigmaVariation.cpp
@@ -24,7 +24,7 @@ constexpr Color_t Colours[NVars] = {kRed, kGreen+1, kBlack, kBlue+1, kOrange+1};
 constexpr ELineStyle Style[NVars] = {kDotted, kDashed, kSolid, kDashDotted, kDashDotted};
 
 /// @warning KS: keep raw pointer or ensure manual delete of PlotMan. If spdlog in automatically deleted before PlotMan then destructor has some spdlog and this could cause segfault
-MaCh3Plotting::PlottingManager* PlotMan;
+M3::Plotting::PlottingManager* PlotMan = nullptr;
 
 /// @brief Histograms have name like ND_CC0pi_1DProj0_Norm_Param_0_sig_n3.00_val_0.25. This code is trying to extract sigma names
 void FindKnot(std::vector<double>& SigmaValues,
@@ -841,7 +841,7 @@ int main(int argc, char **argv)
 
   ScanInput(DialNameVector, SampleNameVector, SampleMaxDim, sigmaArray, filename);
 
-  PlotMan = new MaCh3Plotting::PlottingManager();
+  PlotMan = new M3::Plotting::PlottingManager();
   PlotMan->initialise();
 
   CompareSigVar1D(filename, settings);

--- a/Plotting/PlottingUtils/InputManager.cpp
+++ b/Plotting/PlottingUtils/InputManager.cpp
@@ -1,7 +1,7 @@
 #include "InputManager.h"
 
-
-namespace MaCh3Plotting {
+namespace M3 {
+namespace Plotting {
 // this is the constructor with user specified translation config file
 InputManager::InputManager(const std::string &translationConfigName) {
   // read the config file
@@ -883,4 +883,5 @@ void InputManager::fillFileData(InputFile &inputFileDef, const bool printThought
     find1dPosterior(inputFileDef, parameter, inputFileDef.fitter, true);
   }
 }
-} // namespace MaCh3Plotting
+} // namespace Plotting
+} // namespace M3

--- a/Plotting/PlottingUtils/InputManager.h
+++ b/Plotting/PlottingUtils/InputManager.h
@@ -10,8 +10,8 @@
 // Other plotting includes
 #include "PlottingUtils.h"
 
-namespace MaCh3Plotting {
-
+namespace M3 {
+namespace Plotting {
 /// @brief Types of possible file that can be read.
 enum fileTypeEnum {
   kLLH,         //!< Log Likelihood scan
@@ -32,6 +32,7 @@ enum fileTypeEnum {
 /// from very different file structures used by different fitters and provide a common format to
 /// be used for plot making. Intended use of this objects is only via InputManager which contains
 /// the methods to fill and manipulate it.
+/// @author Ewan Miller
 struct InputFile {
   /// @brief Create InputFile instance based on a specified file.
   /// @param fName The name of the file to open.
@@ -670,4 +671,5 @@ private:
   // vector of InputFile objects that this manager is responsible for
   std::vector<InputFile> _fileVec;
 };
-} // namespace MaCh3Plotting
+} // namespace Plotting
+} // namespace M3

--- a/Plotting/PlottingUtils/PlottingManager.cpp
+++ b/Plotting/PlottingUtils/PlottingManager.cpp
@@ -1,6 +1,7 @@
 #include "PlottingManager.h"
 
-namespace MaCh3Plotting {
+namespace M3 {
+namespace Plotting {
 // this is the constructor using the default plotting config file
 PlottingManager::PlottingManager() {
   // set config file name
@@ -90,6 +91,13 @@ void PlottingManager::initialise() {
 /// @todo make this able to return any un-parsed arguments so that user can specify their own
 /// arguments for use in their plotting scripts
 void PlottingManager::parseInputs(int argc, char * const *argv) {
+  if (argc < 2)
+  {
+    usage();
+    MACH3LOG_ERROR("no arguments were specified :(");
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+
   // parse the inputs
   int c;
   while ((c = getopt(argc, argv, "o:l:d:c:srgh")) != -1)
@@ -116,7 +124,7 @@ void PlottingManager::parseInputs(int argc, char * const *argv) {
     }
     case 'h': {
       usage();
-      throw MaCh3Exception(__FILE__ , __LINE__ );
+      break;
     }
     case 'l': {
       parseFileLabels(optarg, _fileLabels);
@@ -132,6 +140,13 @@ void PlottingManager::parseInputs(int argc, char * const *argv) {
     case 'd': {
       _extraDrawOptions = optarg;
       break;
+    }
+    case '?':
+    default:
+    {
+      MACH3LOG_ERROR("Unknown or malformed option");
+      usage();
+      throw MaCh3Exception(__FILE__, __LINE__);
     }
     }
   }
@@ -150,7 +165,7 @@ void PlottingManager::parseInputs(int argc, char * const *argv) {
 
   if (_plotRatios && _fileNames.size() == 0)
   {
-    MACH3LOG_ERROR("you specified -r <_plotRatios> = true but didnt specify any files to compare against, was this a mistake?");
+    MACH3LOG_ERROR("you specified -r <_plotRatios> = true but didn't specify any files to compare against, was this a mistake?");
   }
 
   if (_fileLabels.size() == 0)
@@ -177,17 +192,38 @@ void PlottingManager::addUserOption() {
   /// @todo Implement this.
 }
 
-std::string PlottingManager::getUserOption(std::string option) {
+std::string PlottingManager::getUserOption(const std::string& option) {
   /// @todo Implement this.
   (void) option;
   return "";
 }
 
-void PlottingManager::usage() {
-  /// @todo Implement this.
+void PlottingManager::usage() const {
   /// @todo could add some function to allow user to specify the help message for their particular
   /// script, then auto generate what the cmd line syntax looks like based on user specified
   /// options?
+  MACH3LOG_INFO("========================================");
+  MACH3LOG_INFO("PlottingManager usage:");
+  MACH3LOG_INFO("========================================");
+
+  MACH3LOG_INFO("Required:");
+  MACH3LOG_INFO("  <input files>               One or more input files (positional args)");
+
+  MACH3LOG_INFO("");
+  MACH3LOG_INFO("Options:");
+  MACH3LOG_INFO("  -o <file>                   Output file name");
+  MACH3LOG_INFO("  -l <labels>                 Comma/space-separated file labels");
+  //MACH3LOG_INFO("  -c <config>                 Configuration file name");
+  //MACH3LOG_INFO("  -d <options>                Extra draw options");
+  //MACH3LOG_INFO("  -s                          Split by sample");
+  //MACH3LOG_INFO("  -r                          Plot ratios (requires multiple input files)");
+  //MACH3LOG_INFO("  -g                          Draw grid");
+  MACH3LOG_INFO("  -h                          Show this help message");
+
+  MACH3LOG_INFO("");
+  MACH3LOG_INFO("Examples:");
+  MACH3LOG_INFO("  ./plot file1.root -f FancyName");
+  MACH3LOG_INFO("========================================");
 }
 
 /// Will check the provided saveName for file extensions, if it is one of .pdf or .eps, then just
@@ -257,4 +293,5 @@ void PlottingManager::parseFileLabels(std::string labelString, std::vector<std::
   }
   labelVec.push_back(labelString.substr(0, end));
 }
-} // namespace MaCh3Plotting
+} // namespace Plotting
+} // namespace M3

--- a/Plotting/PlottingUtils/PlottingManager.h
+++ b/Plotting/PlottingUtils/PlottingManager.h
@@ -18,7 +18,9 @@
 #include "InputManager.h"
 #include "StyleManager.h"
 
-namespace MaCh3Plotting {
+
+namespace M3 {
+namespace Plotting {
 /// @brief The main class to be used in plotting scripts.
 /// @details When it comes to plotting, this guys in charge, the main man, the head honcho, the big
 /// cheese. If it's a plot you need, this is the guy you call. You just call him in your scripts and
@@ -93,10 +95,10 @@ public:
   void addUserOption();
 
   /// @brief Retrieve a command line option you specified using addOption.
-  std::string getUserOption(std::string option);
+  std::string getUserOption(const std::string& option);
 
   /// @brief Print a usage message for the current executable.
-  void usage();
+  void usage() const;
 
   /// @brief Parse string of labels into a vector of strings.
   /// @param labelString string of labels of the form "label1;label2;...".
@@ -189,4 +191,5 @@ private:
   std::unique_ptr<StyleManager> _styleMan;
   std::unique_ptr<InputManager> _inputMan;
 };
-} // namespace MaCh3Plotting
+} // namespace Plotting
+} // namespace M3

--- a/Plotting/PlottingUtils/PlottingUtils.cpp
+++ b/Plotting/PlottingUtils/PlottingUtils.cpp
@@ -1,7 +1,7 @@
 #include "PlottingUtils.h"
 
-namespace MaCh3Plotting {
-
+namespace M3 {
+namespace Plotting {
 /// It will go through your provided graph and make a histogram binning by taking the midpoints of
 /// all the graph points x values, then fill the histogram with the graphs y values. For the first
 /// and last points it will extend the binning out of the graph bounds using the width between the
@@ -109,4 +109,5 @@ std::vector<std::vector<double>> TGraphToVector(TGraph2D graph) {
   return ret;
 }
 
-} // namespace MaCh3Plotting 
+} // namespace Plotting
+} // namespace M3

--- a/Plotting/PlottingUtils/PlottingUtils.h
+++ b/Plotting/PlottingUtils/PlottingUtils.h
@@ -33,7 +33,8 @@ _MaCh3_Safe_Include_Start_ //{
 _MaCh3_Safe_Include_End_ //}
 
 
-namespace MaCh3Plotting {
+namespace M3 {
+namespace Plotting {
 /// @brief This handy little function lets you interpret a TGraph as a TH1D.
 /// @param graph The graph you want to convert.
 /// @param newName The new name you want to give to the histogram. If not specified, will just use
@@ -53,4 +54,5 @@ std::vector<std::vector<double>> TGraphToVector(TGraph graph);
 /// @param graph The graph you want to convert.
 /// @return A vector of vectors containing the data from the initial graph. The first vector is the x axis, the 2nd the y axis, the 3rd is the z axis
 std::vector<std::vector<double>> TGraphToVector(TGraph2D graph);
-} // namespace MaCh3Plotting
+} // namespace Plotting
+} // namespace M3

--- a/Plotting/PlottingUtils/StyleManager.cpp
+++ b/Plotting/PlottingUtils/StyleManager.cpp
@@ -1,6 +1,7 @@
 #include "StyleManager.h"
 
-namespace MaCh3Plotting {
+namespace M3 {
+namespace Plotting {
 StyleManager::StyleManager(std::string styleConfigName) {
   _styleConfig = M3OpenConfig(styleConfigName);
 }
@@ -72,5 +73,5 @@ void StyleManager::setTH1Style(TH1 *hist, const std::string& styleName) const {
   hist->SetLineColor(GetFromManager<Color_t>(styleDef["LineColor"], kRed, __FILE__, __LINE__));
   hist->SetLineStyle(GetFromManager<Color_t>(styleDef["LineStyle"], 1, __FILE__, __LINE__));
 }
-
-} // namespace MaCh3Plotting
+} // namespace Plotting
+} // namespace M3

--- a/Plotting/PlottingUtils/StyleManager.h
+++ b/Plotting/PlottingUtils/StyleManager.h
@@ -12,11 +12,11 @@ _MaCh3_Safe_Include_Start_ //{
 #include "TStyle.h"
 _MaCh3_Safe_Include_End_ //}
 
-
-namespace MaCh3Plotting {
-/// @author Ewan Miller
+namespace M3 {
+namespace Plotting {
 
 /// @brief EW: provides centralized styling utilities for plots, including name prettification and style application
+/// @author Ewan Miller
 /// @ingroup MaCh3Plotting
 class StyleManager {
 public:
@@ -82,5 +82,5 @@ private:
   std::string prettifyName(const std::string &origName, const std::string &nameType) const;
 
 };
-
-} // namespace MaCh3Plotting
+} // namespace Plotting
+} // namespace M3

--- a/Plotting/PredictivePlotting.cpp
+++ b/Plotting/PredictivePlotting.cpp
@@ -11,7 +11,7 @@
 /// @author Kamil Skwarczynski
 
 /// @warning KS: keep raw pointer or ensure manual delete of PlotMan. If spdlog in automatically deleted before PlotMan then destructor has some spdlog and this could cause segfault
-MaCh3Plotting::PlottingManager* PlotMan;
+M3::Plotting::PlottingManager* PlotMan = nullptr;
 constexpr const double ScalingFactor = 10;
 
 std::vector<std::string> FindSamples(const std::string& File)
@@ -615,7 +615,7 @@ int main(int argc, char **argv)
     FileNames.emplace_back(argv[i]);
   }
 
-  PlotMan = new MaCh3Plotting::PlottingManager();
+  PlotMan = new M3::Plotting::PlottingManager();
   PlotMan->initialise();
 
   PredictivePlotting(ConfigName, FileNames);

--- a/README.md
+++ b/README.md
@@ -236,13 +236,13 @@ The MaCh3 core plotting library code can be found [here](https://github.com/mach
 This is an example how your executable can look like using MaCh3:
 ```cpp
   //Manager is responsible for reading from config
-  std::unique_ptr<manager> fitMan = MaCh3ManagerFactory(argc, argv);
+  std::unique_ptr<manager> FitManager = MaCh3ManagerFactory(argc, argv);
 
   std::vector<SampleHandlerBase*> sample; //vector storing information about sample for different detector
   std::vector<ParameterHandlerBase*> Cov; // vector with systematic implementation
-  MakeMaCh3Instance(fitMan.get(), sample, Cov); //Factory like function which initialises everything
+  MakeMaCh3Instance(FitManager.get(), sample, Cov); //Factory like function which initialises everything
 
-  // FitterBase class, can be replaced with other fitting method
+  // FitterBase class has implementation of validation procedures and fitting algorithms
   std::unique_ptr<FitterBase> MarkovChain = MaCh3FitterFactory(FitManager.get());
 
   //Adding samples and covariances to the Fitter class could be in the factory

--- a/python/plotting.h
+++ b/python/plotting.h
@@ -19,7 +19,7 @@ namespace py = pybind11;
 
 void initPlottingModule(py::module &m_plotting){
 
-    py::class_<MaCh3Plotting::PlottingManager>(m_plotting, "PlottingManager")
+    py::class_<M3::Plotting::PlottingManager>(m_plotting, "PlottingManager")
         .def(
             py::init<const std::string &>(),
             "construct a PlottingManager using the specified config file",
@@ -33,102 +33,102 @@ void initPlottingModule(py::module &m_plotting){
         
         .def(
             "initialise", 
-            &MaCh3Plotting::PlottingManager::initialise, 
+            &M3::Plotting::PlottingManager::initialise,
             "initalise this PlottingManager"
         )
         
         .def(
             "usage", 
-            &MaCh3Plotting::PlottingManager::usage, 
+            &M3::Plotting::PlottingManager::usage,
             "Print a usage message for the current executable"
         )
         
         .def(
             "parse_inputs", 
-            &MaCh3Plotting::PlottingManager::parseInputsVec, 
+            &M3::Plotting::PlottingManager::parseInputsVec,
             "Parse command line variables",
             py::arg("arguments")
         )
         
         .def(
             "set_exec", 
-            &MaCh3Plotting::PlottingManager::setExec, 
+            &M3::Plotting::PlottingManager::setExec,
             "Set the name of the current executable, which will be used when getting executable specific options from the plotting config file",
             py::arg("exec_name")
         )
         
         .def(
             "get_file_name", 
-            &MaCh3Plotting::PlottingManager::getFileName, 
+            &M3::Plotting::PlottingManager::getFileName,
             "Get the path to a particular file",
             py::arg("input_file_id")
         )
         
         .def(
             "get_file_label", 
-            &MaCh3Plotting::PlottingManager::getFileLabel, 
+            &M3::Plotting::PlottingManager::getFileLabel,
             "Get the specified label of a particular input file",
             py::arg("input_file_id")
         )
         
         .def(
             "get_draw_options", 
-            &MaCh3Plotting::PlottingManager::getDrawOptions, 
+            &M3::Plotting::PlottingManager::getDrawOptions,
             "Get any additional root drawing options specified by the user"
         )
         
         .def(
             "get_output_name", 
-            py::overload_cast<const std::string &>(&MaCh3Plotting::PlottingManager::getOutputName), 
+            py::overload_cast<const std::string &>(&M3::Plotting::PlottingManager::getOutputName),
             "Get the output name specified by the user, can specify an additional *suffix* to append to the file name but before the file extension",
             py::arg("suffix") = ""
         )
         
         .def(
             "get_file_names", 
-            &MaCh3Plotting::PlottingManager::getFileNames, 
+            &M3::Plotting::PlottingManager::getFileNames,
             "Get the list of all file names"
         )
         
         .def(
             "get_file_labels", 
-            &MaCh3Plotting::PlottingManager::getFileLabels, 
+            &M3::Plotting::PlottingManager::getFileLabels,
             "Get the list of all file labels"
         )
         
         .def(
             "get_n_files", 
-            &MaCh3Plotting::PlottingManager::getNFiles, 
+            &M3::Plotting::PlottingManager::getNFiles,
             "Get the number of specified files"
         )
         
         .def(
             "get_split_by_sample", 
-            &MaCh3Plotting::PlottingManager::getSplitBySample, 
+            &M3::Plotting::PlottingManager::getSplitBySample,
             "Get whether or not the user has set the 'split by sample' (-s) option"
         )
         
         .def(
             "get_plot_ratios", 
-            &MaCh3Plotting::PlottingManager::getPlotRatios, 
+            &M3::Plotting::PlottingManager::getPlotRatios,
             "Get whether or not the user specified the 'plot ratios' (-r) option"
         )
         
         .def(
             "get_draw_grid", 
-            &MaCh3Plotting::PlottingManager::getDrawGrid, 
+            &M3::Plotting::PlottingManager::getDrawGrid,
             "Get wheter or not the user has specified the 'draw grid' (-g) option"
         )
         
         .def(
             "style", 
-            &MaCh3Plotting::PlottingManager::style, py::return_value_policy::reference, 
+            &M3::Plotting::PlottingManager::style, py::return_value_policy::reference,
             "Get the StyleManager associated with this PlottingManager"
         )
         
         .def(
             "input", 
-            &MaCh3Plotting::PlottingManager::input, py::return_value_policy::reference, 
+            &M3::Plotting::PlottingManager::input, py::return_value_policy::reference,
             "Get the InputManager associated with this PlottingManager"
         )
 
@@ -137,16 +137,16 @@ void initPlottingModule(py::module &m_plotting){
         //     from this one and add the functions to that) and then fold that python code into the module somehow. But that is currently beyond my pybinding abilities
         ;
 
-    py::class_<MaCh3Plotting::InputManager>(m_plotting, "InputManager")
+    py::class_<M3::Plotting::InputManager>(m_plotting, "InputManager")
         .def(
             "print", 
-            &MaCh3Plotting::InputManager::print, 
+            &M3::Plotting::InputManager::print,
             "Print a summary of everything this manager knows"
             )
         
         .def(
             "get_llh_scan", 
-            &MaCh3Plotting::InputManager::getLLHScan, 
+            &M3::Plotting::InputManager::getLLHScan,
             "Get the LLH scan for a particular parameter from a particular file",
             py::arg("input_file_id"), 
             py::arg("param_name"), 
@@ -155,7 +155,7 @@ void initPlottingModule(py::module &m_plotting){
         
         .def(
             "get_llh_scan_by_sample", 
-            &MaCh3Plotting::InputManager::getSampleSpecificLLHScan, 
+            &M3::Plotting::InputManager::getSampleSpecificLLHScan,
             "Get the LLH scan for a particular parameter from a particular file for a particular sample",
             py::arg("input_file_id"), 
             py::arg("param"), 
@@ -164,7 +164,7 @@ void initPlottingModule(py::module &m_plotting){
         
         .def(
             "get_enabled_llh", 
-            &MaCh3Plotting::InputManager::getEnabledLLH, 
+            &M3::Plotting::InputManager::getEnabledLLH,
             "Get whether a particular file has LLH scans for a particular parameter", 
             py::arg("input_file_id"), 
             py::arg("param"),
@@ -173,7 +173,7 @@ void initPlottingModule(py::module &m_plotting){
         
         .def(
             "get_enabled_llh_by_sample", 
-            &MaCh3Plotting::InputManager::getEnabledLLHBySample, 
+            &M3::Plotting::InputManager::getEnabledLLHBySample,
             "Get whether a particular file has LLH scans for a particular parameter for a particular sample",
             py::arg("input_file_id"), 
             py::arg("param"), 
@@ -182,7 +182,7 @@ void initPlottingModule(py::module &m_plotting){
         
         .def(
             "get_post_fit_error", 
-            &MaCh3Plotting::InputManager::getPostFitError, 
+            &M3::Plotting::InputManager::getPostFitError,
             "Get the post fit error for a parameter from a particular file",
             py::arg("input_file_id"), 
             py::arg("param"),
@@ -191,7 +191,7 @@ void initPlottingModule(py::module &m_plotting){
         
         .def(
             "get_post_fit_value", 
-            &MaCh3Plotting::InputManager::getPostFitValue, 
+            &M3::Plotting::InputManager::getPostFitValue,
             "Get the post fit value for a parameter from a particular file",
             py::arg("input_file_id"), 
             py::arg("param"),
@@ -200,19 +200,19 @@ void initPlottingModule(py::module &m_plotting){
         
         .def(
             "get_known_parameters", 
-            &MaCh3Plotting::InputManager::getKnownParameters, 
+            &M3::Plotting::InputManager::getKnownParameters,
             "Get all the parameters that this manager knows about. Useful for iterating over"
             )
         
         .def(
             "get_known_samples", 
-            &MaCh3Plotting::InputManager::getKnownSamples, 
+            &M3::Plotting::InputManager::getKnownSamples,
             "Get all the samples that this manager knows about. Useful for iterating over"
             )
         
         .def(
             "get_tagged_parameters", 
-            &MaCh3Plotting::InputManager::getTaggedParameters, 
+            &M3::Plotting::InputManager::getTaggedParameters,
             "Get all the parameters whose tags match some specified list",
             py::arg("tags"),
             py::arg("check_type") = "all"
@@ -220,7 +220,7 @@ void initPlottingModule(py::module &m_plotting){
         
         .def(
             "get_tagged_samples", 
-            &MaCh3Plotting::InputManager::getTaggedSamples, 
+            &M3::Plotting::InputManager::getTaggedSamples,
             "Get all the samples whose tags match some specified list",
             py::arg("tags"),
             py::arg("check_type") = "all"
@@ -228,48 +228,48 @@ void initPlottingModule(py::module &m_plotting){
         
         .def(
             "get_n_input_files", 
-            &MaCh3Plotting::InputManager::getNInputFiles, 
+            &M3::Plotting::InputManager::getNInputFiles,
             "Get the number of input files registered with this manager"
             )
         
         .def(
             "get_known_llh_parameters", 
-            &MaCh3Plotting::InputManager::getKnownLLHParameters, 
+            &M3::Plotting::InputManager::getKnownLLHParameters,
             "Get all the parameters that a file has LLH scans for",
             py::arg("file_id")
             )
         
         .def(
             "get_known_llh_samples", 
-            &MaCh3Plotting::InputManager::getKnownLLHSamples, 
+            &M3::Plotting::InputManager::getKnownLLHSamples,
             "Get all the samples that a file has individual LLH scans for",
             py::arg("file_id")
             )
         
         .def(
             "get_known_post_fit_parameters", 
-            &MaCh3Plotting::InputManager::getKnownPostFitParameters, 
+            &M3::Plotting::InputManager::getKnownPostFitParameters,
             "Get all the parameters that a file has post fit values and errors for",
             py::arg("file_id")
             )
         
         .def(
             "get_known_MCMC_parameters", 
-            &MaCh3Plotting::InputManager::getKnownMCMCParameters, 
+            &M3::Plotting::InputManager::getKnownMCMCParameters,
             "Get all the parameters that a file has MCMC chain entries for",
             py::arg("file_id")
             )
         
         .def(
             "get_known_1d_posterior_parameters", 
-            &MaCh3Plotting::InputManager::getKnown1dPosteriorParameters, 
+            &M3::Plotting::InputManager::getKnown1dPosteriorParameters,
             "Get all the parameters that a file has processed 1d posteriors for",
             py::arg("file_id")
             )
         
         .def(
             "get_MCMC_entry", 
-            &MaCh3Plotting::InputManager::getMCMCentry, 
+            &M3::Plotting::InputManager::getMCMCentry,
             "Load up a particular step in the MCMC chain for a particular input file",
             py::arg("file_id"),
             py::arg("step")
@@ -277,7 +277,7 @@ void initPlottingModule(py::module &m_plotting){
         
         .def(
             "get_MCMC_value", 
-            &MaCh3Plotting::InputManager::getMCMCvalue, 
+            &M3::Plotting::InputManager::getMCMCvalue,
             "Get the value of a particular parameter for the current entry (set by set_MCMC_entry) in the chain for a particular file",
             py::arg("file_id"),
             py::arg("param")
@@ -285,30 +285,30 @@ void initPlottingModule(py::module &m_plotting){
         
         .def(
             "get_n_MCMC_entries", 
-            &MaCh3Plotting::InputManager::getnMCMCentries, 
+            &M3::Plotting::InputManager::getnMCMCentries,
             "Get the number of entries in the MCMC chain in a particular file"
             )
         
         .def(
             "get_1d_posterior",
-            &MaCh3Plotting::InputManager::get1dPosterior,
+            &M3::Plotting::InputManager::get1dPosterior,
             "Get the 1d posterior for a particular parameter from a particular file",
             py::arg("file_id"),
             py::arg("param")
             )
         ;
 
-    py::class_<MaCh3Plotting::StyleManager>(m_plotting, "StyleManager")
+    py::class_<M3::Plotting::StyleManager>(m_plotting, "StyleManager")
         .def(
             "prettify_parameter_name", 
-            &MaCh3Plotting::StyleManager::prettifyParamName, 
+            &M3::Plotting::StyleManager::prettifyParamName,
             "Convert internally used parameter name to a nice pretty name that can be used in plots",
             py::arg("param")
         )
         
         .def(
             "prettify_sample_name", 
-            &MaCh3Plotting::StyleManager::prettifyParamName, 
+            &M3::Plotting::StyleManager::prettifyParamName,
             "Convert internally used sample name to a nice pretty name that can be used in plots",
             py::arg("sample")
         )


### PR DESCRIPTION
# Pull request description
Plotting Manager didn't have implemented usage, which was problematic. In addition, if passed it didn't throw error instead segfault terribly. This is changed now.

In addition, unify namespace MaCh3Plotting → M3::Plotting

## Changes or fixes
- Contributing now documents suggested namespace convention
- Fix minor issues with README (pointed out by Alex)
## Examples
<img width="1456" height="592" alt="image" src="https://github.com/user-attachments/assets/b6c19eac-c94e-4ca8-8ac2-47c67b6d140a" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
