### PR TITLE
feat: Allow Plotting Lib to try figure out on it's own param names

### DIFF
--- a/Plotting/PlottingUtils/InputManager.cpp
+++ b/Plotting/PlottingUtils/InputManager.cpp
@@ -3,7 +3,7 @@
 namespace M3 {
 namespace Plotting {
 // this is the constructor with user specified translation config file
-InputManager::InputManager(const std::string &translationConfigName) {
+InputManager::InputManager(const std::string &translationConfigName, const std::vector<std::string>& _fileNames) {
   // read the config file
   _translatorConfig = M3OpenConfig(translationConfigName);
 
@@ -19,6 +19,9 @@ InputManager::InputManager(const std::string &translationConfigName) {
   _knownParameters = Get<std::vector<std::string>>(_parametersConfig["Parameters"], __FILE__, __LINE__);
   _knownSamples = Get<std::vector<std::string>>(_samplesConfig["Samples"], __FILE__, __LINE__);
 
+  if(_knownParameters.size() == 0){
+    _knownParameters = TryToFindDefaultParamNames(_fileNames[0]);
+  }
   MACH3LOG_DEBUG("Will now check the specified parameters for tags");
 
   // loop through all parameters and get their tags
@@ -55,6 +58,10 @@ InputManager::InputManager(const std::string &translationConfigName) {
       }
     }
     _sampleToTagsMap[samp] = tags;
+  }
+
+  for (std::string fileName : _fileNames) {
+    addFile(fileName);
   }
 }
 
@@ -823,7 +830,7 @@ void InputManager::fillFileData(InputFile &inputFileDef, const bool printThought
       // double check that we actually found it.. just in case
       if (LLHObj == nullptr)
       {
-        MACH3LOG_ERROR("Hmmm, something seems to have gone wrong and I couldnt find the {} LLH scan for {} when attempting to read the data for it", LLHType, parameter);
+        MACH3LOG_ERROR("Hmmm, something seems to have gone wrong and I couldn't find the {} LLH scan for {} when attempting to read the data for it", LLHType, parameter);
         MACH3LOG_ERROR("This will very likely cause segfaults and sadness");
       }
 
@@ -883,5 +890,49 @@ void InputManager::fillFileData(InputFile &inputFileDef, const bool printThought
     find1dPosterior(inputFileDef, parameter, inputFileDef.fitter, true);
   }
 }
+
+std::vector<std::string> InputManager::TryToFindDefaultParamNames(const std::string& fileName) const {
+  std::vector<std::string> ParamNames;
+  auto file = std::unique_ptr<TFile>(TFile::Open(fileName.c_str()));
+  // MCMC processor output format
+  if (auto* ProcessorDir = dynamic_cast<TDirectory*>(file->Get("Post"));
+  ProcessorDir != nullptr)
+  {
+    TIter next(ProcessorDir->GetListOfKeys());
+
+    while (auto* key = dynamic_cast<TKey*>(next())) {
+      ParamNames.emplace_back(key->GetName());
+      MACH3LOG_DEBUG("Adding name {}, assuming MCMC Processor file", ParamNames.back());
+    }
+
+    return ParamNames;
+  }
+
+  // LLH scan format
+  if (auto* llhDir = dynamic_cast<TDirectory*>(file->Get("Total_LLH"));
+  llhDir != nullptr)
+  {
+    TIter next(llhDir->GetListOfKeys());
+
+    while (auto* key = dynamic_cast<TKey*>(next())) {
+      std::string name = key->GetName();
+      // Remove _total from hist name
+      const char suffix[] = "_full";
+      const std::size_t suffix_len = sizeof(suffix) - 1;
+      name.erase(name.size() - suffix_len);
+      ParamNames.push_back(std::move(name));
+      MACH3LOG_DEBUG("Adding name {}, assuming LLH scan file", ParamNames.back());
+    }
+
+    return ParamNames;
+  }
+
+   MACH3LOG_ERROR("You didn't specify any parameter in universalTranslator.yaml");
+   MACH3LOG_ERROR("Also you specified file I don't know format of so couldn't atomically find params");
+   throw MaCh3Exception(__FILE__, __LINE__);
+   return ParamNames;
+}
+
+
 } // namespace Plotting
 } // namespace M3

--- a/Plotting/PlottingUtils/InputManager.h
+++ b/Plotting/PlottingUtils/InputManager.h
@@ -228,7 +228,7 @@ public:
   /// @param translationConfigName The config file defining the fitter file structures, fit
   /// parameter, and what the parameters are called in each fitter.
   /// @return Constructed InputManager instance.
-  InputManager(const std::string &translationConfigName);
+  InputManager(const std::string &translationConfigName, const std::vector<std::string>& _fileNames);
 
   /// @brief Add a new InputFile object to this input manager.
   /// @param fileName The name of the file to read.
@@ -635,6 +635,9 @@ private:
     // EM: Default to just return the specified name
     return sample;
   }
+
+
+  std::vector<std::string> TryToFindDefaultParamNames(const std::string& fileNames) const;
 
   // helper fn to test if string "str" ends with other string "ending"
   inline bool strEndsWith(const std::string& str, const std::string& ending) const {

--- a/Plotting/PlottingUtils/PlottingManager.cpp
+++ b/Plotting/PlottingUtils/PlottingManager.cpp
@@ -56,11 +56,7 @@ void PlottingManager::initialise() {
   _styleMan = std::make_unique<StyleManager>(styleConfig);
 
   // create the InputManager and add all the files to it
-  _inputMan = std::make_unique<InputManager>(translationConfig);
-  for (std::string fileName : _fileNames)
-  {
-    _inputMan->addFile(fileName);
-  }
+  _inputMan = std::make_unique<InputManager>(translationConfig, _fileNames);
 }
 
 /// Takes in c style command line arguments and parses particular general ones that are useful for a


### PR DESCRIPTION
# Pull request description
For analysis which have ton of non-standard parameters, adding them all to universalTranslator is pain :(.

There are multiple analysis, for which we don't care much about comparison with other fitters.

This PR if no parameters are specified in translator code will try to figure out names.

This should make using plotting lib more appealing for M3-only folks

## Examples
<img width="1172" height="469" alt="debug_MCMC" src="https://github.com/user-attachments/assets/b41fca93-6edd-46de-bac4-ff4f1de2c777" />
<img width="1132" height="613" alt="debug_LLH" src="https://github.com/user-attachments/assets/70603889-59e7-4c02-b648-e5024b81e945" />
[PostFitParamPlots.pdf](https://github.com/user-attachments/files/28805049/PostFitParamPlots.pdf)
[LLHScan_Sample.pdf](https://github.com/user-attachments/files/28805051/LLHScan_Sample.pdf)

---
- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
