### PR TITLE
tidy: move code duplicates to plotting utils

### DIFF
--- a/Plotting/MatrixPlotter.cpp
+++ b/Plotting/MatrixPlotter.cpp
@@ -59,6 +59,18 @@ std::unique_ptr<TH2D> GetSubMatrix(TH2D *MatrixFull,
   return Hist;
 }
 
+void SetupCanvas(TCanvas* canv) {
+  canv->SetGrid();
+  gStyle->SetOptStat(0);
+  canv->SetTickx();
+  canv->SetTicky();
+  canv->SetBottomMargin(0.2);
+  canv->SetTopMargin(0.1);
+  canv->SetRightMargin(0.15);
+  canv->SetLeftMargin(0.15);
+  gStyle->SetOptTitle(1);
+}
+
 void DynamicLabelSize(TH2D* Hist) {
   if (Hist->GetNbinsX() < 20) {
     Hist->SetMarkerSize(1.0);
@@ -115,16 +127,7 @@ void PlotMatrix(const std::unique_ptr<M3::Plotting::PlottingManager>& man, const
   }
 
   auto MatrixPlot = std::make_unique<TCanvas>("MatrixPlot", "MatrixPlot", 0, 0, 1024, 1024);
-  MatrixPlot->SetGrid();
-  gStyle->SetOptStat(0);
-  gStyle->SetOptTitle(0);
-  MatrixPlot->SetTickx();
-  MatrixPlot->SetTicky();
-  MatrixPlot->SetBottomMargin(0.2);
-  MatrixPlot->SetTopMargin(0.1);
-  MatrixPlot->SetRightMargin(0.15);
-  MatrixPlot->SetLeftMargin(0.15);
-  gStyle->SetOptTitle(1);
+  SetupCanvas(MatrixPlot.get());
   gStyle->SetPaintTextFormat("4.1f");
 
   // Make pretty Correlation colors (red to blue)
@@ -187,16 +190,7 @@ void CompareMatrices(const std::unique_ptr<M3::Plotting::PlottingManager>& man,
     file[i]->GetObject("Correlation_plot", MatrixFull[i]);
   }
   auto MatrixPlot = std::make_unique<TCanvas>("MatrixPlot", "MatrixPlot", 0, 0, 1024, 1024);
-  MatrixPlot->SetGrid();
-  gStyle->SetOptStat(0);
-  gStyle->SetOptTitle(0);
-  MatrixPlot->SetTickx();
-  MatrixPlot->SetTicky();
-  MatrixPlot->SetBottomMargin(0.2);
-  MatrixPlot->SetTopMargin(0.1);
-  MatrixPlot->SetRightMargin(0.15);
-  MatrixPlot->SetLeftMargin(0.15);
-  gStyle->SetOptTitle(1);
+  SetupCanvas(MatrixPlot.get());
 
   //KS: Fancy colors
   constexpr int NRGBs = 10;

--- a/Plotting/PlotLLH.cpp
+++ b/Plotting/PlotLLH.cpp
@@ -293,12 +293,13 @@ void makeSplitSampleLLHScanComparisons(const std::string& paramName,
   label->SetTextAlign(11);
   label->SetTextAngle(-55);
   label->SetTextSize(0.012);
+  const auto& SampleTags = PlotMan->getOption<std::vector<std::string>>("sampleTags");
 
   // need to draw the labels after other stuff or they don't show up
-  for (uint i = 0; i < PlotMan->input().getTaggedSamples(PlotMan->getOption<std::vector<std::string>>("sampleTags")).size(); i++)
+  for (uint i = 0; i < PlotMan->input().getTaggedSamples(SampleTags).size(); i++)
   {
     MACH3LOG_DEBUG("  Will I draw the label for sample {}??", i);
-    std::string sampName = PlotMan->input().getTaggedSamples(PlotMan->getOption<std::vector<std::string>>("sampleTags"))[i];
+    std::string sampName = PlotMan->input().getTaggedSamples(SampleTags)[i];
     if (!drawLabel[i])
     { 
       MACH3LOG_DEBUG("   - Not drawing label");

--- a/Plotting/PlotSigmaVariation.cpp
+++ b/Plotting/PlotSigmaVariation.cpp
@@ -53,10 +53,6 @@ void FindKnot(std::vector<double>& SigmaValues,
   double sigma = 0.0;
   // Find the "_sig_" part in the name
   size_t sig_pos = histname.find("_sig_");
-  if (sig_pos == std::string::npos) {
-    MACH3LOG_ERROR("Missing _sig_ in {}", histname);
-    throw MaCh3Exception(__FILE__ , __LINE__ );
-  }
 
   // Extract the part after "_sig_"
   std::string sigma_part = histname.substr(sig_pos + 5);

--- a/Plotting/PlotSigmaVariation.cpp
+++ b/Plotting/PlotSigmaVariation.cpp
@@ -53,6 +53,11 @@ void FindKnot(std::vector<double>& SigmaValues,
   double sigma = 0.0;
   // Find the "_sig_" part in the name
   size_t sig_pos = histname.find("_sig_");
+  if (sig_pos == std::string::npos) {
+    MACH3LOG_ERROR("Missing _sig_ in {}", histname);
+    throw MaCh3Exception(__FILE__ , __LINE__ );
+  }
+
   // Extract the part after "_sig_"
   std::string sigma_part = histname.substr(sig_pos + 5);
 
@@ -261,27 +266,9 @@ void MakeRatio(const std::vector<std::unique_ptr<TH1D>>& Poly,
 
   Ratio[0]->GetYaxis()->SetTitle("Ratio to Prior");
   Ratio[0]->SetBit(TH1D::kNoTitle);
-  Ratio[0]->SetBit(TH1D::kNoTitle);
 
-  double maxz = -999;
-  double minz = +999;
-  for (int j = 0; j < static_cast<int>(sigmaArray.size())-1; j++)
-  {
-    for (int i = 1; i < Ratio[0]->GetXaxis()->GetNbins(); i++)
-    {
-      maxz = std::max(maxz, Ratio[j]->GetBinContent(i));
-      minz = std::min(minz, Ratio[j]->GetBinContent(i));
-    }
-  }
-  maxz = maxz*1.001;
-  minz = minz*1.001;
-
-  if (std::fabs(1 - maxz) > std::fabs(1-minz))
-    Ratio[0]->GetYaxis()->SetRangeUser(1-std::fabs(1-maxz),1+std::fabs(1-maxz));
-  else
-    Ratio[0]->GetYaxis()->SetRangeUser(1-std::fabs(1-minz),1+std::fabs(1-minz));
+  M3::Plotting::SetSymmetricRatioRange(Ratio);
 }
-
 
 void PlotRatio(const std::vector<std::unique_ptr<TH1D>>& Poly,
                const std::unique_ptr<TCanvas>& canv,

--- a/Plotting/PlottingUtils/PlottingUtils.cpp
+++ b/Plotting/PlottingUtils/PlottingUtils.cpp
@@ -7,7 +7,7 @@ namespace Plotting {
 /// and last points it will extend the binning out of the graph bounds using the width between the
 /// outermost and second outermost points. This can be useful if e.g. you want to draw cumulative
 /// stacks of LLH scans.
-TH1D TGraphToTH1D(TGraph graph, const std::string& newName, const std::string& newTitle) {
+TH1D TGraphToTH1D(const TGraph& graph, const std::string& newName, const std::string& newTitle) {
   std::string name;
   std::string title;
 
@@ -60,7 +60,7 @@ TH1D TGraphToTH1D(TGraph graph, const std::string& newName, const std::string& n
   return retHist;
 }
 
-std::vector<std::vector<double>> TGraphToVector(TGraph graph) {
+std::vector<std::vector<double>> TGraphToVector(const TGraph& graph) {
   int nPoints = graph.GetN();
   std::vector<std::vector<double>> ret(2);
   std::vector<double> pointsX(nPoints);
@@ -83,8 +83,7 @@ std::vector<std::vector<double>> TGraphToVector(TGraph graph) {
 }
 
 
-std::vector<std::vector<double>> TGraphToVector(TGraph2D graph) {
-
+std::vector<std::vector<double>> TGraphToVector(const TGraph2D& graph) {
   int nPoints = graph.GetN();
   std::vector<std::vector<double>> ret(3);
   std::vector<double> pointsX(nPoints);
@@ -107,6 +106,29 @@ std::vector<std::vector<double>> TGraphToVector(TGraph2D graph) {
   ret[2] = pointsZ;
 
   return ret;
+}
+
+void SetSymmetricRatioRange(const std::vector<std::unique_ptr<TH1D>>& RatioPlot)
+{
+  double maxz = -999;
+  double minz = +999;
+
+  for (int j = 0; j < static_cast<int>(RatioPlot.size()); j++) {
+    if (!RatioPlot[j]) continue;
+
+    for (int i = 1; i < RatioPlot[0]->GetXaxis()->GetNbins(); i++) {
+      maxz = std::max(maxz, RatioPlot[j]->GetBinContent(i));
+      minz = std::min(minz, RatioPlot[j]->GetBinContent(i));
+    }
+  }
+
+  maxz = maxz * 1.001;
+  minz = minz * 1.001;
+
+  if (std::fabs(1 - maxz) > std::fabs(1 - minz))
+    RatioPlot[0]->GetYaxis()->SetRangeUser(1 - std::fabs(1 - maxz), 1 + std::fabs(1 - maxz));
+  else
+    RatioPlot[0]->GetYaxis()->SetRangeUser(1 - std::fabs(1 - minz), 1 + std::fabs(1 - minz));
 }
 
 } // namespace Plotting

--- a/Plotting/PlottingUtils/PlottingUtils.h
+++ b/Plotting/PlottingUtils/PlottingUtils.h
@@ -41,18 +41,20 @@ namespace Plotting {
 /// the name of the graph.
 /// @param newTitle The new title you want to give to the histogram. If not specified, will just use
 /// the title of the graph.
-TH1D TGraphToTH1D(TGraph graph, const std::string& newName = "", const std::string& newTitle = "");
+TH1D TGraphToTH1D(const TGraph& graph, const std::string& newName = "", const std::string& newTitle = "");
 
 
 /// @brief This handy little function lets you interpret a TGraph as a vector containing the same data.
 /// @param graph The graph you want to convert.
 /// @return A vector of vectors containing the data from the initial graph. The first vector is the x axis, the 2nd the y axis
-std::vector<std::vector<double>> TGraphToVector(TGraph graph);
+std::vector<std::vector<double>> TGraphToVector(const TGraph& graph);
 
+/// @brief Set a symmetric Y-axis range around 1 for ratio plots.
+void SetSymmetricRatioRange(const std::vector<std::unique_ptr<TH1D>>& RatioPlot);
 
 /// @brief This handy little function lets you interpret a 2d TGraph as a vector containing the same data.
 /// @param graph The graph you want to convert.
 /// @return A vector of vectors containing the data from the initial graph. The first vector is the x axis, the 2nd the y axis, the 3rd is the z axis
-std::vector<std::vector<double>> TGraphToVector(TGraph2D graph);
+std::vector<std::vector<double>> TGraphToVector(const TGraph2D& graph);
 } // namespace Plotting
 } // namespace M3

--- a/Plotting/PredictivePlotting.cpp
+++ b/Plotting/PredictivePlotting.cpp
@@ -12,6 +12,7 @@
 
 /// @warning KS: keep raw pointer or ensure manual delete of PlotMan. If spdlog in automatically deleted before PlotMan then destructor has some spdlog and this could cause segfault
 M3::Plotting::PlottingManager* PlotMan = nullptr;
+
 std::vector<std::string> FindSamples(const std::string& File)
 {
   TFile *file = M3::Open(File, "READ", __FILE__, __LINE__);
@@ -345,21 +346,7 @@ void OverlayPredicitve(const YAML::Node& Settings,
       RatioPlotData->Divide(DataHist.get());
       PassErrorToRatioPlot(RatioPlotData.get(), DataHist.get(), DataHist.get());
 
-      double maxz = -999;
-      double minz = +999;
-      for (int j = 0; j < nFiles; j++) {
-        for (int i = 1; i < RatioPlot[0]->GetXaxis()->GetNbins(); i++) {
-          maxz = std::max(maxz, RatioPlot[j]->GetBinContent(i));
-          minz = std::min(minz, RatioPlot[j]->GetBinContent(i));
-        }
-      }
-      maxz = maxz*1.001;
-      minz = minz*1.001;
-
-      if (std::fabs(1 - maxz) > std::fabs(1-minz))
-        RatioPlot[0]->GetYaxis()->SetRangeUser(1-std::fabs(1-maxz),1+std::fabs(1-maxz));
-      else
-        RatioPlot[0]->GetYaxis()->SetRangeUser(1-std::fabs(1-minz),1+std::fabs(1-minz));
+      M3::Plotting::SetSymmetricRatioRange(RatioPlot);
 
       RatioPlot[0]->Draw("p e2");
       for(int ig = 1; ig < nFiles; ig++ ) {


### PR DESCRIPTION
# Pull request description
SetSymmetricRatioRange was used in at least two places, move it to plotting utils to avoid duplciates.

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
