### PR TITLE
feat: Linspace and logspace binning in ReturnKinematicParameter

### DIFF
--- a/Samples/BinningHandler.cpp
+++ b/Samples/BinningHandler.cpp
@@ -6,123 +6,6 @@ BinningHandler::BinningHandler() {
 }
 
 // ************************************************
-auto BinRangeToBinEdges(YAML::Node const &bin_range) {
-// ************************************************
-  bool is_lin = true;
-  YAML::Node bin_range_specifier;
-  if (bin_range["linspace"]) {
-    bin_range_specifier = bin_range["linspace"];
-  } else if (bin_range["logspace"]) {
-    is_lin = false;
-    bin_range_specifier = bin_range["logspace"];
-  } else {
-    std::stringstream ss;
-    ss << bin_range;
-    MACH3LOG_ERROR("When parsing binning, expected bin range specifier with "
-                   "key linspace or logspace, but found,\n{}",
-                   ss.str());
-    throw MaCh3Exception(__FILE__, __LINE__);
-  }
-
-  auto nb = Get<int>(bin_range_specifier["nb"], __FILE__, __LINE__);
-  auto low = Get<double>(bin_range_specifier["low"], __FILE__, __LINE__);
-  auto up = Get<double>(bin_range_specifier["up"], __FILE__, __LINE__);
-
-  std::vector<double> edges(nb + 1, low);
-  // force the last bin to be exactly as parsed to avoid numerical instabilities
-  // not quite lining back up with the end of the range, which could
-  // cause spurious errors or infinitesimally small bins for specifications
-  // like: [ { logspace: { nb: 10, 1E-1, 10}, 10, 11} ]
-  edges.back() = up;
-
-  if (is_lin) {
-    double bw = (up - low) / nb;
-    for (int i = 0; i < (nb - 1); ++i) {
-      edges[i + 1] = edges[i] + bw;
-    }
-  } else {
-    double llow = std::log10(low);
-    double lup = std::log10(up);
-    double lbw = (lup - llow) / nb;
-    for (int i = 0; i < (nb - 1); ++i) {
-      edges[i + 1] = std::pow(10, llow + (i + 1) * lbw);
-    }
-  }
-
-  return edges;
-}
-
-// ************************************************
-/// @brief Builds a single dimension's bin edges from YAML::Node
-/// @details
-/// BinEdges:  [ <dim0bin0lowedge>, <dim0bin1upedge>, <dim0bin2upedge>, ...
-/// <dim0binNupedge> ] BinEdges:  { linspace: { nb: 100, low: 0, up: 10} }
-/// BinEdges:  { logspace: { nb: 100, low: 1E-1, up: 10} }
-/// BinEdges:  [ { linspace: { nb: 100, low: 0, up: 10} }, 10, 15, { logspace: {
-/// nb: 5, low: 15, up: 100} } ]
-auto BuildBinEdgesFromNode(YAML::Node const &bin_edges_node,
-                           bool &found_range_specifier) {
-// ************************************************
-  if (bin_edges_node.IsMap()) {
-    found_range_specifier = true;
-    return BinRangeToBinEdges(bin_edges_node);
-  }
-  std::vector<double> edges_builder;
-  if (!bin_edges_node.IsSequence()) {
-    std::stringstream ss;
-    ss << bin_edges_node;
-    MACH3LOG_ERROR(
-        "When parsing binning, expected to find a YAML map or sequence, "
-        "but found:\n{}",
-        ss.str());
-    throw MaCh3Exception(__FILE__, __LINE__);
-  }
-  for (auto const &it : bin_edges_node) {
-    if (it.IsScalar()) {
-      edges_builder.push_back(it.as<double>());
-    } else if (it.IsMap()) {
-      found_range_specifier = true;
-      auto range_edges = BinRangeToBinEdges(it);
-      std::copy(range_edges.begin(), range_edges.end(),
-                std::back_inserter(edges_builder));
-    } else {
-      std::stringstream ss;
-      ss << bin_edges_node;
-      MACH3LOG_ERROR(
-          "When parsing binning, expected elements in outer sequence to all be "
-          "either scalars or maps, but found:\n{}",
-          ss.str());
-      throw MaCh3Exception(__FILE__, __LINE__);
-    }
-  }
-
-  // Check for duplicates or out-of-order bins
-  std::vector<double> edges;
-  for (size_t eb_it = 0; eb_it < edges_builder.size(); ++eb_it) {
-    if (edges.size()) {
-      if (edges_builder[eb_it] == edges.back()) { // remove duplicate edges
-        continue;
-      } else if (edges_builder[eb_it] < edges.back()) {
-        std::stringstream ss;
-        ss << "[ ";
-        for(auto const & e : edges_builder){
-          ss << fmt::format("{:.3g} ", e);
-        }
-        ss << "]";
-        MACH3LOG_ERROR(
-            "When parsing binning, found edges that were not monotonically "
-            "increasing, problem bin at index: {}:\n{}",
-            eb_it, ss.str());
-        throw MaCh3Exception(__FILE__, __LINE__);
-      }
-    }
-    edges.push_back(edges_builder[eb_it]);
-  }
-
-  return edges;
-}
-
-// ************************************************
 /// @brief Parses YAML node describing multidim uniform binning
 /// @details
 /// # dimensional list implicit for 1D binnings
@@ -150,13 +33,13 @@ auto BuildBinEdgesFromNode(YAML::Node const &bin_edges_node,
 ///            ...
 ///            [<dimNbin0lowedge>, <dimNbin1upedge>, <dimNbin2upedge>, ...
 ///            <dimNbinNupedge>] ]
-auto UniformBinEdgeConfigParser(YAML::Node const &bin_edges_node,
+std::vector<std::vector<double>> UniformBinEdgeConfigParser(YAML::Node const &bin_edges_node,
                                 bool &found_range_specifier) {
 // ************************************************
   if (bin_edges_node.IsMap()) {
     found_range_specifier = true;
     return std::vector<std::vector<double>>{
-        BinRangeToBinEdges(bin_edges_node),
+      BinRangeToBinEdges(bin_edges_node),
     };
   } else if (bin_edges_node.IsSequence()) {
     if (!bin_edges_node.size()) {
@@ -169,7 +52,7 @@ auto UniformBinEdgeConfigParser(YAML::Node const &bin_edges_node,
     auto const &first_el = bin_edges_node[0];
     if (first_el.IsScalar() || first_el.IsMap()) { // 1D binning
       return std::vector<std::vector<double>>{
-          BuildBinEdgesFromNode(bin_edges_node, found_range_specifier),
+        BuildBinEdgesFromNode(bin_edges_node, found_range_specifier),
       };
     }
     // ND binning
@@ -182,9 +65,9 @@ auto UniformBinEdgeConfigParser(YAML::Node const &bin_edges_node,
     std::stringstream ss;
     ss << bin_edges_node;
     MACH3LOG_ERROR(
-        "When parsing binning, expected to find a YAML map or sequence, "
-        "but found:\n{}",
-        ss.str());
+      "When parsing binning, expected to find a YAML map or sequence, "
+      "but found:\n{}",
+      ss.str());
     throw MaCh3Exception(__FILE__, __LINE__);
   }
 }
@@ -199,10 +82,10 @@ void BinningHandler::SetupSampleBinning(const YAML::Node& Settings, SampleInfo& 
   MACH3LOG_INFO("Setting up Sample Binning");
   //Binning
   SingleSample.VarStr = (Settings["VarStr"] && Settings["VarStr"].IsScalar())
-                            ? std::vector<std::string>{Get<std::string>(
-                                  Settings["VarStr"], __FILE__, __LINE__)}
-                            : Get<std::vector<std::string>>(Settings["VarStr"],
-                                                            __FILE__, __LINE__);
+    ? std::vector<std::string>{Get<std::string>(
+      Settings["VarStr"], __FILE__, __LINE__)}
+    : Get<std::vector<std::string>>(Settings["VarStr"],
+                                    __FILE__, __LINE__);
   SingleSample.nDimensions = static_cast<int>(SingleSample.VarStr.size());
 
   SampleBinningInfo SingleBinning;
@@ -210,7 +93,7 @@ void BinningHandler::SetupSampleBinning(const YAML::Node& Settings, SampleInfo& 
   bool found_range_specifier = false;
   if(Uniform == false) {
     if(Settings["Bins"].IsSequence()) {
-        SingleBinning.InitNonUniform(Get<std::vector<std::vector<std::vector<double>>>>(Settings["Bins"], __FILE__, __LINE__));
+      SingleBinning.InitNonUniform(Get<std::vector<std::vector<std::vector<double>>>>(Settings["Bins"], __FILE__, __LINE__));
     } else if(Settings["Bins"].IsMap()){
       // Load binning from external file
       auto file = Get<std::string>(Settings["Bins"]["File"], __FILE__, __LINE__);
@@ -222,9 +105,9 @@ void BinningHandler::SetupSampleBinning(const YAML::Node& Settings, SampleInfo& 
       std::stringstream ss;
       ss << Settings["Bins"];
       MACH3LOG_ERROR(
-          "When parsing binning, expected to find a YAML map or sequence, "
-          "but found:\n{}",
-          ss.str());
+        "When parsing binning, expected to find a YAML map or sequence, "
+        "but found:\n{}",
+        ss.str());
       throw MaCh3Exception(__FILE__, __LINE__);
     }
   } else {
@@ -243,14 +126,14 @@ void BinningHandler::SetupSampleBinning(const YAML::Node& Settings, SampleInfo& 
       ss << (Settings["BinEdges"] ? Settings["BinEdges"] : Settings["VarBins"]);
       MACH3LOG_ERROR(R"(A bin range specifier was found in node:
 
-  {}
+                     {}
 
-Please carefully check the number of square brackets used, a 2D binning
-  comprised of just 2 range specifiers must explicitly include the axis
-  list specifier like:
+                     Please carefully check the number of square brackets used, a 2D binning
+                     comprised of just 2 range specifiers must explicitly include the axis
+                     list specifier like:
 
-  BinEdges: [ [ {{linspace: {{nb:10, low:0, up: 10}}}} ], [ {{linspace: {{nb:5, low:10, up: 100}}}} ] ]
-)", ss.str());
+                     BinEdges: [ [ {{linspace: {{nb:10, low:0, up: 10}}}} ], [ {{linspace: {{nb:5, low:10, up: 100}}}} ] ]
+                     )", ss.str());
     }
     throw MaCh3Exception(__FILE__, __LINE__);
   }
@@ -300,8 +183,8 @@ int BinningHandler::FindGlobalBin(const int NomSample,
 
 // ************************************************
 int BinningHandler::FindNominalBin(const int iSample,
-                   const int iDim,
-                   const double Var) const {
+                                   const int iDim,
+                                   const double Var) const {
 // ************************************************
   const SampleBinningInfo& info = SampleBinning[iSample];
 
@@ -331,7 +214,7 @@ int BinningHandler::GetGlobalBinSafe(const int Sample, const std::vector<int>& B
 // ************************************************
 int BinningHandler::GetSampleStartBin(const int Sample) const {
 // ************************************************
- return static_cast<int>(SampleBinning[Sample].GlobalOffset);
+  return static_cast<int>(SampleBinning[Sample].GlobalOffset);
 }
 
 // ************************************************

--- a/Samples/BinningHandler.h
+++ b/Samples/BinningHandler.h
@@ -4,6 +4,7 @@
 
 #include "Samples/SampleStructs.h"
 #include "Samples/SampleInfo.h"
+#include "Samples/HistogramUtils.h"
 #include "Manager/Manager.h"
 
 // ***************************

--- a/Samples/HistogramUtils.cpp
+++ b/Samples/HistogramUtils.cpp
@@ -660,6 +660,123 @@ std::unique_ptr<TH1D> MakeSummaryFromSpectra(const TH2D* Spectra,
   return h1;
 }
 
+// ************************************************
+std::vector<double> BinRangeToBinEdges(YAML::Node const &bin_range) {
+// ************************************************
+  bool is_lin = true;
+  YAML::Node bin_range_specifier;
+  if (bin_range["linspace"]) {
+    bin_range_specifier = bin_range["linspace"];
+  } else if (bin_range["logspace"]) {
+    is_lin = false;
+    bin_range_specifier = bin_range["logspace"];
+  } else {
+    std::stringstream ss;
+    ss << bin_range;
+    MACH3LOG_ERROR("When parsing binning, expected bin range specifier with "
+                   "key linspace or logspace, but found,\n{}",
+                   ss.str());
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+
+  auto nb = Get<int>(bin_range_specifier["nb"], __FILE__, __LINE__);
+  auto low = Get<double>(bin_range_specifier["low"], __FILE__, __LINE__);
+  auto up = Get<double>(bin_range_specifier["up"], __FILE__, __LINE__);
+
+  std::vector<double> edges(nb + 1, low);
+  // force the last bin to be exactly as parsed to avoid numerical instabilities
+  // not quite lining back up with the end of the range, which could
+  // cause spurious errors or infinitesimally small bins for specifications
+  // like: [ { logspace: { nb: 10, 1E-1, 10}, 10, 11} ]
+  edges.back() = up;
+
+  if (is_lin) {
+    double bw = (up - low) / nb;
+    for (int i = 0; i < (nb - 1); ++i) {
+      edges[i + 1] = edges[i] + bw;
+    }
+  } else {
+    double llow = std::log10(low);
+    double lup = std::log10(up);
+    double lbw = (lup - llow) / nb;
+    for (int i = 0; i < (nb - 1); ++i) {
+      edges[i + 1] = std::pow(10, llow + (i + 1) * lbw);
+    }
+  }
+
+  return edges;
+}
+
+// ************************************************
+/// @brief Builds a single dimension's bin edges from YAML::Node
+/// @details
+/// BinEdges:  [ <dim0bin0lowedge>, <dim0bin1upedge>, <dim0bin2upedge>, ...
+/// <dim0binNupedge> ] BinEdges:  { linspace: { nb: 100, low: 0, up: 10} }
+/// BinEdges:  { logspace: { nb: 100, low: 1E-1, up: 10} }
+/// BinEdges:  [ { linspace: { nb: 100, low: 0, up: 10} }, 10, 15, { logspace: {
+/// nb: 5, low: 15, up: 100} } ]
+std::vector<double> BuildBinEdgesFromNode(YAML::Node const &bin_edges_node,
+                           bool &found_range_specifier) {
+// ************************************************
+  if (bin_edges_node.IsMap()) {
+    found_range_specifier = true;
+    return BinRangeToBinEdges(bin_edges_node);
+  }
+  std::vector<double> edges_builder;
+  if (!bin_edges_node.IsSequence()) {
+    std::stringstream ss;
+    ss << bin_edges_node;
+    MACH3LOG_ERROR(
+        "When parsing binning, expected to find a YAML map or sequence, "
+        "but found:\n{}",
+        ss.str());
+    throw MaCh3Exception(__FILE__, __LINE__);
+  }
+  for (auto const &it : bin_edges_node) {
+    if (it.IsScalar()) {
+      edges_builder.push_back(it.as<double>());
+    } else if (it.IsMap()) {
+      found_range_specifier = true;
+      auto range_edges = BinRangeToBinEdges(it);
+      std::copy(range_edges.begin(), range_edges.end(),
+                std::back_inserter(edges_builder));
+    } else {
+      std::stringstream ss;
+      ss << bin_edges_node;
+      MACH3LOG_ERROR(
+          "When parsing binning, expected elements in outer sequence to all be "
+          "either scalars or maps, but found:\n{}",
+          ss.str());
+      throw MaCh3Exception(__FILE__, __LINE__);
+    }
+  }
+
+  // Check for duplicates or out-of-order bins
+  std::vector<double> edges;
+  for (size_t eb_it = 0; eb_it < edges_builder.size(); ++eb_it) {
+    if (edges.size()) {
+      if (edges_builder[eb_it] == edges.back()) { // remove duplicate edges
+        continue;
+      } else if (edges_builder[eb_it] < edges.back()) {
+        std::stringstream ss;
+        ss << "[ ";
+        for(auto const & e : edges_builder){
+          ss << fmt::format("{:.3g} ", e);
+        }
+        ss << "]";
+        MACH3LOG_ERROR(
+            "When parsing binning, found edges that were not monotonically "
+            "increasing, problem bin at index: {}:\n{}",
+            eb_it, ss.str());
+        throw MaCh3Exception(__FILE__, __LINE__);
+      }
+    }
+    edges.push_back(edges_builder[eb_it]);
+  }
+
+  return edges;
+}
+
 namespace M3 {
 // **************************************************************************
 TFile* Open(const std::string& Name, const std::string& Type, const std::string& File, const int Line) {

--- a/Samples/HistogramUtils.h
+++ b/Samples/HistogramUtils.h
@@ -135,6 +135,15 @@ double CalculateEnu(double PLep, double cosTheta, double EB, bool neutrino);
 /// @param name    Name of the output TH1D.
 std::unique_ptr<TH1D> MakeSummaryFromSpectra(const TH2D* Spectra, const std::string& name);
 
+/// @brief Builds a single dimension's bin edges from YAML::Node
+/// @param bin_edges_node Yaml node containing binning
+/// @param found_range_specifier Whether or not a range specifier (linspace/logspace) was found
+std::vector<double> BuildBinEdgesFromNode(YAML::Node const &bin_edges_node, bool &found_range_specifier);
+
+/// @brief Converts a range (linspace/logspace) to a std::vector<double>
+/// @param bin_edges_node Yaml node containing binning
+std::vector<double> BinRangeToBinEdges(YAML::Node const &bin_range);
+
 namespace M3 {
 /// @brief KS: Creates a copy of a ROOT-like object and wraps it in a smart pointer.
 ///

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -1513,7 +1513,8 @@ std::unique_ptr<TH2> SampleHandlerBase::Get2DVarHist(const int iSample,
                                                      const std::string& ProjectionVar_StrX,
                                                      const std::string& ProjectionVar_StrY,
                                                      const std::vector< KinematicCut >& EventSelectionVec,
-                                                     const int WeightStyle, const std::vector< KinematicCut >& SubEventSelectionVec) {
+                                                     const int WeightStyle,
+                                                     const std::vector< KinematicCut >& SubEventSelectionVec) {
 // ************************************************
   //DB Need to overwrite the Selection member variable so that IsEventSelected function operates correctly.
   //   Consequently, store the selection cuts already saved in the sample, overwrite the Selection variable, then reset
@@ -1705,10 +1706,11 @@ std::vector<double> SampleHandlerBase::ReturnKinematicParameterBinning(const int
   std::vector<double> BinningVect;
   // We first check if binning for a sample has been specified
   auto BinningConfig = M3OpenConfig(SampleManager->raw()["BinningFile"].as<std::string>());
+  bool found_range_specifier = false;
   if(BinningConfig[GetSampleTitle(Sample)] && BinningConfig[GetSampleTitle(Sample)][KinematicParameter]){
-    BinningVect = Get<std::vector<double>>(BinningConfig[GetSampleTitle(Sample)][KinematicParameter], __FILE__, __LINE__);
+    BinningVect = BuildBinEdgesFromNode(BinningConfig[GetSampleTitle(Sample)][KinematicParameter], found_range_specifier);
   } else {
-    BinningVect = Get<std::vector<double>>(BinningConfig[KinematicParameter], __FILE__, __LINE__);
+    BinningVect = BuildBinEdgesFromNode(BinningConfig[KinematicParameter], found_range_specifier);
   }
 
   // Ensure binning is increasing
@@ -1723,9 +1725,11 @@ std::vector<double> SampleHandlerBase::ReturnKinematicParameterBinning(const int
 
   if (!IsIncreasing(BinningVect)) {
     MACH3LOG_ERROR("Binning for {} is not increasing [{}]", KinematicParameter, fmt::join(BinningVect, ", "));
-    throw MaCh3Exception(__FILE__,__LINE__);
+    if(found_range_specifier){
+      MACH3LOG_ERROR("A bin range specifier was found. Please carefully check the number of square brackets used.");
+    }
+    throw MaCh3Exception(__FILE__, __LINE__);
   }
-
   return BinningVect;
 }
 
@@ -1798,7 +1802,7 @@ std::vector<KinematicCut> SampleHandlerBase::BuildModeChannelSelection(const int
 
 // ************************************************
 std::unique_ptr<TH1> SampleHandlerBase::Get1DVarHistByModeAndChannel(const int iSample, const std::string& ProjectionVar_Str,
-    const int kModeToFill, const int kChannelToFill, const int WeightStyle) {
+                                                                     const int kModeToFill, const int kChannelToFill, const int WeightStyle) {
 // ************************************************
   auto SelectionVec = BuildModeChannelSelection(iSample, kModeToFill, kChannelToFill);
   return Get1DVarHist(iSample, ProjectionVar_Str, SelectionVec, WeightStyle);
@@ -1957,7 +1961,7 @@ void SampleHandlerBase::PrintIntegral(const int iSample, const TString& OutputFi
 
 // ************************************************
 std::vector<std::unique_ptr<TH1>> SampleHandlerBase::ReturnHistsBySelection1D(const int iSample, const std::string& KinematicProjection,
-                                                            const int Selection1, const int Selection2, const int WeightStyle) {
+                                                                              const int Selection1, const int Selection2, const int WeightStyle) {
 // ************************************************
   std::vector<std::unique_ptr<TH1>> hHistList;
   std::string legendEntry;
@@ -2027,7 +2031,7 @@ std::vector<std::unique_ptr<TH2>> SampleHandlerBase::ReturnHistsBySelection2D(co
 
 // ************************************************
 std::unique_ptr<THStack> SampleHandlerBase::ReturnStackedHistBySelection1D(const int iSample, const std::string& KinematicProjection,
-                                                         int Selection1, int Selection2, int WeightStyle) {
+                                                                           int Selection1, int Selection2, int WeightStyle) {
 // ************************************************
   auto HistList = ReturnHistsBySelection1D(iSample, KinematicProjection, Selection1, Selection2, WeightStyle);
   auto StackHist = std::make_unique<THStack>((GetSampleTitle(iSample)+"_"+KinematicProjection+"_Stack").c_str(),"");

--- a/Samples/SampleStructs.h
+++ b/Samples/SampleStructs.h
@@ -764,18 +764,31 @@ namespace Utils {
       case 211: return 0.13957039; // pi_+/-
       case 111: return 0.1349768;  // pi_0
       case 221: return 0.547862;   // eta
+      case 331: return 0.95778;    // eta'
       case 311:                    // K_0
       case 130:                    // K_0_L
       case 310:                    // K_0_S
         return 0.497611;
       case 321: return 0.493677;   // K_+/-
+      case 113: return 0.77526;    // rho_0
+      case 213: return 0.77511;    // rho_+/-
+      case 223: return 0.78266;    // omega
+      case 411: return 1.86966;    // D_+/-
+      case 421: return 1.86484;    // D_0
+      case 431: return 1.96835;    // D_s+/-
       // Baryons
       case 2112: return 0.939565; // n
       case 2212: return 0.938272; // p
-      case 3122: return 1.115683; // lambda
-      case 3222: return 1.118937; // sig_+
-      case 3112: return 1.197449; // sig_-
-      case 3212: return 1.192642; // sig_0
+      case 3122: return 1.115683; // Lambda
+      case 3222: return 1.118937; // Sig_+
+      case 3112: return 1.197449; // Sig_-
+      case 3212: return 1.192642; // Sig_0
+      case 3312: return 1.32171;  // Xi_+/-
+      case 3322: return 1.31486;  // Xi_0 
+      case 3334: return 1.67245;  // Omega_+/-
+      case 4122: return 2.28646;  // Lambda_c+
+      case 4212: return 2.45265;  // Sigma_c+
+      case 4222: return 2.45397;  // Sigma_c++
       // Nuclei
       case 1000050110: return 10.255103; // Boron-11
       case 1000060120: return 11.177929; // Carbon-12


### PR DESCRIPTION
# Pull request description
Binning yaml read by `ReturnKinematicParameter` can now specify binnings in three ways:
`Var_string: [bin1_lower, bin1_upper, bin2_upper, ..., binN_upper]`
`Var_string: {linspace: {nb: N, low: bin1_lower, up: binN_upper}}`
`Var_string: {logspace: {nb: N, low: bin1_lower, up: binN_upper}}`

This matches the possible ways to specify the fitting variable binning

## Changes or fixes
Moved `BuildBinEdgesFromNode` and `BinRangeToBinEdges` from `BinningHandler` to `HistogramUtils`. These are then accessible from `SampleHandlerBase` and called in `ReturnKinematicParameter`

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
