### PR TITLE
bugfix: Can't have Sample Handler with Same name

### DIFF
--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -276,9 +276,9 @@ void FitterBase::AddSampleHandler(SampleHandlerInterface* const sample) {
 
   for (const auto &s : samples) {
     if (s->GetName() == sample->GetName()) {
-      MACH3LOG_WARN("SampleHandler with name '{}' already exists!", sample->GetName());
-      MACH3LOG_WARN("Is it intended?");
-      //throw MaCh3Exception(__FILE__ , __LINE__ );
+      MACH3LOG_ERROR("SampleHandler with name '{}' already exists!", sample->GetName());
+      MACH3LOG_ERROR("Is it intended?");
+      throw MaCh3Exception(__FILE__ , __LINE__ );
     }
   }
   // Save additional info from samples
@@ -371,7 +371,6 @@ void FitterBase::StartFromPreviousFit(const std::string& FitName) {
         MACH3LOG_ERROR("Yaml configs in previous chain (from path {}) and current one are different", FitName);
         throw MaCh3Exception(__FILE__ , __LINE__ );
       }
-
       delete ConfigCov;
     }
 


### PR DESCRIPTION
Haradhan noticed issue with LLH scan, which tries to create TDirectory for each sample handler.
If samples have same name it will casue segfault as root will not create directory with same name

# Pull request description


## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
