### PR TITLE
tidy: Const Correctness and Remove Duplciates in Param Handler

### DIFF
--- a/Fitters/MaCh3Factory.h
+++ b/Fitters/MaCh3Factory.h
@@ -92,12 +92,10 @@ std::unique_ptr<CovType> MaCh3CovarianceFactory(Manager *FitManager, const std::
 
   // Fixed CovObject parameters loop
   if (FixParams.size() == 1 && FixParams.at(0) == "All") {
-    for (int j = 0; j < CovObject->GetNumParams(); j++) {
-      CovObject->ToggleFixParameter(j);
-    }
+    CovObject->SetFixAllParameters();
   } else {
     for (unsigned int j = 0; j < FixParams.size(); j++) {
-      CovObject->ToggleFixParameter(FixParams.at(j));
+      CovObject->SetFixParameter(FixParams.at(j));
     }
   }
 

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -630,7 +630,7 @@ void ParameterHandlerBase::SetParameters(const std::vector<double>& pars) {
     }
     // If not empty, set the parameters to the specified
   } else {
-    if (pars.size() != size_t(_fNumPar)) {
+    if (pars.size() != static_cast<size_t>(_fNumPar)) {
       MACH3LOG_ERROR("Parameter arrays of incompatible size! Not changing parameters! {} has size {} but was expecting {}", matrixName, pars.size(), _fNumPar);
       throw MaCh3Exception(__FILE__ , __LINE__ );
     }
@@ -827,7 +827,7 @@ void ParameterHandlerBase::SetFlatPrior(const int i, const bool eL) {
 // ********************************************
 void ParameterHandlerBase::SetIndivStepScale(const std::vector<double>& stepscale) {
 // ********************************************
-  if (int(stepscale.size()) != _fNumPar)
+  if (static_cast<int>(stepscale.size()) != _fNumPar)
   {
     MACH3LOG_WARN("Stepscale vector not equal to number of parameters. Quitting..");
     MACH3LOG_WARN("Size of argument vector: {}", stepscale.size());
@@ -867,10 +867,7 @@ void ParameterHandlerBase::MakePosDef(TMatrixDSym *cov) {
 // ********************************************
 void ParameterHandlerBase::ResetIndivStepScale() {
 // ********************************************
-  std::vector<double> stepScales(_fNumPar);
-  for (int i = 0; i <_fNumPar; i++) {
-    stepScales[i] = 1.;
-  }
+  std::vector<double> stepScales(_fNumPar, 1.0);
   _fGlobalStepScale = 1.0;
   SetIndivStepScale(stepScales);
 }

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -20,7 +20,7 @@ ParameterHandlerBase::ParameterHandlerBase(std::string name, std::string file, d
     pca = false;
   }
 
-  Init(name, file);
+  InitFromFile(name, file);
 
   // Call the innocent helper function
   if (pca) ConstructPCA(threshold, FirstPCA, LastPCA);
@@ -70,7 +70,7 @@ void ParameterHandlerBase::ConstructPCA(const double eigen_threshold, int FirstP
 }
 
 // ********************************************
-void ParameterHandlerBase::Init(const std::string& name, const std::string& file) {
+void ParameterHandlerBase::InitFromFile(const std::string& name, const std::string& file) {
 // ********************************************
   // Set the covariance matrix from input ROOT file (e.g. flux, ND280, NIWG)
   TFile *infile = new TFile(file.c_str(), "READ");
@@ -100,24 +100,10 @@ void ParameterHandlerBase::Init(const std::string& name, const std::string& file
   // Set the covariance matrix
   _fNumPar = CovMat->GetNrows();
 
-  InvertCovMatrix.resize(_fNumPar, std::vector<double>(_fNumPar, 0.0));
-  throwMatrixCholDecomp = new double*[_fNumPar]();
-  // Set the defaults to true
-  for(int i = 0; i < _fNumPar; i++) {
-    throwMatrixCholDecomp[i] = new double[_fNumPar]();
-    for (int j = 0; j < _fNumPar; j++) {
-      throwMatrixCholDecomp[i][j] = 0.;
-    }
-  }
+  ReserveMemory(_fNumPar);
   SetName(name);
   MakePosDef(CovMat);
   SetCovMatrix(CovMat);
-  if (_fNumPar <= 0) {
-    MACH3LOG_CRITICAL("Covariance matrix {} has {} entries!", GetName(), _fNumPar);
-    throw MaCh3Exception(__FILE__ , __LINE__ );
-  }
-
-  ReserveMemory(_fNumPar);
 
   infile->Close();
 
@@ -222,6 +208,11 @@ void ParameterHandlerBase::SetCovMatrix(TMatrixDSym *cov) {
 // ********************************************
 void ParameterHandlerBase::ReserveMemory(const int SizeVec) {
 // ********************************************
+  if (SizeVec <= 0) {
+    MACH3LOG_CRITICAL("Covariance matrix {} has {} entries!", GetName(), SizeVec);
+    throw MaCh3Exception(__FILE__ , __LINE__ );
+  }
+
   _fNames = std::vector<std::string>(SizeVec);
   _fFancyNames = std::vector<std::string>(SizeVec);
 
@@ -242,6 +233,16 @@ void ParameterHandlerBase::ReserveMemory(const int SizeVec) {
   for(int i = 0; i < SizeVec; i++) {
     corr_throw[i] = 0.0;
     randParams[i] = 0.0;
+  }
+
+  InvertCovMatrix.resize(SizeVec, std::vector<double>(SizeVec, 0.0));
+  throwMatrixCholDecomp = new double*[SizeVec]();
+  // Set the defaults to true
+  for(int i = 0; i < SizeVec; i++) {
+    throwMatrixCholDecomp[i] = new double[SizeVec]();
+    for (int j = 0; j < SizeVec; j++) {
+      throwMatrixCholDecomp[i][j] = 0.;
+    }
   }
 
   _fGlobalStepScale = 1.0;
@@ -1149,7 +1150,7 @@ void ParameterHandlerBase::MakeClosestPosDef(TMatrixDSym *cov) {
 
 // ********************************************
 // KS: Convert covariance matrix to correlation matrix and return TH2D which can be used for fancy plotting
-TH2D* ParameterHandlerBase::GetCorrelationMatrix() {
+TH2D* ParameterHandlerBase::GetCorrelationMatrix() const {
 // ********************************************
   TH2D* hMatrix = new TH2D(GetName().c_str(), GetName().c_str(), _fNumPar, 0.0, _fNumPar, _fNumPar, 0.0, _fNumPar);
   hMatrix->SetDirectory(nullptr);

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -83,7 +83,7 @@ class ParameterHandlerBase {
   /// @param stepscale Vector of individual step scale, should have same
   void SetIndivStepScale(const std::vector<double>& stepscale);
   /// @brief KS: In case someone really want to change this
-  inline void SetPrintLength(const unsigned int PriLen) { PrintLength = PriLen; }
+  void SetPrintLength(const unsigned int PriLen) { PrintLength = PriLen; }
 
   /// @brief KS: After step scale, prefit etc. value were modified save this modified config.
   void SaveUpdatedMatrixConfig();
@@ -317,7 +317,7 @@ class ParameterHandlerBase {
   void SetTune(const std::string& TuneName);
 
   /// @brief Get pointer for PCAHandler
-  inline PCAHandler* GetPCAHandler() const {
+  PCAHandler* GetPCAHandler() const {
     if (!pca) {
       MACH3LOG_ERROR("Am not running in PCA mode");
       throw MaCh3Exception(__FILE__ , __LINE__ );
@@ -342,7 +342,7 @@ class ParameterHandlerBase {
                                 std::vector<double>& BranchValues,
                                 std::vector<std::string>& BranchNames,
                                 const std::vector<std::string>& FancyNames = {});
-protected:
+ protected:
   /// @brief Initialisation of the class using matrix from root file
   void InitFromFile(const std::string& name, const std::string& file);
   /// @brief Initialise vectors with parameters information

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -182,7 +182,7 @@ class ParameterHandlerBase {
   /// @details This function converts the covariance matrix to a correlation matrix and
   ///          returns a TH2D object, which can be used for advanced plotting purposes.
   /// @return A pointer to a TH2D object representing the correlation matrix
-  TH2D* GetCorrelationMatrix();
+  TH2D* GetCorrelationMatrix() const;
 
   /// @brief DB Pointer return to param position
   ///
@@ -193,7 +193,7 @@ class ParameterHandlerBase {
   /// push_back then the pointer is no longer valid... maybe need a better
   /// way to deal with this? It was fine before when the return was to an
   /// element of a new array. There must be a clever C++ way to be careful
-  const M3::float_t* RetPointer(const int iParam) {return &(_fPropVal.data()[iParam]);}
+  const M3::float_t* RetPointer(const int iParam) const {return &(_fPropVal.data()[iParam]);}
 
   /// @brief Get a reference to the proposed parameter values
   /// Can be useful if you want to track these without having to copy values using getProposed()
@@ -344,7 +344,7 @@ class ParameterHandlerBase {
                                 const std::vector<std::string>& FancyNames = {});
 protected:
   /// @brief Initialisation of the class using matrix from root file
-  void Init(const std::string& name, const std::string& file);
+  void InitFromFile(const std::string& name, const std::string& file);
   /// @brief Initialise vectors with parameters information
   /// @param size integer telling size to which we will resize all vectors/allocate memory
   void ReserveMemory(const int size);

--- a/Parameters/ParameterHandlerGeneric.cpp
+++ b/Parameters/ParameterHandlerGeneric.cpp
@@ -83,8 +83,7 @@ void ParameterHandlerGeneric::LoadAndMergeYAML(const std::vector<std::string>& Y
         // with PCAHandler, not the first index after the end as is more common
         // throughout computer science...
         ThrowSubMatrixOverrides[{running_num_file_pars,
-          running_num_file_pars + (numrows - 1)}] =
-          std::move(submatrix);
+          running_num_file_pars + (numrows - 1)}] = std::move(submatrix);
 
           // LP: check names by default, but have option to disable check if you
           // know what you're doing
@@ -202,14 +201,6 @@ void ParameterHandlerGeneric::InitialiseFromConfig(const std::vector<std::string
   // Set the covariance matrix
   _fNumPar = int(_fYAMLDoc["Systematics"].size());
 
-  InvertCovMatrix.resize(_fNumPar, std::vector<double>(_fNumPar, 0.0));
-  throwMatrixCholDecomp = new double*[_fNumPar]();
-  for(int i = 0; i < _fNumPar; i++) {
-    throwMatrixCholDecomp[i] = new double[_fNumPar]();
-    for (int j = 0; j < _fNumPar; j++) {
-      throwMatrixCholDecomp[i][j] = 0.;
-    }
-  }
   ReserveMemory(_fNumPar);
 
   int i = 0;
@@ -239,7 +230,7 @@ void ParameterHandlerGeneric::InitialiseFromConfig(const std::vector<std::string
 
     // Allow to fix param, this setting should be used only for params which are permanently fixed like baseline, please use global config for fixing param more flexibly
     if(GetFromManager<bool>(param["Systematic"]["FixParam"], false, __FILE__ , __LINE__)) {
-      ToggleFixParameter(_fFancyNames[i]);
+      SetFixParameter(_fFancyNames[i]);
     }
 
     if(param["Systematic"]["SpecialProposal"]) {
@@ -369,7 +360,7 @@ ParameterHandlerGeneric::~ParameterHandlerGeneric() {
 
 // ********************************************
 // DB Grab the Spline Names for the relevant SampleName
-const std::vector<std::string> ParameterHandlerGeneric::GetSplineParsNamesFromSampleName(const std::string& SampleName) {
+const std::vector<std::string> ParameterHandlerGeneric::GetSplineParsNamesFromSampleName(const std::string& SampleName) const {
 // ********************************************
   std::vector<std::string> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kSpline]) {
@@ -383,7 +374,7 @@ const std::vector<std::string> ParameterHandlerGeneric::GetSplineParsNamesFromSa
 }
 
 // ********************************************
-const std::vector<SplineInterpolation> ParameterHandlerGeneric::GetSplineInterpolationFromSampleName(const std::string& SampleName) {
+const std::vector<SplineInterpolation> ParameterHandlerGeneric::GetSplineInterpolationFromSampleName(const std::string& SampleName) const {
 // ********************************************
   std::vector<SplineInterpolation> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[SystType::kSpline]) {
@@ -399,7 +390,7 @@ const std::vector<SplineInterpolation> ParameterHandlerGeneric::GetSplineInterpo
 
 // ********************************************
 // DB Grab the Spline Modes for the relevant SampleName
-const std::vector< std::vector<int> > ParameterHandlerGeneric::GetSplineModeVecFromSampleName(const std::string& SampleName) {
+const std::vector< std::vector<int> > ParameterHandlerGeneric::GetSplineModeVecFromSampleName(const std::string& SampleName) const {
 // ********************************************
   std::vector< std::vector<int> > returnVec;
   //Need a counter or something to correctly get the index in _fSplineModes since it's not of length nPars
@@ -416,7 +407,7 @@ const std::vector< std::vector<int> > ParameterHandlerGeneric::GetSplineModeVecF
 
 // ********************************************
 // Get Norm params
-NormParameter ParameterHandlerGeneric::GetNormParameter(const YAML::Node& param, const int Index) {
+NormParameter ParameterHandlerGeneric::GetNormParameter(const YAML::Node& param, const int Index) const {
 // ********************************************
   NormParameter norm;
 
@@ -441,7 +432,7 @@ NormParameter ParameterHandlerGeneric::GetNormParameter(const YAML::Node& param,
 
 // ********************************************
 // Get Base Param
-void ParameterHandlerGeneric::GetBaseParameter(const YAML::Node& param, const int Index, TypeParameterBase& Parameter) {
+void ParameterHandlerGeneric::GetBaseParameter(const YAML::Node& param, const int Index, TypeParameterBase& Parameter) const {
 // ********************************************
   Parameter.name = GetParFancyName(Index);
 
@@ -484,7 +475,7 @@ void ParameterHandlerGeneric::GetBaseParameter(const YAML::Node& param, const in
 // ********************************************
 // Grab the global syst index for the relevant SampleName
 // i.e. get a vector of size nSplines where each entry is filled with the global syst number
-const std::vector<int> ParameterHandlerGeneric::GetGlobalSystIndexFromSampleName(const std::string& SampleName, const SystType Type) {
+const std::vector<int> ParameterHandlerGeneric::GetGlobalSystIndexFromSampleName(const std::string& SampleName, const SystType Type) const {
 // ********************************************
   std::vector<int> returnVec;
   for (auto &pair : _fSystToGlobalSystIndexMap[Type]) {
@@ -513,8 +504,8 @@ const std::vector<int> ParameterHandlerGeneric::GetSystIndexFromSampleName(const
 }
 
 // ********************************************
-// Get Norm params
-SplineParameter ParameterHandlerGeneric::GetSplineParameter(const YAML::Node& param, const int Index) {
+// Get Spline params
+SplineParameter ParameterHandlerGeneric::GetSplineParameter(const YAML::Node& param, const int Index) const {
 // ********************************************
   SplineParameter Spline;
 
@@ -530,7 +521,7 @@ SplineParameter ParameterHandlerGeneric::GetSplineParameter(const YAML::Node& pa
     Spline._SplineInterpolationType = kTSpline3;
   }
 
-  Spline._fSplineNames = SplinePar["SplineName"].as<std::string>();
+  Spline._fSplineNames = Get<std::string>(SplinePar["SplineName"], __FILE__ , __LINE__);
   Spline._SplineKnotUpBound = GetFromManager<double>(SplinePar["SplineKnotUpBound"], M3::DefSplineKnotUpBound, __FILE__ , __LINE__);
   Spline._SplineKnotLowBound = GetFromManager<double>(SplinePar["SplineKnotLowBound"], M3::DefSplineKnotLowBound, __FILE__ , __LINE__);
 
@@ -585,7 +576,7 @@ bool ParameterHandlerGeneric::AppliesToSample(const int SystIndex, const std::st
 
 // ********************************************
 // Get Func params
-FunctionalParameter ParameterHandlerGeneric::GetFunctionalParameters(const YAML::Node& param, const int Index) {
+FunctionalParameter ParameterHandlerGeneric::GetFunctionalParameters(const YAML::Node& param, const int Index) const {
 // ********************************************
   FunctionalParameter func;
   GetBaseParameter(param, Index, func);
@@ -598,7 +589,7 @@ FunctionalParameter ParameterHandlerGeneric::GetFunctionalParameters(const YAML:
 
 // ********************************************
 // Get Osc params
-OscillationParameter ParameterHandlerGeneric::GetOscillationParameters(const YAML::Node& param, const int Index) {
+OscillationParameter ParameterHandlerGeneric::GetOscillationParameters(const YAML::Node& param, const int Index) const {
 // ********************************************
   OscillationParameter OscParamInfo;
   GetBaseParameter(param, Index, OscParamInfo);
@@ -629,7 +620,8 @@ const std::vector<SplineParameter> ParameterHandlerGeneric::GetSplineParsFromSam
 
 // ********************************************
 template<typename ParamT>
-std::vector<ParamT> ParameterHandlerGeneric::GetTypeParamsFromSampleName(const std::map<int, int>& indexMap, const std::vector<ParamT>& params, const std::string& SampleName) const {
+std::vector<ParamT> ParameterHandlerGeneric::GetTypeParamsFromSampleName(const std::map<int, int>& indexMap,
+                                                                         const std::vector<ParamT>& params, const std::string& SampleName) const {
 // ********************************************
   std::vector<ParamT> returnVec;
   for (const auto& pair : indexMap) {
@@ -644,7 +636,7 @@ std::vector<ParamT> ParameterHandlerGeneric::GetTypeParamsFromSampleName(const s
 
 // ********************************************
 // DB Grab the number of parameters for the relevant SampleName
-int ParameterHandlerGeneric::GetNumParamsFromSampleName(const std::string& SampleName, const SystType Type) {
+int ParameterHandlerGeneric::GetNumParamsFromSampleName(const std::string& SampleName, const SystType Type) const {
 // ********************************************
   int returnVal = 0;
   IterateOverParams(SampleName,
@@ -656,7 +648,7 @@ int ParameterHandlerGeneric::GetNumParamsFromSampleName(const std::string& Sampl
 
 // ********************************************
 // DB Grab the parameter names for the relevant SampleName
-const std::vector<std::string> ParameterHandlerGeneric::GetParsNamesFromSampleName(const std::string& SampleName, const SystType Type) {
+const std::vector<std::string> ParameterHandlerGeneric::GetParsNamesFromSampleName(const std::string& SampleName, const SystType Type) const {
 // ********************************************
   std::vector<std::string> returnVec;
   IterateOverParams(SampleName,
@@ -668,7 +660,7 @@ const std::vector<std::string> ParameterHandlerGeneric::GetParsNamesFromSampleNa
 
 // ********************************************
 // DB DB Grab the parameter indices for the relevant SampleName
-const std::vector<int> ParameterHandlerGeneric::GetParsIndexFromSampleName(const std::string& SampleName, const SystType Type) {
+const std::vector<int> ParameterHandlerGeneric::GetParsIndexFromSampleName(const std::string& SampleName, const SystType Type) const {
 // ********************************************
   std::vector<int> returnVec;
   IterateOverParams(SampleName,
@@ -680,7 +672,7 @@ const std::vector<int> ParameterHandlerGeneric::GetParsIndexFromSampleName(const
 
 // ********************************************
 template <typename FilterFunc, typename ActionFunc>
-void ParameterHandlerGeneric::IterateOverParams(const std::string& SampleName, FilterFunc filter, ActionFunc action) {
+void ParameterHandlerGeneric::IterateOverParams(const std::string& SampleName, FilterFunc filter, ActionFunc action) const {
 // ********************************************
   for (int i = 0; i < _fNumPar; ++i) {
     if ((AppliesToSample(i, SampleName)) && filter(i)) { // Common filter logic
@@ -1001,22 +993,6 @@ void ParameterHandlerGeneric::SetGroupOnlyParameters(const std::string& Group, c
 }
 
 // ********************************************
-// Toggle fix/free to parameters of a given group
-void ParameterHandlerGeneric::ToggleFixGroupOnlyParameters(const std::string& Group) {
-// ********************************************
-  for (int i = 0; i < _fNumPar; ++i) 
-    if(IsParFromGroup(i, Group)) ToggleFixParameter(i);
-}
-
-// ********************************************
-// Toggle fix/free to parameters of several groups
-void ParameterHandlerGeneric::ToggleFixGroupOnlyParameters(const std::vector< std::string>& Groups) {
-// ********************************************
-  for(size_t i = 0; i < Groups.size(); i++)
-    ToggleFixGroupOnlyParameters(Groups[i]); 
-}
-
-// ********************************************
 // Set parameters to be fixed in a given group
 void ParameterHandlerGeneric::SetFixGroupOnlyParameters(const std::string& Group) {
 // ********************************************
@@ -1074,7 +1050,7 @@ int ParameterHandlerGeneric::GetNumParFromGroup(const std::string& Group) const 
 
 // ********************************************
 // DB Grab the Normalisation parameters for the relevant sample name
-std::vector<const M3::float_t*> ParameterHandlerGeneric::GetOscParsFromSampleName(const std::string& SampleName) {
+std::vector<const M3::float_t*> ParameterHandlerGeneric::GetOscParsFromSampleName(const std::string& SampleName) const {
 // ********************************************
   std::vector<const M3::float_t*> returnVec;
   for (const auto& pair : _fSystToGlobalSystIndexMap[SystType::kOsc]) {

--- a/Parameters/ParameterHandlerGeneric.h
+++ b/Parameters/ParameterHandlerGeneric.h
@@ -37,13 +37,13 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
     /// @param i spline parameter index, not confuse with global index
     SplineInterpolation GetParSplineInterpolation(const int i) const {return SplineParams.at(i)._SplineInterpolationType;}
     /// @brief Get the interpolation types for splines affecting a particular SampleName
-    const std::vector<SplineInterpolation> GetSplineInterpolationFromSampleName(const std::string& SampleName);
+    const std::vector<SplineInterpolation> GetSplineInterpolationFromSampleName(const std::string& SampleName) const;
     /// @brief Get the name of the spline associated with the spline at index i
     /// @param i spline parameter index, not to be confused with global index
     std::string GetParSplineName(const int i) const {return SplineParams.at(i)._fSplineNames;}
 
     /// @brief DB Get spline parameters depending on given SampleName
-    const std::vector<int> GetGlobalSystIndexFromSampleName(const std::string& SampleName, const SystType Type);
+    const std::vector<int> GetGlobalSystIndexFromSampleName(const std::string& SampleName, const SystType Type) const;
     /// @brief EM: value at which we cap spline knot weight
     /// @param i spline parameter index, not confuse with global index
     double GetParSplineKnotUpperBound(const int i) const {return SplineParams.at(i)._SplineKnotUpBound;}
@@ -54,23 +54,23 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
     /// @brief DB Grab the number of parameters for the relevant SampleName
     /// @param SampleName property of SampleHandler class based on which we select whether to apply uncertainties or not
     /// @param Type Type of syst, for example kNorm, kSpline etc
-    int GetNumParamsFromSampleName(const std::string& SampleName, const SystType Type);
+    int GetNumParamsFromSampleName(const std::string& SampleName, const SystType Type) const;
     /// @brief DB Grab the parameter names for the relevant SampleName
     /// @param SampleName property of SampleHandler class based on which we select whether to apply uncertainties or not
     /// @param Type Type of syst, for example kNorm, kSpline etc
-    const std::vector<std::string> GetParsNamesFromSampleName(const std::string& SampleName, const SystType Type);
+    const std::vector<std::string> GetParsNamesFromSampleName(const std::string& SampleName, const SystType Type) const;
     /// @brief DB Grab the parameter indices for the relevant SampleName
     /// @param SampleName property of SampleHandler class based on which we select whether to apply uncertainties or not
     /// @param Type Type of syst, for example kNorm, kSpline etc
-    const std::vector<int> GetParsIndexFromSampleName(const std::string& SampleName, const SystType Type);
+    const std::vector<int> GetParsIndexFromSampleName(const std::string& SampleName, const SystType Type) const;
 
     /// @brief DB Get spline parameters depending on given SampleName
-    const std::vector<std::string> GetSplineParsNamesFromSampleName(const std::string& SampleName);
+    const std::vector<std::string> GetSplineParsNamesFromSampleName(const std::string& SampleName) const;
     /// @brief DB Get spline parameters depending on given SampleName
-    const std::vector<std::string> GetSplineFileParsNamesFromSampleName(const std::string& SampleName);
+    const std::vector<std::string> GetSplineFileParsNamesFromSampleName(const std::string& SampleName) const;
 
     /// @brief DB Grab the Spline Modes for the relevant SampleName
-    const std::vector< std::vector<int> > GetSplineModeVecFromSampleName(const std::string& SampleName);
+    const std::vector< std::vector<int> > GetSplineModeVecFromSampleName(const std::string& SampleName) const;
     /// @brief Grab the index of the syst relative to global numbering.
     /// @param SampleName property of SampleHandler class based on which we select whether to apply uncertainties or not
     /// @param Type Type of syst, for example kNorm, kSpline etc
@@ -116,20 +116,13 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
     /// @param Groups vector of group names (e.g. {"Xsec", "Flux"})
     void SetFreeGroupOnlyParameters(const std::vector<std::string>& Groups);
 
-    /// @brief TN Method to toggle fix/free parameters within a group
-    /// @param Group name of the parameter group (Xsec, Flux, Osc, etc.)
-    void ToggleFixGroupOnlyParameters(const std::string& Group);   
-    /// @brief TN Method to toggle fix/free parameters within given groups
-    /// @param Groups vector of group names (e.g. {"Xsec", "Flux"})
-    void ToggleFixGroupOnlyParameters(const std::vector<std::string>& Groups);
-
     /// @brief Dump Matrix to ROOT file, useful when we need to pass matrix info to another fitting group
     /// @param Name Name of TFile to which we save stuff
     /// @warning This is mostly used for backward compatibility
     void DumpMatrixToFile(const std::string& Name);
 
     /// @brief Get pointers to Osc params from Sample name
-    std::vector<const M3::float_t*> GetOscParsFromSampleName(const std::string& SampleName);
+    std::vector<const M3::float_t*> GetOscParsFromSampleName(const std::string& SampleName) const;
 
   protected:
     /// @brief Initialisation of the class using config
@@ -171,7 +164,7 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
     /// parameter.
     /// @param SampleName The Sample ID used to filter parameters.
     template <typename FilterFunc, typename ActionFunc>
-    void IterateOverParams(const std::string& SampleName, FilterFunc filter, ActionFunc action);
+    void IterateOverParams(const std::string& SampleName, FilterFunc filter, ActionFunc action) const;
 
     /// @brief Initializes the systematic parameters from the configuration file.
     /// This function loads parameters like normalizations and splines from the provided YAML file.
@@ -185,26 +178,26 @@ class ParameterHandlerGeneric : public ParameterHandlerBase {
     /// @brief Get Norm params
     /// @param param Yaml node describing param
     /// @param Index Global parameter index
-    NormParameter GetNormParameter(const YAML::Node& param, const int Index);
+    NormParameter GetNormParameter(const YAML::Node& param, const int Index) const;
 
     /// @brief Get Osc params
     /// @param param Yaml node describing param
     /// @param Index Global parameter index
-    OscillationParameter GetOscillationParameters(const YAML::Node& param, const int Index);
+    OscillationParameter GetOscillationParameters(const YAML::Node& param, const int Index) const;
 
     /// @brief Get Func params
     /// @param param Yaml node describing param
     /// @param Index Global parameter index
-    FunctionalParameter GetFunctionalParameters(const YAML::Node& param, const int Index);
+    FunctionalParameter GetFunctionalParameters(const YAML::Node& param, const int Index) const;
     /// @brief Get Spline params
     /// @param param Yaml node describing param
     /// @param Index Global parameter index
-    SplineParameter GetSplineParameter(const YAML::Node& param, const int Index);
+    SplineParameter GetSplineParameter(const YAML::Node& param, const int Index) const;
     /// @brief Fill base parameters
     /// @param param Yaml node describing param
     /// @param Index Global parameter index
     /// @param Parameter Object storing info
-    void GetBaseParameter(const YAML::Node& param, const int Index, TypeParameterBase& Parameter);
+    void GetBaseParameter(const YAML::Node& param, const int Index, TypeParameterBase& Parameter) const;
 
     /// @brief Check if parameter is affecting given sample name
     /// @param SystIndex number of parameter


### PR DESCRIPTION
# Pull request description
Tidy of parameter handler

## Changes or fixes
- More const correctness
- Reduce usage of `ToggleFixParameter `and use `SetFixParameter `which is safer
- Matrix initialisation is now handled in `ReserveMemory `to avoid code duplicates
- Renamed `Init `into `InitFromFile`

## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
