### PR TITLE
tidy: Remove Duplicates in ReturnHistsBySelection

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -595,6 +595,9 @@ int ParameterHandlerBase::CheckBounds() const _noexcept_ {
 // ********************************************
   int NOutside = 0;
   for (int i = 0; i < _fNumPar; ++i) {
+    // KS: Count how many parameters are outside bounds using branchless logic
+    // faster by at least factor two
+    // Do not multithread even with 5k params no gains
     NOutside += (_fPropVal[i] > _fUpBound[i]) | (_fPropVal[i] < _fLowBound[i]);
   }
   return NOutside;

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -594,13 +594,8 @@ double ParameterHandlerBase::CalcLikelihood() const _noexcept_ {
 int ParameterHandlerBase::CheckBounds() const _noexcept_ {
 // ********************************************
   int NOutside = 0;
-  #ifdef MULTITHREAD
-  #pragma omp parallel for reduction(+:NOutside)
-  #endif
-  for (int i = 0; i < _fNumPar; ++i){
-    if(_fPropVal[i] > _fUpBound[i] || _fPropVal[i] < _fLowBound[i]){
-      NOutside++;
-    }
+  for (int i = 0; i < _fNumPar; ++i) {
+    NOutside += (_fPropVal[i] > _fUpBound[i]) | (_fPropVal[i] < _fLowBound[i]);
   }
   return NOutside;
 }

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -1991,7 +1991,7 @@ int SampleHandlerBase::GetRangeForPlotType(const SamplePlotType TypeEnum, const 
       return GetNOscChannels(iSample);
       break;
     default:
-      MACH3LOG_ERROR("You've passed me a Selection1 which was not implemented in ReturnHistsBySelection1D. Selection1 and Selection2 are counters for different indexable quantities");
+      MACH3LOG_ERROR("You've passed me a SamplePlotType with value {} which was not implemented.", TypeEnum);
       throw MaCh3Exception(__FILE__, __LINE__);
   }
 }

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -1870,9 +1870,10 @@ void SampleHandlerBase::PrintIntegral(const int iSample, const TString& OutputFi
 
   for (int i=0;i<Modes->GetNModes();i++) {
     if (GetNDim(iSample) == 1) {
-      IntegralList[i] = ReturnHistsBySelection1D(iSample, GetKinVarName(iSample, 0),1,i,WeightStyle);
+      IntegralList[i] = ReturnHistsBySelection1D(iSample, GetKinVarName(iSample, 0), SamplePlotType::kOscChannelPlot, i, WeightStyle);
     } else {
-      IntegralList[i] = CastVector<TH2, TH1>(ReturnHistsBySelection2D(iSample, GetKinVarName(iSample, 0), GetKinVarName(iSample, 1),1,i,WeightStyle));
+      IntegralList[i] = CastVector<TH2, TH1>(ReturnHistsBySelection2D(iSample, GetKinVarName(iSample, 0), GetKinVarName(iSample, 1),
+                                                                      SamplePlotType::kOscChannelPlot, i, WeightStyle));
     }
   }
 
@@ -1979,26 +1980,24 @@ void SampleHandlerBase::PrintIntegral(const int iSample, const TString& OutputFi
 }
 
 // ************************************************
-int SampleHandlerBase::GetRangeForPlotType(const int TypeEnum, const int iSample) const {
+int SampleHandlerBase::GetRangeForPlotType(const SamplePlotType TypeEnum, const int iSample) const {
 // ************************************************
-  int iMax = -1;
   switch (TypeEnum) {
     case SamplePlotType::kModePlot:
-      iMax = Modes->GetNModes();
+      return Modes->GetNModes();
       break;
     case SamplePlotType::kOscChannelPlot:
-      iMax = GetNOscChannels(iSample);
+      return GetNOscChannels(iSample);
       break;
     default:
       MACH3LOG_ERROR("You've passed me a Selection1 which was not implemented in ReturnHistsBySelection1D. Selection1 and Selection2 are counters for different indexable quantities");
       throw MaCh3Exception(__FILE__, __LINE__);
   }
-  return iMax;
 }
 
 // ************************************************
 std::vector<std::unique_ptr<TH1>> SampleHandlerBase::ReturnHistsBySelection1D(const int iSample, const std::string& KinematicProjection,
-                                                                              const int Selection1, const int Selection2, const int WeightStyle) {
+                                                                              const SamplePlotType Selection1, const int Selection2, const int WeightStyle) {
 // ************************************************
   std::vector<std::unique_ptr<TH1>> hHistList;
   std::string legendEntry;
@@ -2026,7 +2025,7 @@ std::vector<std::unique_ptr<TH1>> SampleHandlerBase::ReturnHistsBySelection1D(co
 
 // ************************************************
 std::vector<std::unique_ptr<TH2>> SampleHandlerBase::ReturnHistsBySelection2D(const int iSample, const std::string& KinematicProjectionX,
-                                                                              const std::string& KinematicProjectionY, const int Selection1,
+                                                                              const std::string& KinematicProjectionY, const SamplePlotType Selection1,
                                                                               const int Selection2, const int WeightStyle) {
 // ************************************************
   std::vector<std::unique_ptr<TH2>> hHistList;
@@ -2046,7 +2045,7 @@ std::vector<std::unique_ptr<TH2>> SampleHandlerBase::ReturnHistsBySelection2D(co
 
 // ************************************************
 std::unique_ptr<THStack> SampleHandlerBase::ReturnStackedHistBySelection1D(const int iSample, const std::string& KinematicProjection,
-                                                                           int Selection1, int Selection2, int WeightStyle) {
+                                                                           const SamplePlotType Selection1, int Selection2, int WeightStyle) {
 // ************************************************
   auto HistList = ReturnHistsBySelection1D(iSample, KinematicProjection, Selection1, Selection2, WeightStyle);
   auto StackHist = std::make_unique<THStack>((GetSampleTitle(iSample)+"_"+KinematicProjection+"_Stack").c_str(),"");

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -1767,7 +1767,6 @@ bool SampleHandlerBase::IsSubEventVarString(const std::string& VarStr) const {
   }
   return false;
 }
-// ===============================================================
 
 // ************************************************
 std::vector<KinematicCut> SampleHandlerBase::BuildModeChannelSelection(const int iSample, const int kModeToFill, const int kChannelToFill) const {
@@ -1980,6 +1979,24 @@ void SampleHandlerBase::PrintIntegral(const int iSample, const TString& OutputFi
 }
 
 // ************************************************
+int SampleHandlerBase::GetRangeForPlotType(const int TypeEnum, const int iSample) const {
+// ************************************************
+  int iMax = -1;
+  switch (TypeEnum) {
+    case SamplePlotType::kModePlot:
+      iMax = Modes->GetNModes();
+      break;
+    case SamplePlotType::kOscChannelPlot:
+      iMax = GetNOscChannels(iSample);
+      break;
+    default:
+      MACH3LOG_ERROR("You've passed me a Selection1 which was not implemented in ReturnHistsBySelection1D. Selection1 and Selection2 are counters for different indexable quantities");
+      throw MaCh3Exception(__FILE__, __LINE__);
+  }
+  return iMax;
+}
+
+// ************************************************
 std::vector<std::unique_ptr<TH1>> SampleHandlerBase::ReturnHistsBySelection1D(const int iSample, const std::string& KinematicProjection,
                                                                               const int Selection1, const int Selection2, const int WeightStyle) {
 // ************************************************
@@ -1989,27 +2006,16 @@ std::vector<std::unique_ptr<TH1>> SampleHandlerBase::ReturnHistsBySelection1D(co
   if (THStackLeg != nullptr) {delete THStackLeg;}
   THStackLeg = new TLegend(0.1,0.1,0.9,0.9);
 
-  int iMax = -1;
-  if (Selection1 == FDPlotType::kModePlot) {
-    iMax = Modes->GetNModes();
-  }
-  if (Selection1 == FDPlotType::kOscChannelPlot) {
-    iMax = GetNOscChannels(iSample);
-  }
-  if (iMax == -1) {
-    MACH3LOG_ERROR("You've passed me a Selection1 which was not implemented in ReturnHistsBySelection1D. Selection1 and Selection2 are counters for different indexable quantities");
-    throw MaCh3Exception(__FILE__, __LINE__);
-  }
-
+  const int iMax = GetRangeForPlotType(Selection1, iSample);
   for (int i=0;i<iMax;i++) {
-    if (Selection1 == FDPlotType::kModePlot) {
+    if (Selection1 == SamplePlotType::kModePlot) {
       hHistList.push_back(Get1DVarHistByModeAndChannel(iSample, KinematicProjection,i,Selection2,WeightStyle));
       THStackLeg->AddEntry(hHistList[i].get(), (Modes->GetMaCh3ModeName(i)+Form(" : (%4.2f)",hHistList[i]->Integral())).c_str(),"f");
 
       hHistList[i]->SetFillColor(static_cast<Color_t>(Modes->GetMaCh3ModePlotColor(i)));
       hHistList[i]->SetLineColor(static_cast<Color_t>(Modes->GetMaCh3ModePlotColor(i)));
     }
-    if (Selection1 == FDPlotType::kOscChannelPlot) {
+    if (Selection1 == SamplePlotType::kOscChannelPlot) {
       hHistList.push_back(Get1DVarHistByModeAndChannel(iSample, KinematicProjection,Selection2,i,WeightStyle));
       THStackLeg->AddEntry(hHistList[i].get(),(GetFlavourName(iSample, i)+Form(" | %4.2f",hHistList[i]->Integral())).c_str(),"f");
     }
@@ -2025,23 +2031,12 @@ std::vector<std::unique_ptr<TH2>> SampleHandlerBase::ReturnHistsBySelection2D(co
 // ************************************************
   std::vector<std::unique_ptr<TH2>> hHistList;
 
-  int iMax = -1;
-  if (Selection1 == FDPlotType::kModePlot) {
-    iMax = Modes->GetNModes();
-  }
-  if (Selection1 == FDPlotType::kOscChannelPlot) {
-    iMax = GetNOscChannels(iSample);
-  }
-  if (iMax == -1) {
-    MACH3LOG_ERROR("You've passed me a Selection1 which was not implemented in ReturnHistsBySelection1D. Selection1 and Selection2 are counters for different indexable quantities");
-    throw MaCh3Exception(__FILE__, __LINE__);
-  }
-
+  const int iMax = GetRangeForPlotType(Selection1, iSample);
   for (int i=0;i<iMax;i++) {
-    if (Selection1 == FDPlotType::kModePlot) {
+    if (Selection1 == SamplePlotType::kModePlot) {
       hHistList.push_back(Get2DVarHistByModeAndChannel(iSample, KinematicProjectionX,KinematicProjectionY,i,Selection2,WeightStyle));
     }
-    if (Selection1 == FDPlotType::kOscChannelPlot) {
+    if (Selection1 == SamplePlotType::kOscChannelPlot) {
       hHistList.push_back(Get2DVarHistByModeAndChannel(iSample, KinematicProjectionX,KinematicProjectionY,Selection2,i,WeightStyle));
     }
   }

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -1991,7 +1991,7 @@ int SampleHandlerBase::GetRangeForPlotType(const SamplePlotType TypeEnum, const 
       return GetNOscChannels(iSample);
       break;
     default:
-      MACH3LOG_ERROR("You've passed me a SamplePlotType with value {} which was not implemented.", TypeEnum);
+      MACH3LOG_ERROR("You've passed me a SamplePlotType with value {} which was not implemented.", static_cast<int>(TypeEnum));
       throw MaCh3Exception(__FILE__, __LINE__);
   }
 }

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -1998,7 +1998,7 @@ int SampleHandlerBase::GetRangeForPlotType(const SamplePlotType TypeEnum, const 
 
 // ************************************************
 std::vector<std::unique_ptr<TH1>> SampleHandlerBase::ReturnHistsBySelection1D(const int iSample, const std::string& KinematicProjection,
-                                                                              const SamplePlotType Selection1, const int Selection2, const int WeightStyle) {
+                                                                              const int Selection1, const int Selection2, const int WeightStyle) {
 // ************************************************
   std::vector<std::unique_ptr<TH1>> hHistList;
   std::string legendEntry;
@@ -2006,7 +2006,7 @@ std::vector<std::unique_ptr<TH1>> SampleHandlerBase::ReturnHistsBySelection1D(co
   if (THStackLeg != nullptr) {delete THStackLeg;}
   THStackLeg = new TLegend(0.1,0.1,0.9,0.9);
 
-  const int iMax = GetRangeForPlotType(Selection1, iSample);
+  const int iMax = GetRangeForPlotType(static_cast<SamplePlotType>(Selection1), iSample);
   for (int i=0;i<iMax;i++) {
     if (Selection1 == SamplePlotType::kModePlot) {
       hHistList.push_back(Get1DVarHistByModeAndChannel(iSample, KinematicProjection,i,Selection2,WeightStyle));
@@ -2026,12 +2026,12 @@ std::vector<std::unique_ptr<TH1>> SampleHandlerBase::ReturnHistsBySelection1D(co
 
 // ************************************************
 std::vector<std::unique_ptr<TH2>> SampleHandlerBase::ReturnHistsBySelection2D(const int iSample, const std::string& KinematicProjectionX,
-                                                                              const std::string& KinematicProjectionY, const SamplePlotType Selection1,
+                                                                              const std::string& KinematicProjectionY, const int Selection1,
                                                                               const int Selection2, const int WeightStyle) {
 // ************************************************
   std::vector<std::unique_ptr<TH2>> hHistList;
 
-  const int iMax = GetRangeForPlotType(Selection1, iSample);
+  const int iMax = GetRangeForPlotType(static_cast<SamplePlotType>(Selection1), iSample);
   for (int i=0;i<iMax;i++) {
     if (Selection1 == SamplePlotType::kModePlot) {
       hHistList.push_back(Get2DVarHistByModeAndChannel(iSample, KinematicProjectionX,KinematicProjectionY,i,Selection2,WeightStyle));
@@ -2046,7 +2046,7 @@ std::vector<std::unique_ptr<TH2>> SampleHandlerBase::ReturnHistsBySelection2D(co
 
 // ************************************************
 std::unique_ptr<THStack> SampleHandlerBase::ReturnStackedHistBySelection1D(const int iSample, const std::string& KinematicProjection,
-                                                                           const SamplePlotType Selection1, int Selection2, int WeightStyle) {
+                                                                           const int Selection1, int Selection2, int WeightStyle) {
 // ************************************************
   auto HistList = ReturnHistsBySelection1D(iSample, KinematicProjection, Selection1, Selection2, WeightStyle);
   auto StackHist = std::make_unique<THStack>((GetSampleTitle(iSample)+"_"+KinematicProjection+"_Stack").c_str(),"");

--- a/Samples/SampleHandlerBase.h
+++ b/Samples/SampleHandlerBase.h
@@ -38,6 +38,7 @@ class SampleHandlerBase :  public SampleHandlerInterface
   /// @copydoc SampleHandlerInterface::GetSampleTitle
   std::string GetSampleTitle(const int Sample) const final {return SampleDetails[Sample].SampleTitle;}
   /// @brief Sample name tag used only for getting relevant uncertainties
+  /// @param Sample Index of the sample.
   std::string GetSampleName(const int Sample) const {return SampleDetails[Sample].SampleName;}
   /// @copydoc SampleHandlerInterface::GetKinVarName
   std::string GetKinVarName(const int iSample, const int Dimension) const final;
@@ -108,11 +109,14 @@ class SampleHandlerBase :  public SampleHandlerInterface
   std::unique_ptr<TH2> Get2DVarHist(const int iSample, const std::string& ProjectionVarX, const std::string& ProjectionVarY,
                                     const std::vector< KinematicCut >& EventSelectionVec = {},
                                     int WeightStyle = 0, const std::vector< KinematicCut >& SubEventSelectionVec = {}) final;
+  /// @brief Construct vector of kinematic cuts that will be applied, on top of default cuts include stuff like cut on mode etc.
+  /// @param Sample Index of the sample.
   std::vector<KinematicCut> BuildModeChannelSelection(const int iSample, const int kModeToFill, const int kChannelToFill) const;
-
+  /// @brief Fill projection histogram by looping over all events, and skipping one which doens't pass specified condition
   void Fill1DSubEventHist(const int iSample, TH1D* _h1DVar, const std::string& ProjectionVar,
                           const std::vector< KinematicCut >& SubEventSelectionVec = {},
                           int WeightStyle=0);
+  /// @brief Fill projection histogram by looping over all events, and skipping one which doesn't pass specified condition
   void Fill2DSubEventHist(const int iSample, TH2* _h2DVar, const std::string& ProjectionVarX, const std::string& ProjectionVarY,
                           const std::vector< KinematicCut >& SubEventSelectionVec = {}, int WeightStyle = 0);
   /// @copydoc SampleHandlerInterface::Get1DVarHistByModeAndChannel
@@ -123,13 +127,18 @@ class SampleHandlerBase :  public SampleHandlerInterface
   std::unique_ptr<TH2> Get2DVarHistByModeAndChannel(const int iSample, const std::string& ProjectionVar_StrX,
                                                     const std::string& ProjectionVar_StrY, const int kModeToFill = -1,
                                                     const int kChannelToFill = -1, const int WeightStyle = 0) final;
-
+  /// @brief Produce 1D projection into X-variable, for a single MaCh3 mode
   std::unique_ptr<TH1> GetModeHist1D(const int iSample, int s, int m, int style = 0) {
     return Get1DVarHistByModeAndChannel(iSample, GetKinVarName(iSample, 0), m, s, style);
   }
+  /// @brief Produce 2D projection into X-variable, and Y-variable for a single MaCh3 mode
   std::unique_ptr<TH2> GetModeHist2D(const int iSample, int s, int m, int style = 0) {
     return Get2DVarHistByModeAndChannel(iSample, GetKinVarName(iSample, 0), GetKinVarName(iSample, 1), m, s, style);
   }
+  /// @brief KS: Return range for plot type, for example number of modes, osc channels etc
+  /// @param TypeEnum Plot type enumerator see @ref SampleHandlerBase::SamplePlotType
+  /// @param iSample Sample enumerator
+  int GetRangeForPlotType(const int TypeEnum, const int iSample) const;
 
   std::vector<std::unique_ptr<TH1>> ReturnHistsBySelection1D(const int iSample, const std::string& KinematicProjection,
                                                              const int Selection1, const int Selection2 = -1,
@@ -440,7 +449,7 @@ class SampleHandlerBase :  public SampleHandlerInterface
   /// Mapping from input file names to final neutrino PDG codes.
   std::unordered_map<std::string, NuPDG> FileToFinalPDGMap;
 
-  enum FDPlotType {
+  enum SamplePlotType {
     kModePlot = 0,
     kOscChannelPlot = 1
   };

--- a/Samples/SampleHandlerBase.h
+++ b/Samples/SampleHandlerBase.h
@@ -15,6 +15,11 @@ _MaCh3_Safe_Include_Start_ //{
 #include "TLegend.h"
 _MaCh3_Safe_Include_End_ //}
 
+enum SamplePlotType {
+  kModePlot = 0,
+  kOscChannelPlot = 1
+};
+
 /// @brief Class responsible for handling implementation of samples used in analysis, reweighting and returning LLH
 /// @author Dan Barrow
 /// @author Ed Atkin
@@ -112,7 +117,7 @@ class SampleHandlerBase :  public SampleHandlerInterface
   /// @brief Construct vector of kinematic cuts that will be applied, on top of default cuts include stuff like cut on mode etc.
   /// @param Sample Index of the sample.
   std::vector<KinematicCut> BuildModeChannelSelection(const int iSample, const int kModeToFill, const int kChannelToFill) const;
-  /// @brief Fill projection histogram by looping over all events, and skipping one which doens't pass specified condition
+  /// @brief Fill projection histogram by looping over all events, and skipping one which doesn't pass specified condition
   void Fill1DSubEventHist(const int iSample, TH1D* _h1DVar, const std::string& ProjectionVar,
                           const std::vector< KinematicCut >& SubEventSelectionVec = {},
                           int WeightStyle=0);
@@ -136,19 +141,19 @@ class SampleHandlerBase :  public SampleHandlerInterface
     return Get2DVarHistByModeAndChannel(iSample, GetKinVarName(iSample, 0), GetKinVarName(iSample, 1), m, s, style);
   }
   /// @brief KS: Return range for plot type, for example number of modes, osc channels etc
-  /// @param TypeEnum Plot type enumerator see @ref SampleHandlerBase::SamplePlotType
+  /// @param TypeEnum Plot type enumerator see @ref SamplePlotType
   /// @param iSample Sample enumerator
-  int GetRangeForPlotType(const int TypeEnum, const int iSample) const;
+  int GetRangeForPlotType(const SamplePlotType TypeEnum, const int iSample) const;
 
   std::vector<std::unique_ptr<TH1>> ReturnHistsBySelection1D(const int iSample, const std::string& KinematicProjection,
-                                                             const int Selection1, const int Selection2 = -1,
+                                                             const SamplePlotType Selection1, const int Selection2 = -1,
                                                              const int WeightStyle = 0);
   std::vector<std::unique_ptr<TH2>> ReturnHistsBySelection2D(const int iSample, const std::string& KinematicProjectionX,
                                                              const std::string& KinematicProjectionY,
-                                                             const int Selection1, const int Selection2=-1,
+                                                             const SamplePlotType Selection1, const int Selection2 = -1,
                                                              const int WeightStyle=0);
   std::unique_ptr<THStack> ReturnStackedHistBySelection1D(const int iSample, const std::string& KinematicProjection,
-                                          const int Selection1, const int Selection2 = -1, const int WeightStyle = 0);
+                                          const SamplePlotType Selection1, const int Selection2 = -1, const int WeightStyle = 0);
   /// @brief Return the legend used for stacked histograms with sample info
   const TLegend* ReturnStackHistLegend() const {return THStackLeg;}
 
@@ -448,9 +453,4 @@ class SampleHandlerBase :  public SampleHandlerInterface
   std::unordered_map<std::string, NuPDG> FileToInitPDGMap;
   /// Mapping from input file names to final neutrino PDG codes.
   std::unordered_map<std::string, NuPDG> FileToFinalPDGMap;
-
-  enum SamplePlotType {
-    kModePlot = 0,
-    kOscChannelPlot = 1
-  };
 };

--- a/Samples/SampleHandlerBase.h
+++ b/Samples/SampleHandlerBase.h
@@ -146,14 +146,14 @@ class SampleHandlerBase :  public SampleHandlerInterface
   int GetRangeForPlotType(const SamplePlotType TypeEnum, const int iSample) const;
 
   std::vector<std::unique_ptr<TH1>> ReturnHistsBySelection1D(const int iSample, const std::string& KinematicProjection,
-                                                             const SamplePlotType Selection1, const int Selection2 = -1,
+                                                             const int Selection1, const int Selection2 = -1,
                                                              const int WeightStyle = 0);
   std::vector<std::unique_ptr<TH2>> ReturnHistsBySelection2D(const int iSample, const std::string& KinematicProjectionX,
                                                              const std::string& KinematicProjectionY,
-                                                             const SamplePlotType Selection1, const int Selection2 = -1,
+                                                             const int Selection1, const int Selection2 = -1,
                                                              const int WeightStyle=0);
   std::unique_ptr<THStack> ReturnStackedHistBySelection1D(const int iSample, const std::string& KinematicProjection,
-                                          const SamplePlotType Selection1, const int Selection2 = -1, const int WeightStyle = 0);
+                                          const int Selection1, const int Selection2 = -1, const int WeightStyle = 0);
   /// @brief Return the legend used for stacked histograms with sample info
   const TLegend* ReturnStackHistLegend() const {return THStackLeg;}
 


### PR DESCRIPTION
# Pull request description
Simply, we no longer define twice getter for iMax.
It is simple code but since we declare it twice better to have helper function

## Changes or fixes
- Check bounds now uses branchless comparison instead of if, and without multithreading. Did benchmark and new is much faster. It doesn't matter at all as this operation is sub percent of total step time...
- Renamed FDPlotType into SamplePlotType

## Examples

Benchmark results for check bounds
```
===== N = 100 =====
Branchless: 0.021882 ms (result=48000)
Scalar: 0.053182 ms (result=48000)
OMP Branchless: 1.76174 ms (result=48000)
OMP: 1.06407 ms (result=48000)

===== N = 1000 =====
Branchless: 0.347344 ms (result=466000)
Scalar: 1.26515 ms (result=466000)
OMP Branchless: 1.08954 ms (result=466000)
OMP: 1.03105 ms (result=466000)

===== N = 5000 =====
Branchless: 1.79323 ms (result=2461000)
Scalar: 4.45375 ms (result=2461000)
OMP Branchless: 1.3847 ms (result=2461000)
OMP: 1.8341 ms (result=2461000)
[root@be08be133572 hosthome]#
```

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
