### PR TITLE
feat: cmake support for build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,16 @@ option(MaCh3_GPU_ENABLED "Use GPU acceleration or not" ON)
 option(MaCh3_NuOsc_GPU_ENABLED "By default MaCh3 will use NuOscillator with GPU if MaCh3 is compiled with GPU, this flag allows disabling GPU for NuOscillator even if MaCh3 has GPU enabled" ON)
 set(MaCh3_PYTHON_INSTALL_DIR  CACHE STRING "The location to install the MaCh3 python module to (if MaCh3_PYTHON_ENABLED is set to ON). If not set then will be installed in the build location of MaCh3")
 
+if (NOT DEFINED CMAKE_BUILD_TYPE OR
+        CMAKE_BUILD_TYPE STREQUAL "Release" OR
+        CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo ")
+  # Do nothing as this is default
+elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(MaCh3_DEBUG_ENABLED ON)
+else()
+  cmessage(FATAL_ERROR "Passed not supported build type: ${CMAKE_BUILD_TYPE}")
+endif()
+
 if ("${MaCh3_PYTHON_INSTALL_DIR}" STREQUAL "")
   set(MaCh3_PYTHON_INSTALL_DIR ${PROJECT_BINARY_DIR}/pyMaCh3)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (NOT DEFINED CMAKE_BUILD_TYPE OR
 elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(MaCh3_DEBUG_ENABLED ON)
 else()
-  cmessage(FATAL_ERROR "Passed not supported build type: ${CMAKE_BUILD_TYPE}")
+  message(FATAL_ERROR "Passed not supported build type: ${CMAKE_BUILD_TYPE}")
 endif()
 
 if ("${MaCh3_PYTHON_INSTALL_DIR}" STREQUAL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,9 @@ option(MaCh3_NuOsc_GPU_ENABLED "By default MaCh3 will use NuOscillator with GPU 
 set(MaCh3_PYTHON_INSTALL_DIR  CACHE STRING "The location to install the MaCh3 python module to (if MaCh3_PYTHON_ENABLED is set to ON). If not set then will be installed in the build location of MaCh3")
 
 if (NOT DEFINED CMAKE_BUILD_TYPE OR
+        CMAKE_BUILD_TYPE STREQUAL "" OR
         CMAKE_BUILD_TYPE STREQUAL "Release" OR
-        CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo ")
+        CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
   # Do nothing as this is default
 elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(MaCh3_DEBUG_ENABLED ON)


### PR DESCRIPTION
# Pull request description
Cmake provides several build types
https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html

We haven't been using this feature at MaCh3, even though it is standard.

The only thing that it does is set MaCh3 options based on Build type.
For example, if build type is debug, then it will enable debugging within MaCh3

The issue has been brought up by Luke

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
