### PR TITLE
feat: Configurable bin width scaling in plotting lib

### DIFF
--- a/Plotting/PlotLLH.cpp
+++ b/Plotting/PlotLLH.cpp
@@ -13,16 +13,6 @@
 /// @ingroup MaCh3Plotting
 /// @author Ewan Miller
 
-// some options for the plots
-double ratioPlotSplit;
-double yTitleOffset;
-double sampleLabelThreshold;
-int lineWidth;
-bool totalOnSplitPlots;
-bool sameAxis;
-
-double ratioLabelScaling;
-
 /// @warning KS: keep raw pointer or ensure manual delete of PlotMan. If spdlog in automatically deleted before PlotMan then destructor has some spdlog and this could cause segfault
 M3::Plotting::PlottingManager *PlotMan;
 
@@ -31,6 +21,7 @@ void SetTPads(TPad*& LLHPad, TPad*& ratioPad)
 {
   int originalErrorLevel = gErrorIgnoreLevel;
   gErrorIgnoreLevel = kFatal;
+  auto ratioPlotSplit = PlotMan->getOption<double>("ratioPlotSplit");
   if (PlotMan->getPlotRatios())
   {
     LLHPad = new TPad("LLHPad", "LLHPad", 0.0, ratioPlotSplit, 1.0, 1.0);
@@ -47,12 +38,12 @@ void SetTPads(TPad*& LLHPad, TPad*& ratioPad)
   gErrorIgnoreLevel = originalErrorLevel;
 }
 
-void getSplitSampleStack(int fileIdx, std::string parameterName, TH1D LLH_allSams,
+void getSplitSampleStack(int fileIdx, const std::string& parameterName, const TH1D& LLH_allSams,
                          std::vector<float> &cumSums, std::vector<bool> &drawLabel,
                          THStack *sampleStack, TLegend *splitSamplesLegend,
                          float baselineLLH_main = 0.00001) 
 {
-  std::vector<std::string> sampNames = PlotMan->input().getTaggedSamples(PlotMan->getOption<std::vector<std::string>>("sampleTags"));
+  auto sampNames = PlotMan->input().getTaggedSamples(PlotMan->getOption<std::vector<std::string>>("sampleTags"));
   size_t nSamples = sampNames.size();
 
   cumSums.resize(nSamples);
@@ -99,7 +90,7 @@ void getSplitSampleStack(int fileIdx, std::string parameterName, TH1D LLH_allSam
     MACH3LOG_DEBUG("    LLH fraction = {} / {} = {}", LLH_indivSam->Integral(), LLH_main_integ, LLH_indivSam->Integral() / LLH_main_integ);
 
     cumSums[i] = cumSum;
-    
+    auto sampleLabelThreshold = PlotMan->getOption<double>("sampleLabelThreshold");
     // dont draw a label if the likelihood contribution is less than threshold%
     if ((LLH_indivSam->Integral() / LLH_main_integ > sampleLabelThreshold) &&
         (LLH_indivSam->Integral() / baselineLLH_main > sampleLabelThreshold))
@@ -120,6 +111,10 @@ void drawRatioStack(THStack *ratioCompStack) {
   double stackMin = ratioCompStack->GetMinimum("NOSTACK");
 
   double stackLim = std::max(std::abs(1.0 - stackMax), std::abs(1.0 - stackMin));
+  auto yTitleOffset = PlotMan->getOption<double>("yTitleOffset");
+  auto ratioPlotSplit = PlotMan->getOption<double>("ratioPlotSplit");
+  // scale the ratio plot labels by this much to make them same size as the normal plot
+  auto ratioLabelScaling = (1.0 / ratioPlotSplit - 1.0);
 
   ratioCompStack->SetMinimum(1.0 - 1.05 * stackLim);
   ratioCompStack->SetMaximum(1.0 + 1.05 * stackLim);
@@ -164,7 +159,7 @@ void makeLLHScanComparisons(const std::string& paramName,
   legend->AddEntry(&LLH_main, PlotMan->getFileLabel(0).c_str(), "l");
 
   int nBins = LLH_main.GetNbinsX();
-
+  int lineWidth = PlotMan->getOption<int>("lineWidth");
   // go through the other files
   for (unsigned int extraFileIdx = 1; extraFileIdx < PlotMan->input().getNInputFiles(); extraFileIdx++)
   {
@@ -199,7 +194,7 @@ void makeLLHScanComparisons(const std::string& paramName,
     compStack->Add(compHist);
     legend->AddEntry(compHist, PlotMan->getFileLabel(extraFileIdx).c_str(), "l");
   }
-
+  auto yTitleOffset = PlotMan->getOption<double>("yTitleOffset");
   // draw the log likelihoods
   canv->cd();
   canv->Draw();
@@ -283,6 +278,7 @@ void makeSplitSampleLLHScanComparisons(const std::string& paramName,
   gPad->Modified();
   gPad->Update();
 
+  bool totalOnSplitPlots = PlotMan->getOption<bool>("totalOnSplitPlots");
   if (totalOnSplitPlots)
   {
     LLH_main.SetLineWidth(1); // undo SetLineWidth that was done above
@@ -342,7 +338,7 @@ void makeSplitSampleLLHScanComparisons(const std::string& paramName,
       delete splitSamplesStack;
       continue;
     }
-
+    bool sameAxis = PlotMan->getOption<bool>("sameAxis");
     // if on the same y axis, also check that the contribution of the sample compared to the
     // baseline LLH integral is above the threshold otherwise the labels might get very crowded if
     // the comparisson LLH is much smaller than the baseline one
@@ -417,6 +413,7 @@ void makeSplitSampleLLHScanComparisons(const std::string& paramName,
   }
   canv->SaveAs(outputFileName.c_str());
   delete LLHPad;
+  delete ratioPad;
 }
 
 int PlotLLH() {
@@ -443,9 +440,9 @@ int PlotLLH() {
     // ###############################################################
     // First lets do just the straight up likelihoods from all samples
     // ###############################################################
-    makeLLHScanComparisons(paramName, "sample", PlotMan->getOutputName("_Sample"), canv);
+    makeLLHScanComparisons(paramName, "sample",  PlotMan->getOutputName("_Sample"), canv);
     makeLLHScanComparisons(paramName, "penalty", PlotMan->getOutputName("_Penalty"), canv);
-    makeLLHScanComparisons(paramName, "total", PlotMan->getOutputName("_Total"), canv);
+    makeLLHScanComparisons(paramName, "total",   PlotMan->getOutputName("_Total"), canv);
     // #########################################
     // ## now lets make plots split by sample ##
     // #########################################
@@ -472,18 +469,7 @@ int main(int argc, char **argv) {
 
   PlotMan = new M3::Plotting::PlottingManager();
   PlotMan->parseInputs(argc, argv);
-
   PlotMan->setExec("PlotLLH");
-
-  ratioPlotSplit = PlotMan->getOption<double>("ratioPlotSplit");
-  yTitleOffset = PlotMan->getOption<double>("yTitleOffset");
-  sampleLabelThreshold = PlotMan->getOption<double>("sampleLabelThreshold");
-  lineWidth = PlotMan->getOption<int>("lineWidth");
-  totalOnSplitPlots = PlotMan->getOption<bool>("totalOnSplitPlots");
-  sameAxis = PlotMan->getOption<bool>("sameAxis");
-
-  // scale the ratio plot labels by this much to make them same size as the normal plot
-  ratioLabelScaling = (1.0 / ratioPlotSplit - 1.0);
 
   if(PlotMan->getPlotRatios() && PlotMan->input().getNInputFiles() == 1){
     MACH3LOG_ERROR("Can't plot ratio with single file...");

--- a/Plotting/PlotSigmaVariation.cpp
+++ b/Plotting/PlotSigmaVariation.cpp
@@ -18,8 +18,6 @@ std::vector<double> sigmaArray;
 int PriorKnot = M3::_BAD_INT_;
 
 constexpr const int NVars = 5;
-constexpr const double ScalingFactor = 10;
-
 constexpr Color_t Colours[NVars] = {kRed, kGreen+1, kBlack, kBlue+1, kOrange+1};
 constexpr ELineStyle Style[NVars] = {kDotted, kDashed, kSolid, kDashDotted, kDashDotted};
 
@@ -313,8 +311,9 @@ void PlotRatio(const std::vector<std::unique_ptr<TH1D>>& Poly,
     Poly[ik]->SetLineWidth(2.);
     Poly[ik]->SetLineColor(Colours[ik]);
     Poly[ik]->SetLineStyle(Style[ik]);
-    Poly[ik]->GetYaxis()->SetTitle(fmt::format("Events/{:.0f}", ScalingFactor).c_str());
-    M3::ScaleHistogram(Poly[ik].get(), ScalingFactor);
+    auto BinWidthScale = PlotMan->style().getBinWidthScale(Poly[ik]->GetXaxis()->GetTitle());
+    Poly[ik]->GetYaxis()->SetTitle(fmt::format("Events/{:.0f}", BinWidthScale).c_str());
+    M3::ScaleHistogram(Poly[ik].get(), BinWidthScale);
     max = std::max(max, Poly[ik]->GetMaximum());
   }
   Poly[0]->SetTitle(Title.c_str());
@@ -715,11 +714,13 @@ void PlotSigVar1D(const std::vector<std::vector<std::unique_ptr<TH1D>>>& Project
 
   auto PriorHist = Projection[0][PriorKnot].get();
   PriorHist->SetTitle(Title.c_str());
-  PriorHist->GetYaxis()->SetTitle(fmt::format("Events/{:.0f}", ScalingFactor).c_str());
+
+  auto BinWidthScale = PlotMan->style().getBinWidthScale(PriorHist->GetXaxis()->GetTitle());
+  PriorHist->GetYaxis()->SetTitle(fmt::format("Events/{:.0f}", BinWidthScale).c_str());
   PriorHist->Draw("HIST");
   PriorHist->SetLineWidth(2.);
   PriorHist->SetLineColor(kBlack);
-  M3::ScaleHistogram(PriorHist, ScalingFactor);
+  M3::ScaleHistogram(PriorHist, BinWidthScale);
 
   auto PrettyX = PlotMan->style().prettifyKinematicName(PriorHist->GetXaxis()->GetTitle());
   PriorHist->GetXaxis()->SetTitle(PrettyX.c_str());
@@ -732,8 +733,8 @@ void PlotSigVar1D(const std::vector<std::vector<std::unique_ptr<TH1D>>>& Project
       Projection[nParam][ik]->SetLineWidth(2.);
       Projection[nParam][ik]->SetLineColor(ParamColour[nParam]);
       Projection[nParam][ik]->SetLineStyle(kDotted);
-      Projection[nParam][ik]->GetYaxis()->SetTitle(fmt::format("Events/{:.0f}", ScalingFactor).c_str());
-      M3::ScaleHistogram(Projection[nParam][ik].get(), ScalingFactor);
+      Projection[nParam][ik]->GetYaxis()->SetTitle(fmt::format("Events/{:.0f}", BinWidthScale).c_str());
+      M3::ScaleHistogram(Projection[nParam][ik].get(), BinWidthScale);
       max = std::max(max, Projection[nParam][ik]->GetMaximum());
     }
     PriorHist->SetMaximum(max*1.2);

--- a/Plotting/PlottingUtils/InputManager.h
+++ b/Plotting/PlottingUtils/InputManager.h
@@ -321,7 +321,7 @@ public:
   /// @brief Get the parameter value for the current step for a particular parameter from a particular input file.
   /// @param fileNum The index of the file you want the data from.
   /// @param paramName The parameter you want the value of.
-  double getMCMCvalue(int fileNum, std::string paramName) const {
+  double getMCMCvalue(int fileNum, const std::string& paramName) const {
     if (!getEnabledMCMCchain(fileNum, paramName))
     {
       MACH3LOG_WARN("file at index {} does not have an MCMC entry for parameter {}", fileNum, paramName);
@@ -422,7 +422,7 @@ public:
   /// @param LLHType The type of likelihood scan you would like to check for, e.h. total, prior etc.
   /// @return true if scan exists, false if not.
   inline bool getEnabledLLH(const int fileNum, const std::string& paramName,
-                             std::string LLHType = "total") const {
+                            const std::string& LLHType = "total") const {
     return _fileVec[fileNum].availableParams_map_LLH.at(LLHType).at(paramName);
   }
 

--- a/Plotting/PlottingUtils/PlottingManager.cpp
+++ b/Plotting/PlottingUtils/PlottingManager.cpp
@@ -213,11 +213,11 @@ void PlottingManager::usage() const {
   MACH3LOG_INFO("Options:");
   MACH3LOG_INFO("  -o <file>                   Output file name");
   MACH3LOG_INFO("  -l <labels>                 Comma/space-separated file labels");
-  //MACH3LOG_INFO("  -c <config>                 Configuration file name");
+  MACH3LOG_INFO("  -c <config>                 Configuration file name");
   //MACH3LOG_INFO("  -d <options>                Extra draw options");
   //MACH3LOG_INFO("  -s                          Split by sample");
   //MACH3LOG_INFO("  -r                          Plot ratios (requires multiple input files)");
-  //MACH3LOG_INFO("  -g                          Draw grid");
+  MACH3LOG_INFO("  -g                          Draw grid");
   MACH3LOG_INFO("  -h                          Show this help message");
 
   MACH3LOG_INFO("");

--- a/Plotting/PlottingUtils/PlottingManager.h
+++ b/Plotting/PlottingUtils/PlottingManager.h
@@ -18,7 +18,6 @@
 #include "InputManager.h"
 #include "StyleManager.h"
 
-
 namespace M3 {
 namespace Plotting {
 /// @brief The main class to be used in plotting scripts.
@@ -78,7 +77,7 @@ public:
   /// @brief Parse vector of command line arguments.
   /// @details This mainly just exists for the sake of the python binding.
   /// @param argv The arguments to parse.
-  inline void parseInputsVec(std::vector<std::string> argv) {
+  inline void parseInputsVec(const std::vector<std::string>& argv) {
     std::vector<char *> charVec;
     MACH3LOG_DEBUG("Parsing Inputs :: was given vector:");
     for( const std::string &arg : argv ) 

--- a/Plotting/PlottingUtils/StyleManager.cpp
+++ b/Plotting/PlottingUtils/StyleManager.cpp
@@ -2,7 +2,7 @@
 
 namespace M3 {
 namespace Plotting {
-StyleManager::StyleManager(std::string styleConfigName) {
+StyleManager::StyleManager(const std::string& styleConfigName) {
   _styleConfig = M3OpenConfig(styleConfigName);
 }
 
@@ -73,5 +73,13 @@ void StyleManager::setTH1Style(TH1 *hist, const std::string& styleName) const {
   hist->SetLineColor(GetFromManager<Color_t>(styleDef["LineColor"], kRed, __FILE__, __LINE__));
   hist->SetLineStyle(GetFromManager<Color_t>(styleDef["LineStyle"], 1, __FILE__, __LINE__));
 }
+
+double StyleManager::getBinWidthScale(const std::string &Name) const {
+  constexpr const double DefaultScalingFactor = 10;
+  if(!_styleConfig["BinWidthScaleFactor"]) return DefaultScalingFactor;
+
+  return GetFromManager<double>(_styleConfig["BinWidthScaleFactor"][Name], DefaultScalingFactor, __FILE__, __LINE__);
+}
+
 } // namespace Plotting
 } // namespace M3

--- a/Plotting/PlottingUtils/StyleManager.h
+++ b/Plotting/PlottingUtils/StyleManager.h
@@ -22,7 +22,7 @@ class StyleManager {
 public:
   /// @brief Constructor
   /// @param configName The style config to read from
-  StyleManager(std::string configName);
+  StyleManager(const std::string& configName);
   
   // NO COPYING!
   StyleManager( const StyleManager& ) = delete;
@@ -37,7 +37,7 @@ public:
   /// @param origName The "internal" name used to uniquely identify the parameter inside the
   /// plotting code
   /// @return A beautiful formatted name that can be used in plots
-  inline std::string prettifyParamName(const std::string &origName) const {
+  std::string prettifyParamName(const std::string &origName) const {
     return prettifyName(origName, "parameters");
   };
 
@@ -46,7 +46,7 @@ public:
   /// @param origName The "internal" name used to uniquely identify the sample inside the plotting
   /// code
   /// @return A beautiful formatted name that can be used in plots
-  inline std::string prettifySampleName(const std::string &origName) const {
+  std::string prettifySampleName(const std::string &origName) const {
     return prettifyName(origName, "samples");
   };
 
@@ -55,9 +55,13 @@ public:
   /// @param origName The "internal" name used to uniquely identify the kinematics inside the plotting
   /// code
   /// @return A beautiful formatted name that can be used in plots
-  inline std::string prettifyKinematicName(const std::string &origName) const {
+  std::string prettifyKinematicName(const std::string &origName) const {
     return prettifyName(origName, "kinematics");
   };
+
+  /// @brief Get bin-width scaling factor for a given kinematic variable
+  /// @param variable Name of the kinematic variable (e.g. RecoNeutrinoEnergy, TrueQ2)
+  double getBinWidthScale(const std::string &Name) const;
 
   // style setting options
   /// @brief Set the root colour palette to one of the default root pallettes as defined in (root

--- a/Plotting/PredictivePlotting.cpp
+++ b/Plotting/PredictivePlotting.cpp
@@ -12,8 +12,6 @@
 
 /// @warning KS: keep raw pointer or ensure manual delete of PlotMan. If spdlog in automatically deleted before PlotMan then destructor has some spdlog and this could cause segfault
 M3::Plotting::PlottingManager* PlotMan = nullptr;
-constexpr const double ScalingFactor = 10;
-
 std::vector<std::string> FindSamples(const std::string& File)
 {
   TFile *file = M3::Open(File, "READ", __FILE__, __LINE__);
@@ -263,9 +261,10 @@ void OverlayPredicitve(const YAML::Node& Settings,
       }
       TH1D* hist = InputFiles[0]->Get<TH1D>((DataLocation).c_str());
 
+      auto BinWidthScale = PlotMan->style().getBinWidthScale(hist->GetXaxis()->GetTitle());
       std::unique_ptr<TH1D> DataHist = M3::Clone(hist);
-      DataHist->GetYaxis()->SetTitle(fmt::format("Events/{:.0f}", ScalingFactor).c_str());
-      M3::ScaleHistogram(DataHist.get(), ScalingFactor);
+      DataHist->GetYaxis()->SetTitle(fmt::format("Events/{:.0f}", BinWidthScale).c_str());
+      M3::ScaleHistogram(DataHist.get(), BinWidthScale);
       DataHist->SetLineColor(kBlack);
       //KS: +1 for data, we want to get integral before scaling of the histogram
       std::vector<double> Integral(nFiles+1);
@@ -288,8 +287,8 @@ void OverlayPredicitve(const YAML::Node& Settings,
         PredHist[iFile]->SetMarkerColor(PosteriorColor[iFile]);
         PredHist[iFile]->SetFillColorAlpha(PosteriorColor[iFile], 0.35);
         PredHist[iFile]->SetFillStyle(1001);
-        PredHist[iFile]->GetYaxis()->SetTitle(fmt::format("Events/{:.0f}", ScalingFactor).c_str());
-        M3::ScaleHistogram(PredHist[iFile].get(), ScalingFactor);
+        PredHist[iFile]->GetYaxis()->SetTitle(fmt::format("Events/{:.0f}", BinWidthScale).c_str());
+        M3::ScaleHistogram(PredHist[iFile].get(), BinWidthScale);
       }
       pad1->cd();
 


### PR DESCRIPTION
# Pull request description
 Bin width scale was hard-coded, now let make it configurable but still by default return same value as before (so not breaking)

## Changes or fixes
- In `PlotLLH `remove plenty of global variables because they are really not useful, but it is easier to track code with fewer global.

## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
