### PR TITLE
bugfix: use mach3 double formatter to round according to sig figs in make covariance matrix

### DIFF
--- a/Parameters/ParameterHandlerUtils.h
+++ b/Parameters/ParameterHandlerUtils.h
@@ -330,7 +330,7 @@ inline void MakeCorrelationMatrix(YAML::Node& root,
       YAML::Node& syst_i = it_i->second;
 
       syst_i["ParameterValues"]["PreFitValue"] = M3::Utils::FormatDouble(Values[i], 4);
-      syst_i["Error"] = std::round(Errors[i] * 100.0) / 100.0;
+      syst_i["Error"] = M3::Utils::FormatDouble(Errors[i], 4);
 
       YAML::Node correlationsNode = YAML::Node(YAML::NodeType::Sequence);
       for (std::size_t j = 0; j < FancyNames.size(); ++j) {
@@ -358,7 +358,7 @@ inline void MakeCorrelationMatrix(YAML::Node& root,
       }
 
       syst["ParameterValues"]["PreFitValue"] = M3::Utils::FormatDouble(Values[i], 4);
-      syst["Error"] = std::round(Errors[i] * 100.0) / 100.0;
+      syst["Error"] = M3::Utils::FormatDouble(Errors[i], 4);
 
       YAML::Node correlationsNode = YAML::Node(YAML::NodeType::Sequence);
       for (std::size_t j = 0; j < Correlation[i].size(); ++j) {


### PR DESCRIPTION
# Pull request description

Addressing issue #900:
> Some of the numbers in the postfit covariance matrices produced by [MakeCovarianceMatrix](https://github.com/mach3-software/MaCh3/blob/b972520b4c6b93ff40b2d2438b5fdfae86be0f59/Parameters/ParameterHandlerUtils.h#L281) are rounded to 2 d.p (see [here](https://github.com/mach3-software/MaCh3/blob/b972520b4c6b93ff40b2d2438b5fdfae86be0f59/Parameters/ParameterHandlerUtils.h#L361)).

> In some fits I have been looking at, the errors are O(0.01) so an appreciable amount of information is lost this way. Rounding to 2 significant figures would be best.

## Changes or fixes

Now using `M3::Utils::FormatDouble` which was used elsewhere in the same function, e.g. for the parameter prefit values. This already rounds to significant figures. I've set the number to be 4 significant figures.

---

- [X] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
