### PR TITLE
feat: Prevent using gaussian prior and circular prior

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -148,6 +148,12 @@ void ParameterHandlerBase::EnableSpecialProposal(const YAML::Node& param, const 
                      _fLowBound.at(Index), _fUpBound.at(Index));
       throw MaCh3Exception(__FILE__, __LINE__);
     }
+    // KS: Make sure CircularPrior is applied only to param with flat prior. Sadly doesn't work with Gaussian
+    if(GetFlatPrior(Index) == false) {
+      MACH3LOG_ERROR("Enabled CircularPrior for parameter {}, which has gaussian prior", GetParFancyName(Index));
+      MACH3LOG_ERROR("This is not supported, CircularPrior only works with flat prior");
+      throw MaCh3Exception(__FILE__, __LINE__);
+    }
   }
 
   if (FlipEnabled) {

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -152,6 +152,7 @@ void ParameterHandlerBase::EnableSpecialProposal(const YAML::Node& param, const 
     if(GetFlatPrior(Index) == false) {
       MACH3LOG_ERROR("Enabled CircularPrior for parameter {}, which has gaussian prior", GetParFancyName(Index));
       MACH3LOG_ERROR("This is not supported, CircularPrior only works with flat prior");
+      MACH3LOG_ERROR("Change FlatPrior in Parameter config to true");
       throw MaCh3Exception(__FILE__, __LINE__);
     }
   }


### PR DESCRIPTION
# Pull request description
This has been noticed while debugging Unitarity triangles with Marvin.
Right now, we don't support circular prior with Gaussian so throw error


## Examples
Example of Error
<img width="1541" height="207" alt="image" src="https://github.com/user-attachments/assets/4baa7bcb-b7b5-4aa7-aa65-b55468319310" />

Example of Delta CP using Gaussian prior only (no sample).
<img width="1324" height="1320" alt="image" src="https://github.com/user-attachments/assets/70e115f6-e5d5-4155-bd67-d0f010e75bd2" />


---
- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
