### PR TITLE
feat: implement map for spline index

### DIFF
--- a/Splines/BinnedSplineHandler.cpp
+++ b/Splines/BinnedSplineHandler.cpp
@@ -681,23 +681,7 @@ bool BinnedSplineHandler::isValidSplineIndex(const std::string& SampleTitle, int
 //****************************************
   int iSample = GetSampleIndex(SampleTitle);
 
-  // find matching entry in flat structure
-  bool found = false;
-
-  for (const auto& entry : IndexVect)
-  {
-    if (entry.iSample  == iSample  &&
-       entry.iOscChan == iOscChan &&
-       entry.iSyst    == iSyst    &&
-       entry.iMode    == iMode    &&
-       entry.iVar1    == iVar1    &&
-       entry.iVar2    == iVar2    &&
-       entry.iVar3    == iVar3)
-    {
-      found = true;
-      break;
-    }
-  }
+  bool found = IndexVectMap.find(std::make_tuple(iSample, iOscChan, iSyst, iMode, iVar1, iVar2, iVar3)) != IndexVectMap.end();
 
   if (!found)
   {

--- a/Splines/BinnedSplineHandler.cpp
+++ b/Splines/BinnedSplineHandler.cpp
@@ -46,6 +46,7 @@ void BinnedSplineHandler::CleanUpMemory() {
   //Not a huge saving but it's better than leaving everything up to the compiler
   MACH3LOG_INFO("Cleaning up spline memory");
   CleanVector(IndexVect);
+  IndexVectMap.clear();
   CleanVector(SplineFileParPrefixNames);
   CleanVector(GlobalSystIndex);
   CleanVector(SplineModeVecs);
@@ -1067,6 +1068,11 @@ void BinnedSplineHandler::LoadIndexDir(std::unique_ptr<TFile>& SplineFile) {
   for (Long64_t iEntry = 0; iEntry < IndexTree->GetEntries(); ++iEntry) {
     IndexTree->GetEntry(iEntry);
     IndexVect[iEntry] = *IndexTemp;
+
+    auto key = std::make_tuple(IndexTemp->iSample, IndexTemp->iOscChan, IndexTemp->iSyst,
+                               IndexTemp->iMode, IndexTemp->iVar1, IndexTemp->iVar2, 
+                               IndexTemp->iVar3);
+    IndexVectMap[key] = static_cast<int>(iEntry);
   }
 
   // Load SplineBinning data

--- a/Splines/BinnedSplineHandler.cpp
+++ b/Splines/BinnedSplineHandler.cpp
@@ -333,6 +333,7 @@ void BinnedSplineHandler::BuildSampleIndexingArray(const std::string& SampleTitl
               entry.iVar2    = iVar2;
               entry.iVar3    = iVar3;
               IndexVect.push_back(entry);
+              IndexVectMap[std::make_tuple(iSample, iOscChan, iSyst, iMode, iVar1, iVar2, iVar3)] = static_cast<int>(IndexVect.size() - 1);
             }
           }
         }
@@ -444,36 +445,10 @@ std::vector<TAxis *> BinnedSplineHandler::FindSplineBinning(const std::string& F
 }
 
 //****************************************
-int GetSplineIndex(const std::vector<SplineIndex>& vec,
-                   const int sample, const int oscchan, const int syst, const int mode,
-                   const int var1bin, const int var2bin, const int var3bin) {
-//****************************************
-  /// @todo KS: quoting Dan: I imagine all splines are loaded such that they are sequential in varbins etc. so we could optimise this finding function.
-  for (size_t i = 0; i < vec.size(); i++)
-  {
-    const auto& entry = vec[i];
-    if (entry.iSample == sample  &&
-        entry.iOscChan == oscchan &&
-        entry.iSyst    == syst    &&
-        entry.iMode    == mode    &&
-        entry.iVar1    == var1bin &&
-        entry.iVar2    == var2bin &&
-        entry.iVar3    == var3bin)
-    {
-      return static_cast<int>(i);
-    }
-  }
-
-  MACH3LOG_ERROR("Index not found! sample={} oscchan={} syst={} mode={} var1={} var2={} var3={}",
-                 sample, oscchan, syst, mode, var1bin, var2bin, var3bin);
-  throw MaCh3Exception(__FILE__, __LINE__);
-}
-
-//****************************************
 const M3::float_t* BinnedSplineHandler::RetPointer(const int sample, const int oscchan, const int syst, const int mode,
                               const int var1bin, const int var2bin, const int var3bin) const {
 //****************************************
-  auto Index = GetSplineIndex(IndexVect, sample, oscchan, syst, mode, var1bin, var2bin, var3bin);
+  int Index = IndexVectMap.at(std::make_tuple(sample, oscchan, syst, mode, var1bin, var2bin, var3bin));
   return &weightvec_Monolith[IndexVect[Index].value];
 }
 
@@ -790,7 +765,7 @@ std::vector< std::vector<int> > BinnedSplineHandler::GetEventSplines(const std::
     for(int iMode = 0; iMode<nSampleModes; iMode++) {
       //Only consider if the event mode (Mode) matches ones of the spline modes
       if (Mode == spline_modes[iMode]) {
-        int index = GetSplineIndex(IndexVect, SampleIndex, iOscChan, iSyst, iMode, Var1Bin, Var2Bin, Var3Bin);
+        int index = IndexVectMap.at(std::make_tuple(SampleIndex, iOscChan, iSyst, iMode, Var1Bin, Var2Bin, Var3Bin));
         int splineID = IndexVect[index].value;
         //Also check that the spline isn't flat
         if(!isflatarray[splineID]) {
@@ -940,7 +915,7 @@ void BinnedSplineHandler::FillSampleArray(const std::string& SampleTitle, const 
         }
 
         //Rather than keeping a mega vector of splines then converting, this should just keep everything nice in memory!
-        int index = GetSplineIndex(IndexVect, iSample, iOscChan, SystNum, ModeNum, Var1Bin, Var2Bin, Var3Bin);
+        int index = IndexVectMap.at(std::make_tuple(iSample, iOscChan, SystNum, ModeNum, Var1Bin, Var2Bin, Var3Bin));
         IndexVect[index].value = MonolithIndex;
         coeffindexvec.push_back(CoeffIndex);
         // Should save memory rather saving [x_i_0 ,... x_i_maxknots] for every spline!

--- a/Splines/BinnedSplineHandler.h
+++ b/Splines/BinnedSplineHandler.h
@@ -111,6 +111,8 @@ class BinnedSplineHandler : public SplineBase {
 
     /// @brief Variables related to determined which modes have splines and which piggy-back of other modes
     std::vector<SplineIndex> IndexVect;
+    /// @brief Map between spline origin/properties (iSample, iOscChan, iSyst, iMode, iVar1, iVar2, iVar3) and the index of the spline in IndexVect
+    std::map<std::tuple<int, int, int, int, int, int, int>, int> IndexVectMap;
 
     std::vector<int > coeffindexvec;
     /// Unique coefficient indices


### PR DESCRIPTION
# Pull request description

PR #890 slowed down the spline input/processing. The majority of the slowdown was tracked down to two related functions:
1. `GetSplineIndex` function, which matched `iSample, iOscChan, iSyst, iMode, iVar1, iVar2, iVar3` to a spline by looping through each spline in `IndexVect` and checking for a match, which has O(n) lookup performance. 
2. `isValidSplineIndex` function, which checked that a set of `iSample, iOscChan, iSyst, iMode, iVar1, iVar2, iVar3` corresponded to an entry in `IndexVect`, which worked by looping through every entry in `IndexVect`.

The `GetSplineIndex` function has been replaced by an std::map, and `isValidSplineIndex` has been changed to check for the existence of a key in the std::map. In both cases, the performance improvement is from O(n) -> O(log n). 

I tried using a std::unordered_map but saw no performance benefit.

---

- [X] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
