### PR TITLE
tidy: add sanitizers to likelihood fit and minor tidy

### DIFF
--- a/Fitters/MinuitFit.cpp
+++ b/Fitters/MinuitFit.cpp
@@ -27,6 +27,13 @@ MinuitFit::MinuitFit(Manager *man) : LikelihoodFit(man) {
 
   minuit = std::unique_ptr<ROOT::Math::Minimizer>(
     ROOT::Math::Factory::CreateMinimizer(MinimizerType.c_str(), MinimizerAlgo.c_str()));
+
+  std::string Features = gROOT->GetConfigFeatures();
+  if (Features.find("minuit2_omp") != std::string::npos) {
+    MACH3LOG_ERROR("Minuit in ROOT has been compiled with OMP support");
+    MACH3LOG_ERROR("Since MaCh3 uses OMP for reweight this could cause terrible clash");
+    throw MaCh3Exception(__FILE__ , __LINE__ );
+  }
 }
 
 // *************************
@@ -77,7 +84,8 @@ void MinuitFit::RunMCMC() {
     {
       for(int i = 0; i < (*it)->GetNumParams(); ++i, ++ParCounter)
       {
-        //KS: Index, name, prior, step scale [different to MCMC],
+        // KS: Index, name, prior, step scale [different to MCMC],
+        // divide by 10 because this is what BANFF used to do...
         minuit->SetVariable(ParCounter, ((*it)->GetParName(i)), (*it)->GetParPreFit(i), (*it)->GetDiagonalError(i)/10);
         minuit->SetVariableValue(ParCounter, (*it)->GetParPreFit(i));
         //KS: lower bound, upper bound, if Mirroring enabled then ignore
@@ -92,6 +100,8 @@ void MinuitFit::RunMCMC() {
     {
       for(int i = 0; i < (*it)->GetNParameters(); ++i, ++ParCounter)
       {
+        // KS: Index, name, prior, step scale [different to MCMC],
+        // divide by 10 because this is what BANFF used to do...
         minuit->SetVariable(ParCounter, Form("%i_PCA", i), (*it)->GetPCAHandler()->GetParPropPCA(i), (*it)->GetPCAHandler()->GetEigenValuesMaster()[i]/10);
         if((*it)->GetPCAHandler()->IsParameterFixedPCA(i))
         {

--- a/Fitters/MinuitFit.h
+++ b/Fitters/MinuitFit.h
@@ -3,10 +3,12 @@
 //MaCh3 includes
 #include "Fitters/LikelihoodFit.h"
 
+_MaCh3_Safe_Include_Start_ //{
 // ROOT includes
 #include "Math/Minimizer.h"
 #include "Math/Factory.h"
 #include "Math/Functor.h"
+_MaCh3_Safe_Include_End_ //}
 
 /// @brief Implementation of Minuit fitting algorithm
 /// @cite James:2004xla

--- a/Fitters/PSO.cpp
+++ b/Fitters/PSO.cpp
@@ -30,6 +30,14 @@ void PSO::RunMCMC(){
   // Remove obsolete memory and make other checks before fit starts
   SanitiseInputs();
 
+  // Sanitise the adaptive MCMC
+  for (const auto &syst : systematics) {
+    if (syst->GetDoAdaption()) {
+      MACH3LOG_ERROR("Param Handler {} has enabled Adaption, this is not needed for {} so please turn it off", syst->GetName(), GetName());
+      throw MaCh3Exception(__FILE__ , __LINE__ );
+    }
+  }
+
   if(fTestLikelihood){
     outTree->Branch("nParts", &fParticles, "nParts/I");
     for(int i = 0; i < fDim; ++i){
@@ -51,7 +59,7 @@ void PSO::init(){
 // *************************
   fBestValue = M3::_LARGE_LOGL_;
 
-  //KS: For none PCA this will be eqaul to normal parameters
+  //KS: For none PCA this will be equal to normal parameters
   //const int NparsPSOFull = NPars;
   //const int NparsPSO = NParsPCA;
 


### PR DESCRIPTION
# Pull request description
Add following sanitizers:
- Throw error if ROOT uses Open MP for minuit
- Don't use adaptive and PCA

Otherwise remove annoying iterator of vector which is quite long and doesn't help much...



---
- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
