### PR TITLE
feat: Additional Python Binding Utility

### DIFF
--- a/.github/workflows/CIPythonValidations.yml
+++ b/.github/workflows/CIPythonValidations.yml
@@ -34,6 +34,7 @@ jobs:
         virtualenv .venv 
         source .venv/bin/activate
         pip install --upgrade pip
+        pip install numpy
 
     - name: Install pytest
       env: 

--- a/.github/workflows/CIPythonValidations.yml
+++ b/.github/workflows/CIPythonValidations.yml
@@ -1,5 +1,5 @@
+---
 # Performs unit and integration testing
-
 name: Validations Python CI 
 
 ## The events that trigger the workflow
@@ -21,7 +21,6 @@ jobs:
       image: ghcr.io/mach3-software/mach3:alma9latest
 
     steps:
-    - uses: actions/checkout@v6
 
     - name: Upgrade pip
       run: pip install --upgrade pip
@@ -32,6 +31,9 @@ jobs:
         git clone https://github.com/mach3-software/MaCh3Tutorial.git MaCh3Validations
 
     - name: Install pytest
+      env: 
+        HEAD_REF: ${{ github.head_ref }}
+
       working-directory: /opt/MaCh3Validations
       run: |
         pip install -v --config-settings="cmake.args=-DMaCh3_Branch=$HEAD_REF" .[testing]

--- a/.github/workflows/CIPythonValidations.yml
+++ b/.github/workflows/CIPythonValidations.yml
@@ -34,18 +34,16 @@ jobs:
         virtualenv .venv 
         source .venv/bin/activate
         pip install --upgrade pip
-        pip list
 
     - name: Install pytest
       env: 
         HEAD_REF: ${{ github.head_ref }}
+        CMAKE_ARGS: "-DPYTHON_ENABLED=ON -DMaCh3_Branch=$HEAD_REF"
 
       working-directory: /opt/MaCh3Validations
       run: |
         source .venv/bin/activate
-        pip install -v --config-settings="cmake.args=-DMaCh3_Branch=$HEAD_REF" .[testing]
-        pip list
-
+        pip install -v .[testing]
       
     - name: Validations
       working-directory: /opt/MaCh3Validations

--- a/.github/workflows/CIPythonValidations.yml
+++ b/.github/workflows/CIPythonValidations.yml
@@ -2,12 +2,12 @@
 
 name: Validations Python CI 
 
-# The events that trigger the workflow
+## The events that trigger the workflow
 on:
   pull_request:
-    branches: [ main ]
-    
-  workflow_dispatch: 
+    branches: [ develop ]
+
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -24,16 +24,14 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Get MaCh3 Validations
-      env:
-        HEAD_REF: ${{ github.head_ref }}
       run: |
         cd /opt/
-        git clone --branch "$HEAD_REF" https://github.com/mach3-software/MaCh3Tutorial.git MaCh3Validations
+        git clone https://github.com/mach3-software/MaCh3Tutorial.git MaCh3Validations
 
-    - name: pip Install
+    - name: Install pytest
       working-directory: /opt/MaCh3Validations
       run: |
-        pip install -v .[testing]
+        pip install -v --config-settings="cmake.args=-DMaCh3_Branch=$HEAD_REF" .[testing]
         
     - name: Validations
       working-directory: /opt/MaCh3Validations

--- a/.github/workflows/CIPythonValidations.yml
+++ b/.github/workflows/CIPythonValidations.yml
@@ -50,5 +50,6 @@ jobs:
       run: |
         source .venv/bin/activate
         export MACH3=$PWD
+        source /opt/root/v6-26-10/bin/thisroot.sh
         pytest --config TutorialConfigs/FitterConfig.yaml CIValidations/PythonTests
         

--- a/.github/workflows/CIPythonValidations.yml
+++ b/.github/workflows/CIPythonValidations.yml
@@ -44,7 +44,8 @@ jobs:
       run: |
         source .venv/bin/activate
         pip install -v --config-settings="cmake.args=-DMaCh3_Branch=$HEAD_REF" .[testing]
-        
+        pip list
+
       
     - name: Validations
       working-directory: /opt/MaCh3Validations

--- a/.github/workflows/CIPythonValidations.yml
+++ b/.github/workflows/CIPythonValidations.yml
@@ -37,8 +37,7 @@ jobs:
 
     - name: Install pytest
       env: 
-        HEAD_REF: ${{ github.head_ref }}
-        CMAKE_ARGS: "-DPYTHON_ENABLED=ON -DMaCh3_Branch=$HEAD_REF"
+        CMAKE_ARGS: "-DPYTHON_ENABLED=ON -DMaCh3_Branch=${{ github.head_ref }}"
 
       working-directory: /opt/MaCh3Validations
       run: |

--- a/.github/workflows/CIPythonValidations.yml
+++ b/.github/workflows/CIPythonValidations.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: Upgrade pip
+      run: pip install --upgrade pip
+
     - name: Get MaCh3 Validations
       run: |
         cd /opt/

--- a/.github/workflows/CIPythonValidations.yml
+++ b/.github/workflows/CIPythonValidations.yml
@@ -2,12 +2,12 @@
 
 name: Validations Python CI 
 
-## The events that trigger the workflow
+# The events that trigger the workflow
 on:
   pull_request:
-    branches: [ develop ]
-
-  workflow_dispatch:
+    branches: [ main ]
+    
+  workflow_dispatch: 
 
 permissions:
   contents: read
@@ -23,26 +23,22 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Install pyMaCh3
-      run: |
-        mkdir /python-test-modules
-        pip install .
-        
     - name: Get MaCh3 Validations
+      env:
+        HEAD_REF: ${{ github.head_ref }}
       run: |
         cd /opt/
-        git clone https://github.com/mach3-software/MaCh3Tutorial.git MaCh3Validations
+        git clone --branch "$HEAD_REF" https://github.com/mach3-software/MaCh3Tutorial.git MaCh3Validations
 
-    - name: Install pytest
+    - name: pip Install
       working-directory: /opt/MaCh3Validations
       run: |
-        pip install -r ./CIValidations/PythonTests/requirements.txt
+        pip install -v .[testing]
         
     - name: Validations
       working-directory: /opt/MaCh3Validations
       run: |
         source /opt/root/v6-26-10/bin/thisroot.sh
-        export PYTHONPATH=$PYTHONPATH:/python-test-modules/
         export MACH3=$PWD
         
         python3 -m pytest --config TutorialConfigs/FitterConfig.yaml CIValidations/PythonTests

--- a/.github/workflows/CIPythonValidations.yml
+++ b/.github/workflows/CIPythonValidations.yml
@@ -43,13 +43,13 @@ jobs:
       working-directory: /opt/MaCh3Validations
       run: |
         source .venv/bin/activate
-        pip install -v .[testing]
+        pip install -v ".[testing]"
       
     - name: Validations
       working-directory: /opt/MaCh3Validations
       run: |
         source .venv/bin/activate
         export MACH3=$PWD
-        source /opt/root/v6-26-10/bin/thisroot.sh
+        source $ROOTSYS/bin/thisroot.sh
         pytest --config TutorialConfigs/FitterConfig.yaml CIValidations/PythonTests
         

--- a/.github/workflows/CIPythonValidations.yml
+++ b/.github/workflows/CIPythonValidations.yml
@@ -38,11 +38,14 @@ jobs:
       run: |
         pip install -v --config-settings="cmake.args=-DMaCh3_Branch=$HEAD_REF" .[testing]
         
+    - name: DEBUG DELETE ME
+      run: pip list
+      
     - name: Validations
       working-directory: /opt/MaCh3Validations
       run: |
         source /opt/root/v6-26-10/bin/thisroot.sh
         export MACH3=$PWD
-        
+
         python3 -m pytest --config TutorialConfigs/FitterConfig.yaml CIValidations/PythonTests
         

--- a/.github/workflows/CIPythonValidations.yml
+++ b/.github/workflows/CIPythonValidations.yml
@@ -22,13 +22,18 @@ jobs:
 
     steps:
 
-    - name: Upgrade pip
-      run: pip install --upgrade pip
-
     - name: Get MaCh3 Validations
       run: |
         cd /opt/
         git clone https://github.com/mach3-software/MaCh3Tutorial.git MaCh3Validations
+
+    - name: Setup virtual env
+      working-directory: /opt/MaCh3Validations
+      run: |
+        pip install virtualenv
+        virtualenv .venv 
+        source .venv/bin/activate
+        pip install --upgrade pip
 
     - name: Install pytest
       env: 
@@ -36,16 +41,14 @@ jobs:
 
       working-directory: /opt/MaCh3Validations
       run: |
+        source .venv/bin/activate
         pip install -v --config-settings="cmake.args=-DMaCh3_Branch=$HEAD_REF" .[testing]
         
-    - name: DEBUG DELETE ME
-      run: pip list
       
     - name: Validations
       working-directory: /opt/MaCh3Validations
       run: |
-        source /opt/root/v6-26-10/bin/thisroot.sh
+        source .venv/bin/activate
         export MACH3=$PWD
-
-        python3 -m pytest --config TutorialConfigs/FitterConfig.yaml CIValidations/PythonTests
+        pytest --config TutorialConfigs/FitterConfig.yaml CIValidations/PythonTests
         

--- a/.github/workflows/CIPythonValidations.yml
+++ b/.github/workflows/CIPythonValidations.yml
@@ -50,6 +50,6 @@ jobs:
       run: |
         source .venv/bin/activate
         export MACH3=$PWD
-        source $ROOTSYS/bin/thisroot.sh
+        source "$ROOTSYS/bin/thisroot.sh"
         pytest --config TutorialConfigs/FitterConfig.yaml CIValidations/PythonTests
         

--- a/.github/workflows/CIPythonValidations.yml
+++ b/.github/workflows/CIPythonValidations.yml
@@ -34,6 +34,7 @@ jobs:
         virtualenv .venv 
         source .venv/bin/activate
         pip install --upgrade pip
+        pip list
 
     - name: Install pytest
       env: 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 # CMake version check
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
-project(MaCh3 VERSION 2.5.0 LANGUAGES CXX)
+project(MaCh3 VERSION 2.5.1 LANGUAGES CXX)
 set(MaCh3_VERSION ${PROJECT_VERSION})
 
 option(MaCh3_PYTHON_ENABLED "Whether to build MaCh3 python bindings" OFF)

--- a/python/parameters.h
+++ b/python/parameters.h
@@ -169,13 +169,15 @@ void initParametersModule(py::module &m_parameters){
         .def("get_par_error", &ParameterHandlerBase::GetDiagonalError, py::arg("index"), "The prior error on parameter at index i \n\
             :param index: index of the parameter")
 
-        .def("get_par_fixed", &ParameterHandlerBase::IsParameterFixed, py::arg("index"), "Is the parameter at index i fixed \n\
+        .def("get_par_fixed", static_cast<bool (ParameterHandlerBase::*)(const int) const>(&ParameterHandlerBase::IsParameterFixed), py::arg("index"), "Is the parameter at index i fixed \n\
              :param index: index of the parameter")
 
         .def("get_prior_cov", [](ParameterHandlerBase &self)
              {
-                 auto mat = self.GetCovMatrix()'
-                 ;'
+                 auto mat = self.GetCovMatrix();
+                 if (!mat){
+                     throw std::runtime_error("TMatrixDSym pointer is null");
+                 }
                  int n = mat->GetNrows();
                  const double *data = mat->GetMatrixArray();
                  py::array_t<float> result({n, n});

--- a/python/parameters.h
+++ b/python/parameters.h
@@ -157,20 +157,30 @@ void initParametersModule(py::module &m_parameters){
                  >>> handler.set_parameters()
              )pbdoc")
 
-        .def("get_lower_bound", &ParameterHandlerBase::GetLowerBound, py::arg("index"), "Get the lower bound of parameter at index i. \n\
+             
+        .def("get_par_init", &ParameterHandlerBase::GetParInit, py::arg("index"),
+            "Get initial value of parameter at index i\n\
             :param index: index of the parameter")
 
-        .def("get_upper_bound", &ParameterHandlerBase::GetUpperBound, py::arg("index"), "Get the upper bound of parameter at index i. \n\
+        .def("get_lower_bound", &ParameterHandlerBase::GetLowerBound, py::arg("index"), 
+            "Get the lower bound of parameter at index i. \n\
+            :param index: index of the parameter")
+             
+        .def("get_upper_bound", &ParameterHandlerBase::GetUpperBound, py::arg("index"), 
+            "Get the upper bound of parameter at index i. \n\
             :param index: index of the parameter")
 
-        .def("get_flat_prior", &ParameterHandlerBase::GetFlatPrior, py::arg("index"), "Is the parameter at index i flat?. \n\
+        .def("get_flat_prior", &ParameterHandlerBase::GetFlatPrior, py::arg("index"), 
+            "Is the parameter at index i flat?. \n\
             :param index: index of the parameter")
 
-        .def("get_par_error", &ParameterHandlerBase::GetDiagonalError, py::arg("index"), "The prior error on parameter at index i \n\
+        .def("get_par_error", &ParameterHandlerBase::GetDiagonalError, py::arg("index"), 
+            "The prior error on parameter at index i \n\
             :param index: index of the parameter")
 
-        .def("get_par_fixed", static_cast<bool (ParameterHandlerBase::*)(const int) const>(&ParameterHandlerBase::IsParameterFixed), py::arg("index"), "Is the parameter at index i fixed \n\
-             :param index: index of the parameter")
+        .def("get_par_fixed", static_cast<bool (ParameterHandlerBase::*)(const int) const>(&ParameterHandlerBase::IsParameterFixed), py::arg("index"), 
+            "Is the parameter at index i fixed \n\
+            :param index: index of the parameter")
 
         .def("get_prior_cov", [](ParameterHandlerBase &self)
              {

--- a/python/parameters.h
+++ b/python/parameters.h
@@ -157,28 +157,24 @@ void initParametersModule(py::module &m_parameters){
                  >>> handler.set_parameters()
              )pbdoc")
 
-        .def("get_lower_bound", &ParameterHandlerBase::GetLowerBound, py::arg(index), 
-            "Get the lower bound of parameter at index i. \n\
+        .def("get_lower_bound", &ParameterHandlerBase::GetLowerBound, py::arg(index), "Get the lower bound of parameter at index i. \n\
             :param index: index of the parameter")
 
-        .def("get_upper_bound", &ParameterHandlerBase::GetUpperBound, py::arg(index), 
-            "Get the upper bound of parameter at index i. \n\
+        .def("get_upper_bound", &ParameterHandlerBase::GetUpperBound, py::arg(index), "Get the upper bound of parameter at index i. \n\
             :param index: index of the parameter")
 
-        .def("get_flat_prior", &ParameterHandlerBase::GetFlatPrior, py::arg(index),
-             "Is the parameter at index i flat?. \n\
+        .def("get_flat_prior", &ParameterHandlerBase::GetFlatPrior, py::arg(index), "Is the parameter at index i flat?. \n\
             :param index: index of the parameter")
 
-        .def("get_par_error", &ParameterHandlerBase::GetDiagonalError, py::arg(index),
-             "The prior error on parameter at index i \n\
+        .def("get_par_error", &ParameterHandlerBase::GetDiagonalError, py::arg(index), "The prior error on parameter at index i \n\
             :param index: index of the parameter")
 
-        .def("get_par_fixed", &ParameterHandlerBase::IsParameterFixed, py::arg(index), 
-            "Is the parameter at index i fixed \n\
+        .def("get_par_fixed", &ParameterHandlerBase::IsParameterFixed, py::arg(index), "Is the parameter at index i fixed \n\
              :param index: index of the parameter")
 
         .def("get_prior_cov", [](ParameterHandlerBase &self)
              {
+                 auto mat = self.GetCovMatrix()
                  int n = mat->GetNrows();
                  const double *data = mat->GetMatrixArray();
                  py::array_t<float> result({n, n});
@@ -188,10 +184,9 @@ void initParametersModule(py::module &m_parameters){
                                 [](double v)
                                 { return static_cast<float>(v); });
 
-                 return result;
-             },
+                 return result; },
              "Get the prior covariance")
-             
+
         ; // End of ParameterHandlerBase binding
 
     py::class_<ParameterHandlerGeneric, ParameterHandlerBase /* <--- trampoline*/>(m_parameters, "ParameterHandlerGeneric")

--- a/python/parameters.h
+++ b/python/parameters.h
@@ -157,24 +157,25 @@ void initParametersModule(py::module &m_parameters){
                  >>> handler.set_parameters()
              )pbdoc")
 
-        .def("get_lower_bound", &ParameterHandlerBase::GetLowerBound, py::arg(index), "Get the lower bound of parameter at index i. \n\
+        .def("get_lower_bound", &ParameterHandlerBase::GetLowerBound, py::arg("index"), "Get the lower bound of parameter at index i. \n\
             :param index: index of the parameter")
 
-        .def("get_upper_bound", &ParameterHandlerBase::GetUpperBound, py::arg(index), "Get the upper bound of parameter at index i. \n\
+        .def("get_upper_bound", &ParameterHandlerBase::GetUpperBound, py::arg("index"), "Get the upper bound of parameter at index i. \n\
             :param index: index of the parameter")
 
-        .def("get_flat_prior", &ParameterHandlerBase::GetFlatPrior, py::arg(index), "Is the parameter at index i flat?. \n\
+        .def("get_flat_prior", &ParameterHandlerBase::GetFlatPrior, py::arg("index"), "Is the parameter at index i flat?. \n\
             :param index: index of the parameter")
 
-        .def("get_par_error", &ParameterHandlerBase::GetDiagonalError, py::arg(index), "The prior error on parameter at index i \n\
+        .def("get_par_error", &ParameterHandlerBase::GetDiagonalError, py::arg("index"), "The prior error on parameter at index i \n\
             :param index: index of the parameter")
 
-        .def("get_par_fixed", &ParameterHandlerBase::IsParameterFixed, py::arg(index), "Is the parameter at index i fixed \n\
+        .def("get_par_fixed", &ParameterHandlerBase::IsParameterFixed, py::arg("index"), "Is the parameter at index i fixed \n\
              :param index: index of the parameter")
 
         .def("get_prior_cov", [](ParameterHandlerBase &self)
              {
-                 auto mat = self.GetCovMatrix()
+                 auto mat = self.GetCovMatrix()'
+                 ;'
                  int n = mat->GetNrows();
                  const double *data = mat->GetMatrixArray();
                  py::array_t<float> result({n, n});

--- a/python/parameters.h
+++ b/python/parameters.h
@@ -49,10 +49,9 @@ void initParametersModule(py::module &m_parameters){
             .value("Functional", SystType::kFunc)
             .value("N_Systematic_Types", SystType::kSystTypes);
 
-        
     py::class_<ParameterHandlerBase, PyParameterHandlerBase /* <--- trampoline*/>(m_parameters, "ParameterHandlerBase")
         .def(
-            py::init<const std::vector<std::string>&, const char *, M3::float_t, int, int>(),
+            py::init<const std::vector<std::string> &, const char *, M3::float_t, int, int>(),
             "Construct a parameters object from a set of yaml files that define the systematic parameters \n\
             :param yaml_files: The name of the yaml file to initialise from. \n\
             :param name: the name of this ParameterHandler object. \n\
@@ -63,14 +62,12 @@ void initParametersModule(py::module &m_parameters){
             py::arg("name"),
             py::arg("threshold") = -1.0,
             py::arg("firs_PCA_par") = -999,
-            py::arg("last_PCA_par") = -999
-        )
-        
+            py::arg("last_PCA_par") = -999)
+
         .def(
-            "calculate_likelihood", 
+            "calculate_likelihood",
             &ParameterHandlerBase::CalcLikelihood,
-            "Calculate penalty term based on inverted covariance matrix."
-        )
+            "Calculate penalty term based on inverted covariance matrix.")
 
         .def(
             "get_internal_par_name",
@@ -83,9 +80,8 @@ void initParametersModule(py::module &m_parameters){
             },
             "Get the internally used name of this parameter. \n\
             :param index: The global index of the parameter",
-            py::arg("index")
-        )
-        
+            py::arg("index"))
+
         .def(
             "get_fancy_par_name",
             [](ParameterHandlerBase &self, int index)
@@ -97,20 +93,17 @@ void initParametersModule(py::module &m_parameters){
             },
             "Get the name of this parameter. \n\
             :param index: The global index of the parameter",
-            py::arg("index")
-        )
+            py::arg("index"))
 
         .def(
             "get_n_pars",
             &ParameterHandlerBase::GetNParameters,
-            "Get the number of parameters that this ParameterHandler object knows about."
-        )
-        
+            "Get the number of parameters that this ParameterHandler object knows about.")
+
         .def(
             "propose_step",
             &ParameterHandlerBase::ProposeStep,
-            "Propose a step based on the covariances. Also feel free to overwrite if you want something more funky."
-        )
+            "Propose a step based on the covariances. Also feel free to overwrite if you want something more funky.")
 
         .def(
             "get_proposal_array",
@@ -135,20 +128,17 @@ void initParametersModule(py::module &m_parameters){
             },
             "Get the parameter proposal values as a numpy array. \n\
             This returns a copy of the current proposal values. \n\
-            :return: A numpy array containing the proposal values for all parameters."
-        )
+            :return: A numpy array containing the proposal values for all parameters.")
 
-        .def("set_parameters", 
-             [](ParameterHandlerBase& self, py::object pars_obj = py::none()) {
+        .def("set_parameters", [](ParameterHandlerBase &self, py::object pars_obj = py::none())
+             {
                  if (pars_obj.is_none()) {
                      self.SetParameters();
                  } else {
                      // This handles both numpy arrays and Python lists
                      std::vector<double> pars_vec = pars_obj.cast<std::vector<double>>();
                      self.SetParameters(pars_vec);
-                 }
-             },
-             py::arg("pars") = py::none(),
+                 } }, py::arg("pars") = py::none(),
              R"pbdoc(
                  Set parameter values using array.
                  
@@ -167,9 +157,43 @@ void initParametersModule(py::module &m_parameters){
                  >>> handler.set_parameters()
              )pbdoc")
 
-    ; // End of ParameterHandlerBase binding
+        .def("get_lower_bound", &ParameterHandlerBase::GetLowerBound, py::arg(index), 
+            "Get the lower bound of parameter at index i. \n\
+            :param index: index of the parameter")
 
-    
+        .def("get_upper_bound", &ParameterHandlerBase::GetUpperBound, py::arg(index), 
+            "Get the upper bound of parameter at index i. \n\
+            :param index: index of the parameter")
+
+        .def("get_flat_prior", &ParameterHandlerBase::GetFlatPrior, py::arg(index),
+             "Is the parameter at index i flat?. \n\
+            :param index: index of the parameter")
+
+        .def("get_par_error", &ParameterHandlerBase::GetDiagonalError, py::arg(index),
+             "The prior error on parameter at index i \n\
+            :param index: index of the parameter")
+
+        .def("get_par_fixed", &ParameterHandlerBase::IsParameterFixed, py::arg(index), 
+            "Is the parameter at index i fixed \n\
+             :param index: index of the parameter")
+
+        .def("get_prior_cov", [](ParameterHandlerBase &self)
+             {
+                 int n = mat->GetNrows();
+                 const double *data = mat->GetMatrixArray();
+                 py::array_t<float> result({n, n});
+                 // Shove matrix into the array
+                 std::transform(data, data + n * n,
+                                result.mutable_data(),
+                                [](double v)
+                                { return static_cast<float>(v); });
+
+                 return result;
+             },
+             "Get the prior covariance")
+             
+        ; // End of ParameterHandlerBase binding
+
     py::class_<ParameterHandlerGeneric, ParameterHandlerBase /* <--- trampoline*/>(m_parameters, "ParameterHandlerGeneric")
         .def(
             py::init<const std::vector<std::string>&, const char *, M3::float_t, int, int>(),

--- a/python/samples.h
+++ b/python/samples.h
@@ -122,17 +122,6 @@ public:
     }
 
     /* Trampoline (need one for each virtual function) */
-    M3::int_t GetNSamples(const int iSample) const override
-    {
-        PYBIND11_OVERRIDE_PURE(
-            M3::int_t,              /* Return type */
-            SampleHandlerInterface, /* Parent class */
-            GetNSamples,            /* Name of function in C++ (must match Python name) */
-            iSample                 /* Argument(s) */
-        );
-    }
-
-    /* Trampoline (need one for each virtual function) */
     int GetNOscChannels(const int iSample) const override {
         PYBIND11_OVERRIDE_PURE(
             int,                     /* Return type */

--- a/python/samples.h
+++ b/python/samples.h
@@ -122,6 +122,17 @@ public:
     }
 
     /* Trampoline (need one for each virtual function) */
+    M3::int_t GetNSamples(const int iSample) const override
+    {
+        PYBIND11_OVERRIDE_PURE(
+            M3::int_t,              /* Return type */
+            SampleHandlerInterface, /* Parent class */
+            GetNSamples,            /* Name of function in C++ (must match Python name) */
+            iSample                 /* Argument(s) */
+        );
+    }
+
+    /* Trampoline (need one for each virtual function) */
     int GetNOscChannels(const int iSample) const override {
         PYBIND11_OVERRIDE_PURE(
             int,                     /* Return type */
@@ -433,26 +444,29 @@ void initSamplesModule(py::module &m_samples){
 
     py::class_<SampleHandlerInterface, PySampleHandlerInterface /* <--- trampoline*/>(m_samples, "SampleHandlerInterface")
         .def(py::init())
-        
+
         .def(
-            "reweight", 
+            "reweight",
             &SampleHandlerInterface::Reweight,
-            "reweight the MC events in this sample. You will need to override this."
-        )
-        
+            "reweight the MC events in this sample. You will need to override this.")
+
         .def(
-            "get_likelihood", 
-            &SampleHandlerInterface::GetLikelihood,
-            "Get the sample likelihood at the current point in your model space. You will need to override this."
+            "get_n_samples",
+            &SampleHandlerInterface::GetNSamples,
+            "Get the total number of samples"
         )
-        
+
+        .def(
+            "get_likelihood",
+            &SampleHandlerInterface::GetLikelihood,
+            "Get the sample likelihood at the current point in your model space. You will need to override this.")
+
         .def(
             "set_test_stat",
             &SampleHandlerInterface::SetTestStatistic,
             "Set the test statistic that should be used when calculating likelihoods. \n\
             :param test_stat: The new test statistic to use",
-            py::arg("test_stat")
-        )
+            py::arg("test_stat"))
 
         .def(
             "get_bin_LLH",
@@ -461,16 +475,16 @@ void initSamplesModule(py::module &m_samples){
             :param data: The data content of the bin. \n\
             :param mc: The mc content of the bin \n\
             :param w2: The Sum(w_{i}^2) (sum of weights squared) in the bin, which is sigma^2_{MC stats}",
-            py::arg("data"), 
-            py::arg("mc"), 
-            py::arg("w2")
-        )
-    ; // End of SampleHandlerInterface binding
+            py::arg("data"),
+            py::arg("mc"),
+            py::arg("w2"))
 
-    py::class_<SampleHandlerBase, PySampleHandlerBase /* <--- trampoline*/, 
-            SampleHandlerInterface>(m_samples, "SampleHandlerBase")
+        ; // End of SampleHandlerInterface binding
+
+    py::class_<SampleHandlerBase, PySampleHandlerBase /* <--- trampoline*/,
+               SampleHandlerInterface>(m_samples, "SampleHandlerBase")
         .def(
-            py::init<std::string, ParameterHandlerGeneric*>(),
+            py::init<std::string, ParameterHandlerGeneric *>(),
             "This should never be called directly as SampleHandlerBase is an abstract base class. \n\
             However when creating a derived class, in the __init__() method, you should call the parent constructor i.e. this one by doing:: \n\
             \n\
@@ -478,51 +492,81 @@ void initSamplesModule(py::module &m_samples){
             \n ",
             py::arg("mc_version"), py::arg("xsec_cov"))
 
+        .def("get_data_array", [](SampleHandlerBase & self, const int sample){
+                // Get the MC bin contents ignoring bin edges 
+                return self.GetDataArray(sample);
+            },    
+            py::arg("sample"),
+            "Returns the contents of the Data histogram as a flat list"
+        )
+            
+        .def("get_mc_array", [](SampleHandlerBase & self, const int sample){
+                // Get the MC bin contents ignoring bin edges 
+                return self.GetMCArray(sample);
+            },    
+            py::arg("sample"),
+            "Returns the contents of the MC histogram as a flat list"
+        )
+
+        .def("get_w2_array", [](SampleHandlerBase & self, const int sample){
+                // Get the MC bin contents ignoring bin edges
+                return self.GetW2Array(sample);
+            },    
+            py::arg("sample"),
+            "Returns the contents of the W2 histogram as a flat list"
+        )
+
         .def(
             "get_mc_hist",
-            [](SampleHandlerBase &self, const int sample) {
+            [](SampleHandlerBase &self, const int sample)
+            {
+                int Dimension = self.GetNDim(sample);
 
-              int Dimension = self.GetNDim(sample);
+                // self.Reweight();
 
-              //self.Reweight();
-              
-              // Get the histogram pointer BEFORE cloning
-              const TH1 *hist_original = self.GetMCHist(sample);
-              
-              // Debug: Check the original histogram
-              if (!hist_original) {
-                throw std::runtime_error("GetMCHist returned null pointer");
-              }
-              
-              // Now clone it
-              TH1D *hist = static_cast<TH1D*>(hist_original->Clone("cloned_hist"));
+                // Get the histogram pointer BEFORE cloning
+                const TH1 *hist_original = self.GetMCHist(sample);
 
-              if (Dimension == 1) {
-                // 1D histogram
-                auto [contents, edgesX] = TH1ToNumpy(hist);
-                auto edgesY = py::array_t<M3::float_t>();
-                return py::make_tuple(contents, edgesX, edgesY);
-              } else if (Dimension == 2) {
-
-                TH2Poly *hist2poly = dynamic_cast<TH2Poly *>(hist);
-                if (hist2poly) {
-                    /// @todo Deal with non uniform binning
-                    throw std::runtime_error("pyMaCh3 can't do non-uniform binning for now :(");
+                // Debug: Check the original histogram
+                if (!hist_original)
+                {
+                    throw std::runtime_error("GetMCHist returned null pointer");
                 }
 
-                // 2D histogram - cast to TH2
-                TH2 *hist2d = dynamic_cast<TH2 *>(hist);
-                if (!hist2d) {
-                  throw std::runtime_error("Failed to cast to TH2");
+                // Now clone it
+                TH1D *hist = static_cast<TH1D *>(hist_original->Clone("cloned_hist"));
+
+                if (Dimension == 1)
+                {
+                    // 1D histogram
+                    auto [contents, edgesX] = TH1ToNumpy(hist);
+                    auto edgesY = py::array_t<M3::float_t>();
+                    return py::make_tuple(contents, edgesX, edgesY);
+                } else if (Dimension == 2)
+                {
+
+                    TH2Poly *hist2poly = dynamic_cast<TH2Poly *>(hist);
+                    if (hist2poly)
+                    {
+                        /// @todo Deal with non uniform binning
+                        throw std::runtime_error("pyMaCh3 can't do non-uniform binning for now :(");
+                    }
+
+                    // 2D histogram - cast to TH2
+                    TH2 *hist2d = dynamic_cast<TH2 *>(hist);
+                    if (!hist2d)
+                    {
+                        throw std::runtime_error("Failed to cast to TH2");
+                    }
+                    auto [contents, edgesX, edgesY] = TH2ToNumpy(hist2d);
+                    return py::make_tuple(contents, edgesX, edgesY);
+                } else
+                {
+                    /// @todo Deal with higher dimensions
+                    /// MaCh3 returns flattened bins, will need to figure out how
+                    /// to pass bin edge info into python
+                    throw std::invalid_argument("Dimension must be 1 or 2");
                 }
-                auto [contents, edgesX, edgesY] = TH2ToNumpy(hist2d);
-                return py::make_tuple(contents, edgesX, edgesY);
-              } else {
-                /// @todo Deal with higher dimensions
-                /// MaCh3 returns flattened bins, will need to figure out how
-                /// to pass bin edge info into python
-                throw std::invalid_argument("Dimension must be 1 or 2");
-              }
             },
             py::return_value_policy::reference_internal,
             py::arg("sample"),
@@ -533,40 +577,47 @@ void initSamplesModule(py::module &m_samples){
 
         .def(
             "get_data_hist",
-            [](SampleHandlerBase &self, const int sample) {
-              const TH1 *hist = self.GetDataHist(sample);
+            [](SampleHandlerBase &self, const int sample)
+            {
+                const TH1 *hist = self.GetDataHist(sample);
 
-              int Dimension = self.GetNDim(sample);
-              
-              if (Dimension == 1) {
-                // 1D histogram
-                const auto [contents, edgesX] = TH1ToNumpy(hist);
-                const auto edgesY = py::array_t<M3::float_t>();
-                return py::make_tuple(contents, edgesX, edgesY);
-              } else if (Dimension == 2) {
+                int Dimension = self.GetNDim(sample);
 
-                const TH2Poly *hist2poly = dynamic_cast<const TH2Poly *>(hist);
-                if (hist2poly) {
+                if (Dimension == 1)
+                {
+                    // 1D histogram
+                    const auto [contents, edgesX] = TH1ToNumpy(hist);
+                    const auto edgesY = py::array_t<M3::float_t>();
+                    return py::make_tuple(contents, edgesX, edgesY);
+                }
+                else if (Dimension == 2)
+                {
+
+                    const TH2Poly *hist2poly = dynamic_cast<const TH2Poly *>(hist);
+                    if (hist2poly)
+                    {
+                        /// @todo Deal with non uniform binning
+                        throw std::runtime_error("pyMaCh3 can't do non-uniform binning for now :(");
+                    }
+
                     /// @todo Deal with non uniform binning
                     throw std::runtime_error("pyMaCh3 can't do non-uniform binning for now :(");
-                }
-                
-                /// @todo Deal with non uniform binning
-                throw std::runtime_error("pyMaCh3 can't do non-uniform binning for now :(");
 
-                // 2D histogram - cast to TH2
-                const TH2 *hist2d = dynamic_cast<const TH2 *>(hist);
-                if (!hist2d) {
-                  throw std::runtime_error("Failed to cast to TH2");
+                    // 2D histogram - cast to TH2
+                    const TH2 *hist2d = dynamic_cast<const TH2 *>(hist);
+                    if (!hist2d)
+                    {
+                        throw std::runtime_error("Failed to cast to TH2");
+                    }
+                    const auto [contents, edgesX, edgesY] = TH2ToNumpy(hist2d);
+                    return py::make_tuple(contents, edgesX, edgesY);
+                } else
+                {
+                    /// @todo Deal with higher dimensions
+                    /// MaCh3 returns flattened bins, will need to figure out how
+                    /// to pass bin edge info into python
+                    throw std::invalid_argument("Dimension must be 1 or 2");
                 }
-                const auto [contents, edgesX, edgesY] = TH2ToNumpy(hist2d);
-                return py::make_tuple(contents, edgesX, edgesY);
-              } else {
-                /// @todo Deal with higher dimensions
-                /// MaCh3 returns flattened bins, will need to figure out how
-                /// to pass bin edge info into python
-                throw std::invalid_argument("Dimension must be 1 or 2");
-              }
             },
             py::arg("Dimension"),
             "Get Data histogram as numpy arrays.\n"
@@ -576,37 +627,44 @@ void initSamplesModule(py::module &m_samples){
 
         .def(
             "get_w2_hist",
-            [](SampleHandlerBase &self, const int sample) {
-              const TH1 *hist = self.GetW2Hist(sample);
+            [](SampleHandlerBase &self, const int sample)
+            {
+                const TH1 *hist = self.GetW2Hist(sample);
 
-              int Dimension = self.GetNDim(sample);
+                int Dimension = self.GetNDim(sample);
 
-              if (Dimension == 1) {
-                // 1D histogram
-                const auto [contents, edgesX] = TH1ToNumpy(hist);
-                const auto edgesY = py::array_t<M3::float_t>();
-                return py::make_tuple(contents, edgesX, edgesY);
-              } else if (Dimension == 2) {
-
-                const TH2Poly *hist2poly = dynamic_cast<const TH2Poly *>(hist);
-                if (hist2poly) {
-                    /// @todo Deal with non uniform binning
-                    throw std::runtime_error("pyMaCh3 can't do non-uniform binning for now :(");
+                if (Dimension == 1)
+                {
+                    // 1D histogram
+                    const auto [contents, edgesX] = TH1ToNumpy(hist);
+                    const auto edgesY = py::array_t<M3::float_t>();
+                    return py::make_tuple(contents, edgesX, edgesY);
                 }
-                
-                // 2D histogram - cast to TH2
-                const TH2 *hist2d = dynamic_cast<const TH2 *>(hist);
-                if (!hist2d) {
-                  throw std::runtime_error("Failed to cast to TH2");
+                else if (Dimension == 2)
+                {
+
+                    const TH2Poly *hist2poly = dynamic_cast<const TH2Poly *>(hist);
+                    if (hist2poly)
+                    {
+                        /// @todo Deal with non uniform binning
+                        throw std::runtime_error("pyMaCh3 can't do non-uniform binning for now :(");
+                    }
+
+                    // 2D histogram - cast to TH2
+                    const TH2 *hist2d = dynamic_cast<const TH2 *>(hist);
+                    if (!hist2d)
+                    {
+                        throw std::runtime_error("Failed to cast to TH2");
+                    }
+                    const auto [contents, edgesX, edgesY] = TH2ToNumpy(hist2d);
+                    return py::make_tuple(contents, edgesX, edgesY);
+                } else
+                {
+                    /// @todo Deal with higher dimensions
+                    /// MaCh3 returns flattened bins, will need to figure out how
+                    /// to pass bin edge info into python
+                    throw std::invalid_argument("Dimension must be 1 or 2");
                 }
-                const auto [contents, edgesX, edgesY] = TH2ToNumpy(hist2d);
-                return py::make_tuple(contents, edgesX, edgesY);
-              } else {
-                /// @todo Deal with higher dimensions
-                /// MaCh3 returns flattened bins, will need to figure out how
-                /// to pass bin edge info into python
-                throw std::invalid_argument("Dimension must be 1 or 2");
-              }
             },
             py::arg("sample"),
             "Get W2 histogram as numpy arrays.\n"


### PR DESCRIPTION
# Pull request description
Add additional getter bindings for samples + parameter. (get initial values, errors, covariance matrix, etc.) 

## Changes or fixes
* Add get_data_array, get_mc_array and get_w2_array bindings to Python/samples.h to just get bin contents
* Add getters for bounds, errors, covariance, initial values, fixed parameters + flat parameters

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
