### PR TITLE
tidy: Potential fix for code scanning alert no. 2140: Multiplication result converted to larger type

### DIFF
--- a/Diagnostics/PlotLLHMap.cpp
+++ b/Diagnostics/PlotLLHMap.cpp
@@ -200,13 +200,17 @@ int main(int argc, char *argv[]) {
 
       MACH3LOG_INFO("The 2D histogram has {} x-bins from {} to {} and {} y-bins from {} to {}", nx, minx, maxx, ny, miny, maxy);
 
+      const Long64_t nbinsX = static_cast<Long64_t>(hprof2d->GetNbinsX());
+      const Long64_t nbinsY = static_cast<Long64_t>(hprof2d->GetNbinsY());
+      const Long64_t totalBins = nbinsX * nbinsY;
       for(int bidx = 1; bidx < hprof2d->GetNbinsX() + 1; ++bidx)
       {
         for(int bidy = 1; bidy < hprof2d->GetNbinsY() + 1; ++bidy)
         {
-          const int count = int(double(hprof2d->GetNbinsX()*hprof2d->GetNbinsY())/double(5));
-          if ( ((bidx-1)*hprof2d->GetNbinsY() + bidy) % count == 0)
-            M3::Utils::PrintProgressBar((bidx-1)*hprof2d->GetNbinsY() + bidy, hprof2d->GetNbinsX()*hprof2d->GetNbinsY());
+          const int count = int(double(totalBins)/double(5));
+          const Long64_t currentBin = (static_cast<Long64_t>(bidx) - 1) * nbinsY + bidy;
+          if (count > 0 && (currentBin % count == 0))
+            M3::Utils::PrintProgressBar(currentBin, totalBins);
 
           auto bx_lo = hprof2d->GetXaxis()->GetBinLowEdge(bidx);
           auto bx_hi = bx_lo + hprof2d->GetXaxis()->GetBinWidth(bidx);


### PR DESCRIPTION
Potential fix for [https://github.com/mach3-software/MaCh3/security/code-scanning/2140](https://github.com/mach3-software/MaCh3/security/code-scanning/2140)

Compute the bin-product and progress index using a wider integer type *before* multiplication, and reuse those values in the loop.

Best fix in `Diagnostics/PlotLLHMap.cpp` (around lines 203–210):
- Introduce `const Long64_t nbinsX`, `nbinsY`, and `totalBins` before the nested loops.
- Compute loop-progress index as `Long64_t currentBin = (static_cast<Long64_t>(bidx) - 1) * nbinsY + bidy;`
- Use `currentBin` and `totalBins` in modulo check and `PrintProgressBar`.
- Keep loop bounds as-is to avoid changing functionality.
- Also guard modulo by zero (`count > 0`) to avoid undefined behavior for very small histograms.

No new includes or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
