### PR TITLE
tidy: add deprecation warning for GetModeHist1D

### DIFF
--- a/Samples/SampleHandlerBase.h
+++ b/Samples/SampleHandlerBase.h
@@ -124,10 +124,10 @@ class SampleHandlerBase :  public SampleHandlerInterface
                                                     const std::string& ProjectionVar_StrY, const int kModeToFill = -1,
                                                     const int kChannelToFill = -1, const int WeightStyle = 0) final;
 
-  std::unique_ptr<TH1> GetModeHist1D(const int iSample, int s, int m, int style = 0) {
+  [[deprecated]] std::unique_ptr<TH1> GetModeHist1D(const int iSample, int s, int m, int style = 0) {
     return Get1DVarHistByModeAndChannel(iSample, GetKinVarName(iSample, 0), m, s, style);
   }
-  std::unique_ptr<TH2> GetModeHist2D(const int iSample, int s, int m, int style = 0) {
+  [[deprecated]] std::unique_ptr<TH2> GetModeHist2D(const int iSample, int s, int m, int style = 0) {
     return Get2DVarHistByModeAndChannel(iSample, GetKinVarName(iSample, 0), GetKinVarName(iSample, 1), m, s, style);
   }
 


### PR DESCRIPTION
# Pull request description
For more see this: 
https://t2k-experiment.slack.com/archives/C08MMSCFWDV/p1778667053954489

but tl:dr these functions are not used and and hardcoded to assume X-Var/Y-Var which can be wrong for some analysis in future.

## Examples
<img width="2430" height="268" alt="image" src="https://github.com/user-attachments/assets/29bb5562-da02-4f61-937b-95a21df5723d" />



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
