### PR TITLE
tidy: Tweak syntax of GetFromManager for more helpfull messages

### DIFF
--- a/Diagnostics/PlotLLHMap.cpp
+++ b/Diagnostics/PlotLLHMap.cpp
@@ -72,7 +72,7 @@ int main(int argc, char *argv[]) {
 
   // Open the settings and output file
   YAML::Node Settings = M3OpenConfig(std::string(argv[1]));
-  auto OutFileName = GetFromManager<std::string>(Settings["General"]["OutputFile"], "LLHMap.root");
+  auto OutFileName = GetFromManager<std::string>(Settings["General"]["OutputFile"], "LLHMap.root", __FILE__ , __LINE__);
 
   auto OutFile = new TFile(OutFileName.c_str(),"UPDATE");
   OutFile->cd();
@@ -93,7 +93,7 @@ int main(int argc, char *argv[]) {
   ROOT::RDataFrame LLHMap("llhmap", inpFileList);
 
   // Process what parameters to plot
-  auto ParamsOfInterest = GetFromManager<std::vector<std::string>>(Settings["LLHScan"]["LLHParameters"],{});
+  auto ParamsOfInterest = GetFromManager<std::vector<std::string>>(Settings["LLHScan"]["LLHParameters"],{}, __FILE__ , __LINE__);
   std::vector<std::string> ParamsToProfile = GetParams(ParamsOfInterest, LLHMap);
 
   // This now only works for uniform LLHMaps

--- a/Diagnostics/ReweightMCMC.cpp
+++ b/Diagnostics/ReweightMCMC.cpp
@@ -101,15 +101,15 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
         const YAML::Node& reweightConfigNode = reweight.second;
 
         // Check if this particular reweight is enabled !!! Currently only support one reweight at a time so this defaults to enabled
-        if (!GetFromManager<bool>(reweightConfigNode["Enabled"], true)) {
+        if (!GetFromManager<bool>(reweightConfigNode["Enabled"], true, __FILE__ , __LINE__)) {
             MACH3LOG_INFO("Skipping disabled reweight: {}", reweightKey);
             continue;
         }
 
         ReweightConfig reweightConfig;
         reweightConfig.key = reweightKey;
-        reweightConfig.name = GetFromManager<std::string>(reweightConfigNode["ReweightName"], reweightKey);
-        reweightConfig.type = GetFromManager<std::string>(reweightConfigNode["ReweightType"], "Gaussian");
+        reweightConfig.name = GetFromManager<std::string>(reweightConfigNode["ReweightName"], reweightKey, __FILE__ , __LINE__);
+        reweightConfig.type = GetFromManager<std::string>(reweightConfigNode["ReweightType"], "Gaussian", __FILE__ , __LINE__);
         reweightConfig.dimension = GetFromManager<int>(reweightConfigNode["ReweightDim"], 1);
         // reweightConfig.weightBranchName = "Weight_" + reweightKey; // for now all weights will be stored in branches called Weight until multi weight support
         reweightConfig.weightBranchName = "Weight";
@@ -119,7 +119,7 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
         if (reweightConfig.dimension == 1) {
             if (reweightConfig.type == "Gaussian") {
                 // For Gaussian reweights, we need the parameter name(s) and prior values (mean, sigma pairs)
-                auto paramNames = GetFromManager<std::vector<std::string>>(reweightConfigNode["ReweightVar"], {});
+                auto paramNames = GetFromManager<std::vector<std::string>>(reweightConfigNode["ReweightVar"], {}, __FILE__ , __LINE__);
 
                 // Get prior values - handle both single [mean, sigma] pair and list of pairs for safety
                 auto priorNode = reweightConfigNode["ReweightPrior"];
@@ -129,14 +129,14 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
                     // Check if first element is a number (single [mean, sigma] pair) or sequence (list of pairs)
                     if (priorNode[0].IsScalar()) {
                         // Single [mean, sigma] pair - convert to list format
-                        auto priorValues = GetFromManager<std::vector<double>>(priorNode, {});
+                        auto priorValues = GetFromManager<std::vector<double>>(priorNode, {}, __FILE__ , __LINE__);
                         if (priorValues.size() == 2) {
                             allPriorValues.push_back(priorValues);
                         }
                     } else {
                         // List of [mean, sigma] pairs
                         for (const auto& priorPair : priorNode) {
-                            auto priorValues = GetFromManager<std::vector<double>>(priorPair, {});
+                            auto priorValues = GetFromManager<std::vector<double>>(priorPair, {}, __FILE__ , __LINE__);
                             if (priorValues.size() == 2) {
                                 allPriorValues.push_back(priorValues);
                             }
@@ -154,9 +154,9 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
                 }
             } else if (reweightConfig.type == "TGraph") {
                 // For TGraph reweights, we need the parameter name and the TGraph file and name
-                auto paramNames = GetFromManager<std::vector<std::string>>(reweightConfigNode["ReweightVar"], {});
-                std::string fileName = GetFromManager<std::string>(reweightConfigNode["ReweightPrior"]["file"], "");
-                std::string graphName = GetFromManager<std::string>(reweightConfigNode["ReweightPrior"]["graph_name"], "");
+                auto paramNames = GetFromManager<std::vector<std::string>>(reweightConfigNode["ReweightVar"], {}, __FILE__ , __LINE__);
+                std::string fileName = GetFromManager<std::string>(reweightConfigNode["ReweightPrior"]["file"], "", __FILE__ , __LINE__);
+                std::string graphName = GetFromManager<std::string>(reweightConfigNode["ReweightPrior"]["graph_name"], "", __FILE__ , __LINE__);
                 reweightConfig.paramNames = paramNames;
                 reweightConfig.fileName = fileName;
                 reweightConfig.graphName = graphName;
@@ -191,7 +191,7 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
             }
 
         } else if (reweightConfig.dimension == 2) {
-            auto paramNames = GetFromManager<std::vector<std::string>>(reweightConfigNode["ReweightVar"], {});
+            auto paramNames = GetFromManager<std::vector<std::string>>(reweightConfigNode["ReweightVar"], {}, __FILE__ , __LINE__);
 
             // 2D reweights need 2 parameter names
             if (paramNames.size() != 2) {
@@ -203,9 +203,9 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
 
             if (reweightConfig.type == "TGraph2D") {
                 auto priorConfig = reweightConfigNode["ReweightPrior"];
-                reweightConfig.fileName = GetFromManager<std::string>(priorConfig["file"], "");
-                reweightConfig.graphName = GetFromManager<std::string>(priorConfig["graph_name"], "");
-                reweightConfig.hierarchyType = GetFromManager<std::string>(priorConfig["hierarchy"], "auto");
+                reweightConfig.fileName = GetFromManager<std::string>(priorConfig["file"], "", __FILE__ , __LINE__);
+                reweightConfig.graphName = GetFromManager<std::string>(priorConfig["graph_name"], "", __FILE__ , __LINE__);
+                reweightConfig.hierarchyType = GetFromManager<std::string>(priorConfig["hierarchy"], "auto", __FILE__ , __LINE__);
 
                 if (reweightConfig.fileName.empty() || reweightConfig.graphName.empty()) {
                     MACH3LOG_ERROR("Invalid TGraph2D configuration for {}", reweightKey);
@@ -321,7 +321,7 @@ void ReweightMCMC(const std::string& configFile, const std::string& inputFile)
     }
     MACH3LOG_INFO("Loading YAML config from MCMC chain");
     YAML::Node Settings = TMacroToYAML(*Config);
-    bool asimovfit = GetFromManager<bool>(Settings["General"]["Asimov"], false);
+    bool asimovfit = GetFromManager<bool>(Settings["General"]["Asimov"], false, __FILE__ , __LINE__);
     if (asimovfit) {
         MACH3LOG_WARN("MCMC chain was produced from an Asimov fit");
         MACH3LOG_WARN("ReweightMCMC does not currently handle Asimov shifting, results may be incorrect!");

--- a/Diagnostics/SmearChain.cpp
+++ b/Diagnostics/SmearChain.cpp
@@ -25,7 +25,7 @@ void SmearChain(const std::string& inputFile, const std::string& config)
   std::vector<std::string> Names = Get<std::vector<std::string>>(Smear["Smear"][0], __FILE__, __LINE__);
   std::vector<double> ErrorValue = Get<std::vector<double>>(Smear["Smear"][1], __FILE__, __LINE__);
 
-  bool SaveUnsmearedBranch = GetFromManager<bool>(Smear["SaveUnsmearedBranch"], false);
+  bool SaveUnsmearedBranch = GetFromManager<bool>(Smear["SaveUnsmearedBranch"], false, __FILE__ , __LINE__);
   Processor->SmearChain(Names, ErrorValue, SaveUnsmearedBranch);
 }
 

--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -1397,8 +1397,8 @@ void FitterBase::RunSigmaVar() {
   // Save the settings into the output file
   SaveSettings();
 
-  bool plot_by_mode = GetFromManager<bool>(fitMan->raw()["SigmaVar"]["PlotByMode"], false);
-  bool plot_by_channel = GetFromManager<bool>(fitMan->raw()["SigmaVar"]["PlotByChannel"], false);
+  bool plot_by_mode = GetFromManager<bool>(fitMan->raw()["SigmaVar"]["PlotByMode"], false, __FILE__ , __LINE__);
+  bool plot_by_channel = GetFromManager<bool>(fitMan->raw()["SigmaVar"]["PlotByChannel"], false, __FILE__ , __LINE__);
   auto SkipVector = GetFromManager<std::vector<std::string>>(fitMan->raw()["SigmaVar"]["SkipVector"], {}, __FILE__ , __LINE__);
 
   if (plot_by_mode) MACH3LOG_INFO("Plotting by sample and mode");

--- a/Fitters/LikelihoodFit.cpp
+++ b/Fitters/LikelihoodFit.cpp
@@ -6,7 +6,7 @@ LikelihoodFit::LikelihoodFit(Manager *man) : FitterBase(man) {
 // *******************
   NPars = 0;
   NParsPCA = 0;
-  fMirroring = GetFromManager<bool>(fitMan->raw()["General"]["Fitter"]["Mirroring"], false);
+  fMirroring = GetFromManager<bool>(fitMan->raw()["General"]["Fitter"]["Mirroring"], false, __FILE__ , __LINE__);
   if(fMirroring) MACH3LOG_INFO("Mirroring enabled");
 }
 

--- a/Fitters/MCMCBase.cpp
+++ b/Fitters/MCMCBase.cpp
@@ -16,7 +16,7 @@ MCMCBase::MCMCBase(Manager *man) : FitterBase(man) {
         throw MaCh3Exception(__FILE__, __LINE__);
     }
 
-    AnnealTemp = GetFromManager<double>(fitMan->raw()["General"]["MCMC"]["AnnealTemp"], -999);
+    AnnealTemp = GetFromManager<double>(fitMan->raw()["General"]["MCMC"]["AnnealTemp"], -999, __FILE__ , __LINE__);
     if (AnnealTemp < 0)
         anneal = false;
     else

--- a/Fitters/MCMCProcessor.cpp
+++ b/Fitters/MCMCProcessor.cpp
@@ -2503,7 +2503,7 @@ void MCMCProcessor::FindInputFiles() {
 
   bool InputNotFound = false;
   //CW: Get the xsec Covariance matrix
-  CovPos[kXSecPar] = GetFromManager<std::vector<std::string>>(Settings["General"]["Systematics"]["XsecCovFile"], {"none"});
+  CovPos[kXSecPar] = GetFromManager<std::vector<std::string>>(Settings["General"]["Systematics"]["XsecCovFile"], {"none"}, __FILE__ , __LINE__);
   if(CovPos[kXSecPar].back() == "none")
   {
     MACH3LOG_WARN("Couldn't find XsecCov branch in output");
@@ -2563,24 +2563,24 @@ void MCMCProcessor::FindInputFilesLegacy() {
   YAML::Node Settings = TMacroToYAML(*Config);
 
   //CW: And the ND Covariance matrix
-  CovPos[kNDPar].push_back(GetFromManager<std::string>(Settings["General"]["Systematics"]["NDCovFile"], "none"));
+  CovPos[kNDPar].push_back(GetFromManager<std::string>(Settings["General"]["Systematics"]["NDCovFile"], "none", __FILE__ , __LINE__));
 
   if(CovPos[kNDPar].back() == "none") {
     MACH3LOG_WARN("Couldn't find NDCov (legacy) branch in output");
   } else{
     //If the FD Cov is not none, then you need the name of the covariance object to grab
-    CovNamePos[kNDPar] = GetFromManager<std::string>(Settings["General"]["Systematics"]["NDCovName"], "none");
+    CovNamePos[kNDPar] = GetFromManager<std::string>(Settings["General"]["Systematics"]["NDCovName"], "none", __FILE__ , __LINE__);
     MACH3LOG_INFO("Given NDCovFile {} and NDCovName {}", CovPos[kNDPar].back(), CovNamePos[kNDPar]);
   }
 
   //CW: And the FD Covariance matrix
-  CovPos[kFDDetPar].push_back(GetFromManager<std::string>(Settings["General"]["Systematics"]["FDCovFile"], "none"));
+  CovPos[kFDDetPar].push_back(GetFromManager<std::string>(Settings["General"]["Systematics"]["FDCovFile"], "none", __FILE__ , __LINE__));
 
   if(CovPos[kFDDetPar].back() == "none") {
     MACH3LOG_WARN("Couldn't find FDCov (legacy) branch in output");
   } else {
     //If the FD Cov is not none, then you need the name of the covariance object to grab
-    CovNamePos[kFDDetPar] = GetFromManager<std::string>(Settings["General"]["Systematics"]["FDCovName"], "none");
+    CovNamePos[kFDDetPar] = GetFromManager<std::string>(Settings["General"]["Systematics"]["FDCovName"], "none", __FILE__ , __LINE__);
     MACH3LOG_INFO("Given FDCovFile {} and FDCovName {}", CovPos[kFDDetPar].back(), CovNamePos[kFDDetPar]);
   }
 
@@ -2633,7 +2633,7 @@ void MCMCProcessor::ReadModelFile() {
     ParamNames[kXSecPar].push_back(ParName);
     ParamCentral[kXSecPar].push_back(param["Systematic"]["ParameterValues"]["PreFitValue"].as<double>());
     ParamErrors[kXSecPar].push_back(param["Systematic"]["Error"].as<double>() );
-    ParamFlat[kXSecPar].push_back(GetFromManager<bool>(param["Systematic"]["FlatPrior"], false));
+    ParamFlat[kXSecPar].push_back(GetFromManager<bool>(param["Systematic"]["FlatPrior"], false, __FILE__ , __LINE__));
 
     ParameterGroup.push_back(Group);
 

--- a/Fitters/MaCh3Factory.cpp
+++ b/Fitters/MaCh3Factory.cpp
@@ -6,7 +6,7 @@ std::unique_ptr<FitterBase> MaCh3FitterFactory(Manager *fitMan) {
 // ********************************************
   std::unique_ptr<FitterBase> MaCh3Fitter = nullptr;
 
-  auto Algorithm = GetFromManager<std::string>(fitMan->raw()["General"]["FittingAlgorithm"], "MCMC");
+  auto Algorithm = GetFromManager<std::string>(fitMan->raw()["General"]["FittingAlgorithm"], "MCMC", __FILE__ , __LINE__);
 
   if(Algorithm == "MCMC" || Algorithm == "MR2T2") 
   {

--- a/Fitters/MaCh3Factory.h
+++ b/Fitters/MaCh3Factory.h
@@ -78,9 +78,9 @@ std::unique_ptr<CovType> MaCh3CovarianceFactory(Manager *FitManager, const std::
   auto CovMatrixFile = Get<std::vector<std::string>>(Settings[std::string(PreFix) + "CovFile"], __FILE__, __LINE__);
 
   // PCA threshold, -1 means no pca
-  auto PCAThreshold = GetFromManager<int>(Settings[std::string(PreFix) + "PCAThreshold"], -1);
+  auto PCAThreshold = GetFromManager<int>(Settings[std::string(PreFix) + "PCAThreshold"], -1, __FILE__ , __LINE__);
   // do we pca whole matrix or only submatrix
-  auto PCAParamRegion = GetFromManager<std::vector<int>>(Settings[std::string(PreFix) + "PCAParams"], {-999, -999});
+  auto PCAParamRegion = GetFromManager<std::vector<int>>(Settings[std::string(PreFix) + "PCAParams"], {-999, -999}, __FILE__ , __LINE__);
 
   auto CovObject = std::make_unique<CovType>(CovMatrixFile, CovMatrixName, PCAThreshold, PCAParamRegion[0], PCAParamRegion[1]);
 
@@ -88,7 +88,7 @@ std::unique_ptr<CovType> MaCh3CovarianceFactory(Manager *FitManager, const std::
   // should _ALWAYS_ be done before overriding with fix or flat
   CovObject->SetParameters();
 
-  auto FixParams = GetFromManager<std::vector<std::string>>(Settings[std::string(PreFix) + "Fix"], {});
+  auto FixParams = GetFromManager<std::vector<std::string>>(Settings[std::string(PreFix) + "Fix"], {}, __FILE__ , __LINE__);
 
   // Fixed CovObject parameters loop
   if (FixParams.size() == 1 && FixParams.at(0) == "All") {

--- a/Fitters/OscProcessor.cpp
+++ b/Fitters/OscProcessor.cpp
@@ -150,9 +150,9 @@ void OscProcessor::Get1DReactorConstraintInfo(std::pair<double, double>& Sin13_N
     // Simple check: only enable DoReweight if it's a 1D sin2th_13 Gaussian reweight since Savage Dickey process later on generates values from the Gaussian
     if(CheckNodeExists(Settings, "ReweightMCMC")) {
       YAML::Node firstReweight = Settings["ReweightMCMC"].begin()->second;
-      int dimension = GetFromManager<int>(firstReweight["ReweightDim"], 1);
-      std::string reweightType = GetFromManager<std::string>(firstReweight["ReweightType"], "");
-      auto paramNames = GetFromManager<std::vector<std::string>>(firstReweight["ReweightVar"], {});
+      int dimension = GetFromManager<int>(firstReweight["ReweightDim"], 1, __FILE__ , __LINE__);
+      std::string reweightType = GetFromManager<std::string>(firstReweight["ReweightType"], "", __FILE__ , __LINE__);
+      auto paramNames = GetFromManager<std::vector<std::string>>(firstReweight["ReweightVar"], {}, __FILE__ , __LINE__);
       if (dimension == 1 && reweightType == "Gaussian" && paramNames.size() == 1){
         Sin13_NewPrior = Get<std::pair<double, double>>(firstReweight["ReweightPrior"],__FILE__,__LINE__);
         DoReweight = true;

--- a/Manager/YamlHelper.h
+++ b/Manager/YamlHelper.h
@@ -288,7 +288,7 @@ inline std::string DemangleTypeName(const std::string& mangledName) {
 /// @param File name of file in which function is being called to make better error message
 /// @param Line File line in which function is being called to make better error message
 template<typename Type>
-Type Get(const YAML::Node& node, const std::string File, const int Line) {
+Type Get(const YAML::Node& node, const std::string& File, const int Line) {
 // **********************
   try {
     // Attempt to convert the node to the expected type
@@ -326,7 +326,7 @@ Type Get(const YAML::Node& node, const std::string File, const int Line) {
 /// @param File name of file in which function is being called to make better error message
 /// @param Line File line in which function is being called to make better error message
 template<typename Type>
-Type GetFromManager(const YAML::Node& node, const Type defval, const std::string File = "", const int Line = 1) {
+Type GetFromManager(const YAML::Node& node, const Type defval, const std::string& File = "", const int Line = 1) {
 // **********************
   if (!node) {
     return defval;

--- a/Parameters/AdaptiveMCMCHandler.cpp
+++ b/Parameters/AdaptiveMCMCHandler.cpp
@@ -63,7 +63,7 @@ bool AdaptiveMCMCHandler::InitFromConfig(const YAML::Node& adapt_manager, const 
   }
 
   // We"re going to grab this info from the YAML manager
-  if(!GetFromManager<bool>(adapt_manager["AdaptionOptions"]["Covariance"][matrix_name_str]["DoAdaption"], false)) {
+  if(!GetFromManager<bool>(adapt_manager["AdaptionOptions"]["Covariance"][matrix_name_str]["DoAdaption"], false, __FILE__ , __LINE__)) {
     MACH3LOG_WARN("Not using adaption for {}", matrix_name_str);
     return false;
   }
@@ -73,24 +73,24 @@ bool AdaptiveMCMCHandler::InitFromConfig(const YAML::Node& adapt_manager, const 
     MACH3LOG_ERROR("This is required if you are using adaptive MCMC");
     throw MaCh3Exception(__FILE__, __LINE__);
   }
-
-  start_adaptive_throw  = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["StartThrow"], 10);
-  start_adaptive_update = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["StartUpdate"], 0);
-  end_adaptive_update   = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["EndUpdate"], 10000);
-  adaptive_update_step  = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["UpdateStep"], 100);
-  adaptive_save_n_iterations  = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["SaveNIterations"], -1);
-  output_file_name = GetFromManager<std::string>(adapt_manager["AdaptionOptions"]["Settings"]["OutputFileName"], "");
+  auto AdaptSettings = adapt_manager["AdaptionOptions"]["Settings"];
+  start_adaptive_throw  = GetFromManager<int>(AdaptSettings["StartThrow"], 10, __FILE__ , __LINE__);
+  start_adaptive_update = GetFromManager<int>(AdaptSettings["StartUpdate"], 0, __FILE__ , __LINE__);
+  end_adaptive_update   = GetFromManager<int>(AdaptSettings["EndUpdate"], 10000, __FILE__ , __LINE__);
+  adaptive_update_step  = GetFromManager<int>(AdaptSettings["UpdateStep"], 100, __FILE__ , __LINE__);
+  adaptive_save_n_iterations  = GetFromManager<int>(AdaptSettings["SaveNIterations"], -1, __FILE__ , __LINE__);
+  output_file_name = GetFromManager<std::string>(AdaptSettings["OutputFileName"], "", __FILE__ , __LINE__);
 
   // Check for Robbins-Monro adaption
-  use_robbins_monro = GetFromManager<bool>(adapt_manager["AdaptionOptions"]["Settings"]["UseRobbinsMonro"], false);
-  target_acceptance = GetFromManager<double>(adapt_manager["AdaptionOptions"]["Settings"]["TargetAcceptance"], 0.234);
+  use_robbins_monro = GetFromManager<bool>(AdaptSettings["UseRobbinsMonro"], false, __FILE__ , __LINE__);
+  target_acceptance = GetFromManager<double>(AdaptSettings["TargetAcceptance"], 0.234, __FILE__ , __LINE__);
   if (target_acceptance <= 0 || target_acceptance >= 1) {
     MACH3LOG_ERROR("Target acceptance must be in (0,1), got {}", target_acceptance);
     throw MaCh3Exception(__FILE__, __LINE__);
   }
 
-  acceptance_rate_batch_size = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["AcceptanceRateBatchSize"], 10000);
-  total_rm_restarts = GetFromManager<int>(adapt_manager["AdaptionOptions"]["Settings"]["TotalRobbinsMonroRestarts"], 0);
+  acceptance_rate_batch_size = GetFromManager<int>(AdaptSettings["AcceptanceRateBatchSize"], 10000, __FILE__ , __LINE__);
+  total_rm_restarts = GetFromManager<int>(AdaptSettings["TotalRobbinsMonroRestarts"], 0, __FILE__ , __LINE__);
   n_rm_restarts = 0;
 
   prev_step_accepted = false; 
@@ -116,19 +116,20 @@ bool AdaptiveMCMCHandler::InitFromConfig(const YAML::Node& adapt_manager, const 
   // We'll use the same start scale for Robbins-Monro as standard adaption
   adaption_scale = 2.38/std::sqrt(GetNumParams()); 
 
+  auto AdaptOptions = adapt_manager["AdaptionOptions"]["Covariance"][matrix_name_str];
   // HH: added ability to define blocks by parameter names
-  bool matrix_blocks_by_name = GetFromManager<bool>(adapt_manager["AdaptionOptions"]["Covariance"][matrix_name_str]["MatrixBlocksByName"], false);
+  bool matrix_blocks_by_name = GetFromManager<bool>(AdaptOptions["MatrixBlocksByName"], false, __FILE__ , __LINE__);
   std::vector<std::vector<int>> matrix_blocks;
   // HH: read blocks by names and convert to indices
   if (matrix_blocks_by_name) {
-    auto matrix_blocks_input = GetFromManager<std::vector<std::vector<std::string>>>(adapt_manager["AdaptionOptions"]["Covariance"][matrix_name_str]["MatrixBlocks"], {{}});
+    auto matrix_blocks_input = GetFromManager<std::vector<std::vector<std::string>>>(AdaptOptions["MatrixBlocks"], {{}}, __FILE__ , __LINE__);
     // Now we need to convert to indices
     for (const auto& block : matrix_blocks_input) {
       auto block_indices = GetParIndicesFromNames(block);
       matrix_blocks.push_back(block_indices);
     }
   } else {
-    matrix_blocks = GetFromManager<std::vector<std::vector<int>>>(adapt_manager["AdaptionOptions"]["Covariance"][matrix_name_str]["MatrixBlocks"], {{}});
+    matrix_blocks = GetFromManager<std::vector<std::vector<int>>>(AdaptOptions["MatrixBlocks"], {{}}, __FILE__ , __LINE__);
   }
   SetAdaptiveBlocks(matrix_blocks);
 

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -1004,7 +1004,7 @@ void ParameterHandlerBase::InitialiseAdaption(const YAML::Node& adapt_manager) {
   _fGlobalStepScaleInitial = _fGlobalStepScale;
 
   // HH: adding these here because they will be used to set the individual step scales for non-adapting parameters
-  auto params_to_skip = GetFromManager<std::vector<std::string>>(adapt_manager["AdaptionOptions"]["Covariance"][matrixName]["ParametersToSkip"], {});
+  auto params_to_skip = GetFromManager<std::vector<std::string>>(adapt_manager["AdaptionOptions"]["Covariance"][matrixName]["ParametersToSkip"], {}, __FILE__ , __LINE__);
   // Build a list of skip flags
   param_skip_adapt_flags.resize(_fNumPar, false);
   for (int i = 0; i <_fNumPar; ++i) {

--- a/Plotting/PlotSigmaVariation.cpp
+++ b/Plotting/PlotSigmaVariation.cpp
@@ -367,8 +367,8 @@ void CompareSigVar1D(const std::string& filename, const YAML::Node& Settings)
   gErrorIgnoreLevel = kWarning;
   canvas->Print((outfilename+"[").c_str());
 
-  auto IncludeString = GetFromManager<std::vector<std::string>>(Settings["IncludeString"], {});
-  auto ExcludeString = GetFromManager<std::vector<std::string>>(Settings["ExcludeString"], {});
+  auto IncludeString = GetFromManager<std::vector<std::string>>(Settings["IncludeString"], {}, __FILE__ , __LINE__);
+  auto ExcludeString = GetFromManager<std::vector<std::string>>(Settings["ExcludeString"], {}, __FILE__ , __LINE__);
   TDirectory *dir = nullptr;
 
   for(size_t id = 0; id < DialNameVector.size(); id++)
@@ -482,8 +482,8 @@ void CompareSigVar2D(const std::string& filename, const YAML::Node& Settings)
   gErrorIgnoreLevel = kWarning;
   canvas->Print((outfilename+"[").c_str());
 
-  auto IncludeString = GetFromManager<std::vector<std::string>>(Settings["IncludeString"], {});
-  auto ExcludeString = GetFromManager<std::vector<std::string>>(Settings["ExcludeString"], {});
+  auto IncludeString = GetFromManager<std::vector<std::string>>(Settings["IncludeString"], {}, __FILE__ , __LINE__);
+  auto ExcludeString = GetFromManager<std::vector<std::string>>(Settings["ExcludeString"], {}, __FILE__ , __LINE__);
   TDirectory *dir = nullptr;
 
   for(size_t id = 0; id < DialNameVector.size(); id++)
@@ -740,8 +740,8 @@ void PlotSigVar1D(const std::vector<std::vector<std::unique_ptr<TH1D>>>& Project
 
 void OverlaySigVar1D(const std::string& filename, const YAML::Node& Settings)
 {
-  auto ParamNames = GetFromManager<std::vector<std::string>>(Settings["ParamNames"], {});
-  auto SigColours = GetFromManager<std::vector<int>>(Settings["Coulour"], {});
+  auto ParamNames = GetFromManager<std::vector<std::string>>(Settings["ParamNames"], {}, __FILE__ , __LINE__);
+  auto SigColours = GetFromManager<std::vector<int>>(Settings["Coulour"], {}, __FILE__ , __LINE__);
 
   if(ParamNames.size() == 0) return;
 

--- a/Plotting/PredictivePlotting.cpp
+++ b/Plotting/PredictivePlotting.cpp
@@ -207,7 +207,7 @@ void PrintPosteriorPValue(const YAML::Node& Settings,
   std::cout<<"\\end{tabular}"<<std::endl;
   std::cout<<"\\end{table}"<<std::endl;
 
-  auto Threshold = GetFromManager<double>(Settings["Significance"], 0.05);
+  auto Threshold = GetFromManager<double>(Settings["Significance"], 0.05, __FILE__ , __LINE__);
   for(unsigned int f = 0; f < InputFiles.size(); f++)
   {
     MACH3LOG_INFO("Calculating Shape for file {}", Titles[f]);

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -60,7 +60,7 @@ void SampleHandlerBase::ReadConfig()
 
   fTestStatistic = static_cast<TestStatistic>(SampleManager->GetMCStatLLH());
   if (CheckNodeExists(SampleManager->raw(), "LikelihoodOptions")) {
-    UpdateW2 = GetFromManager<bool>(SampleManager->raw()["LikelihoodOptions"]["UpdateW2"], false);
+    UpdateW2 = GetFromManager<bool>(SampleManager->raw()["LikelihoodOptions"]["UpdateW2"], false, __FILE__ , __LINE__);
   }
 
   if (!CheckNodeExists(SampleManager->raw(), "BinningFile")){


### PR DESCRIPTION
# Pull request description
GetFromManager historically didn't require line and file so throw message wasn't super helpful. We eventually added it but to avoid breaking changes left default arguments.

Here I revisit to use newer better syntax.

Soon I would like to introduce breaking changes so we don't use old syntax. However, there are plenty old in `ProcessMCMC`, which I didn't do now to avoid clashes with CLI PR. But still would like to finish it before releasing 2.6.0


---
- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
