### PR TITLE
tidy: Sanize DiagMCMC for hadded chains

### DIFF
--- a/Fitters/MCMCProcessor.cpp
+++ b/Fitters/MCMCProcessor.cpp
@@ -3549,7 +3549,7 @@ void MCMCProcessor::PrepareDiagMCMC() {
   clock.Stop();
   MACH3LOG_INFO("Took {:.2f}s to finish caching statistic for Diag MCMC with {} steps", clock.RealTime(), nEntries);
 
-  if(AllUnique(StepNumber, nEntries)){
+  if(AllUnique(StepNumber, nEntries) == false){
     MACH3LOG_ERROR("Found steps with duplicate StepNumber, this indicate merged chain has been passed to DiagMCMC");
     MACH3LOG_ERROR("Code hasn't been optimised to work with merged chains, results may be unintended");
     throw MaCh3Exception(__FILE__ , __LINE__ );

--- a/Fitters/MCMCProcessor.cpp
+++ b/Fitters/MCMCProcessor.cpp
@@ -3403,6 +3403,12 @@ void MCMCProcessor::DiagMCMC() {
   AcceptanceProbabilities();
 }
 
+// Check if all entries in StepNumber are unique
+bool AllUnique(unsigned int* StepNumber, size_t size) {
+  std::unordered_set<unsigned int> s(StepNumber, StepNumber + size);
+  return s.size() == size;
+}
+
 // **************************
 //CW: Prepare branches etc. for DiagMCMC
 void MCMCProcessor::PrepareDiagMCMC() {
@@ -3543,6 +3549,11 @@ void MCMCProcessor::PrepareDiagMCMC() {
   clock.Stop();
   MACH3LOG_INFO("Took {:.2f}s to finish caching statistic for Diag MCMC with {} steps", clock.RealTime(), nEntries);
 
+  if(AllUnique(StepNumber, nEntries)){
+    MACH3LOG_ERROR("Found steps with duplicate StepNumber, this indicate merged chain has been passed to DiagMCMC");
+    MACH3LOG_ERROR("Code hasn't been optimised to work with merged chains, results may be unintended");
+    throw MaCh3Exception(__FILE__ , __LINE__ );
+  }
   // Make the sums into average
   #ifdef MULTITHREAD
   #pragma omp parallel for


### PR DESCRIPTION
# Pull request description
Sadly DiagMCMC don't work very well with hadded chains.
Problem only concerns parallel chains, if this is one chain from another all is fine.

This is because we run over nEntires so best example is Trace plot.
We run over first chain, then switch to second but code still loops over entries.
This will lead to discontinuity.

Which is not huge problem but for non-experienced user may cause confusion.

---
- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).