### PR TITLE
breaking: remove nominal

### DIFF
--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -387,7 +387,7 @@ void FitterBase::StartFromPreviousFit(const std::string& FitName) {
     systematics[s]->AcceptStep();
 
     MACH3LOG_INFO("Printing new starting values for: {}", systematics[s]->GetName());
-    systematics[s]->PrintNominalCurrProp();
+    systematics[s]->PrintPreFitCurrPropValues();
 
     // Resetting branch addressed to nullptr as we don't want to write into a delected vector out of scope...
     for (int i = 0; i < systematics[s]->GetNumParams(); ++i) {

--- a/Fitters/MCMCBase.cpp
+++ b/Fitters/MCMCBase.cpp
@@ -134,7 +134,7 @@ void MCMCBase::PrintProgress(bool StepsPrint) {
     }
 
     for (ParameterHandlerBase *cov : systematics) {
-        cov->PrintNominalCurrProp();
+        cov->PrintPreFitCurrPropValues();
     }
 #ifdef MACH3_DEBUG
     if (debug)

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -796,7 +796,7 @@ void ParameterHandlerBase::FlipParameterValue(const int index, const double Flip
 #pragma GCC diagnostic pop
 // ********************************************
 // Function to print the prior values
-void ParameterHandlerBase::PrintNominal() const {
+void ParameterHandlerBase::PrintPreFitValues() const {
 // ********************************************
   MACH3LOG_INFO("Prior values for {} ParameterHandler:", GetName());
   for (int i = 0; i < _fNumPar; i++) {
@@ -806,7 +806,7 @@ void ParameterHandlerBase::PrintNominal() const {
 
 // ********************************************
 // Function to print the prior, current and proposed values
-void ParameterHandlerBase::PrintNominalCurrProp() const {
+void ParameterHandlerBase::PrintPreFitCurrPropValues() const {
 // ********************************************
   MACH3LOG_INFO("Printing parameters for {}", GetName());
   // Dump out the PCA parameters too

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -245,12 +245,9 @@ class ParameterHandlerBase {
   }
 
   /// @brief Print prior value for every parameter
-  void PrintNominal() const;
+  void PrintPreFitValues() const;
   /// @brief Print prior, current and proposed value for each parameter
-  void PrintNominalCurrProp() const;
-  /// @warning only for backward compatibility
-  /// @todo remove it
-  void PrintParameters() const {PrintNominalCurrProp();};
+  void PrintPreFitCurrPropValues() const;
   /// @brief Print step scale for each parameter
   void PrintIndivStepScale() const;
 


### PR DESCRIPTION
# Pull request description
Simple renaming
```
PrintNominal->PrintPreFitValues
PrintNominalCurrProp->PrintPrefitCurrPropValues
```
merge first: https://github.com/mach3-software/MaCh3Tutorial/pull/240

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
