### PR TITLE
feat: Reduce duplicates when defining features for mach3-config

### DIFF
--- a/.github/workflows/CIValidations.yml
+++ b/.github/workflows/CIValidations.yml
@@ -37,7 +37,7 @@ jobs:
             test: MaCh3CLI --NuMCMCToolsValidations
             compilation_flags: -DMaCh3Tutorial_UNITTESTS_ENABLED=TRUE
 
-          - name: Fitter Validations
+          - name: Fitter Validations Low Memory
             test: MaCh3CLI --FitterValidations
             compilation_flags: -DMaCh3Tutorial_UNITTESTS_ENABLED=TRUE -DMaCh3Tutorial_LOW_MEMORY_STRUCTS_ENABLED=ON
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,9 +269,9 @@ LIST(APPEND ALL_FEATURES
   GPU
   PYTHON
   LOW_MEMORY_STRUCTS
+  NUDOCK
   Oscillator
   Fitter
-  NUDOCK
   )
 cmessage(STATUS "MaCh3 Features: ")
 foreach(f ${ALL_FEATURES})

--- a/cmake/Modules/mach3-config.cmake
+++ b/cmake/Modules/mach3-config.cmake
@@ -2,13 +2,12 @@ SET(MACH3_LIB_LIST "-libParameters -libManager -libFitters -libSamples -libSplin
 
 SET(MACH3_FEATURES_LIST)
 
-LIST(APPEND ALL_FEATURES_CONFIG
-  MULTITHREAD
-  GPU
-  DEBUG
-  PYTHON
-  NATIVE
-  )
+set(ALL_FEATURES_CONFIG ${ALL_FEATURES})
+# KS: Oscillator and Fitter aren't features but actual list of features so they are handled differently
+list(REMOVE_ITEM ALL_FEATURES_CONFIG
+  Oscillator
+  Fitter
+)
 foreach(f IN LISTS ALL_FEATURES_CONFIG)
   if(MaCh3_${f}_ENABLED)
     list(APPEND MACH3_FEATURES_LIST "${f}")


### PR DESCRIPTION
# Pull request description
We had defined list of features in two places.
Now only one.
This should reduce bugs when we add only in one place.

This means that NuDock is now properly `mach3-config --features`

## Changes or fixes


## Examples
<img width="953" height="59" alt="image" src="https://github.com/user-attachments/assets/8fa0584f-1286-4cf5-9a80-14b2b3e4365f" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
