### PR TITLE
feat: Poisson errors in post pred code

### DIFF
--- a/Fitters/StatisticalUtils.cpp
+++ b/Fitters/StatisticalUtils.cpp
@@ -2,6 +2,11 @@
 #include "Fitters/StatisticalUtils.h"
 #include <numeric>
 
+_MaCh3_Safe_Include_Start_ //{
+// ROOT includes
+#include "Math/QuantFuncMathCore.h"
+_MaCh3_Safe_Include_End_ //}
+
 // **************************
 std::string GetJeffreysScale(const double BayesFactor){
 // **************************
@@ -711,4 +716,76 @@ void PassErrorToRatioPlot(TH1D* RatioHist, TH1D* Hist1, TH1D* DataHist) {
       RatioHist->SetBinError(j, dx);
     }
   }
+}
+
+
+// ****************
+std::unique_ptr<TGraphAsymmErrors> PoissonGraph(const TH1D* hist, double cl) {
+// ****************
+  auto graph = std::make_unique<TGraphAsymmErrors>();
+
+  const double alpha = 1.0 - cl;
+  const double half = alpha / 2.0;
+
+  for (int i = 1; i <= hist->GetNbinsX(); i++)
+  {
+    double N  = hist->GetBinContent(i);
+    double x  = hist->GetBinCenter(i);
+    double ex = hist->GetBinWidth(i) / 2.0;
+
+    double low = 0.0;
+    double high = 0.0;
+
+    if (N > 0) {
+      low  = N - ROOT::Math::gamma_quantile(half, N, 1.0);
+      high = ROOT::Math::gamma_quantile_c(half, N + 1, 1.0) - N;
+    } else {
+      low = 0.0;
+      high = ROOT::Math::gamma_quantile_c(half, 1, 1.0);
+    }
+
+    int p = graph->GetN();
+    graph->SetPoint(p, x, N);
+    graph->SetPointError(p, ex, ex, low, high);
+  }
+  return graph;
+}
+
+
+// ***************************************************************************
+std::unique_ptr<TGraphAsymmErrors> PoissonGraphScaled(const TH1D* hist, double scale, double cl) {
+// ***************************************************************************
+  auto graph = std::make_unique<TGraphAsymmErrors>();
+
+  const double alpha = 1.0 - cl;
+  const double half = alpha / 2.0;
+
+  for (int i = 1; i <= hist->GetNbinsX(); i++) {
+    double N = hist->GetBinContent(i);  // Raw count
+    double x = hist->GetBinCenter(i);
+    double ex = hist->GetBinWidth(i) / 2.0;
+    double binWidth = hist->GetBinWidth(i);
+
+    double low = 0.0;
+    double high = 0.0;
+
+    if (N > 0) {
+      low = N - ROOT::Math::gamma_quantile(half, N, 1.0);
+      high = ROOT::Math::gamma_quantile_c(half, N + 1, 1.0) - N;
+    } else {
+      low = 0.0;
+      high = ROOT::Math::gamma_quantile_c(half, 1, 1.0);
+    }
+
+    // Scale the y-value and y-errors by (scale / binWidth)
+    double scaleFactor = scale / binWidth;
+    double y = N * scaleFactor;
+    double low_scaled = low * scaleFactor;
+    double high_scaled = high * scaleFactor;
+
+    int p = graph->GetN();
+    graph->SetPoint(p, x, y);
+    graph->SetPointError(p, ex, ex, low_scaled, high_scaled);
+  }
+  return graph;
 }

--- a/Fitters/StatisticalUtils.h
+++ b/Fitters/StatisticalUtils.h
@@ -18,12 +18,14 @@ _MaCh3_Safe_Include_Start_ //{
 #include "TLine.h"
 #include "TROOT.h"
 #include "TStyle.h"
+#include "TGraphAsymmErrors.h"
 _MaCh3_Safe_Include_End_ //}
+
+class TGraphAsymmErrors;
 
 /// @file StatisticalUtils.h
 /// @brief Utility functions for statistical interpretations in MaCh3
 /// @author Kamil Skwarczynski
-
 
 namespace M3 {
   /// @brief KS: Different Information Criterion tests mostly based Gelman paper
@@ -223,5 +225,17 @@ double GetModeError(TH1D* hpost);
 /// @warning The canvas is saved to the current ROOT file using `TempCanvas->Write()`.
 void Get2DBayesianpValue(TH2D *Histogram);
 
-
+/// @brief Propagate numerator uncertainties to a ratio histogram.
 void PassErrorToRatioPlot(TH1D* RatioHist, TH1D* Hist1, TH1D* DataHist);
+
+/// @brief Create a TGraphAsymmErrors from a histogram using exact Poisson
+///        confidence intervals instead of symmetric sqrt(N) uncertainties.
+/// @author Yashwanth S Prabhu
+std::unique_ptr<TGraphAsymmErrors> PoissonGraph(const TH1D* h, double cl = 0.683);
+
+/// @brief Create a TGraphAsymmErrors from a histogram using exact Poisson
+///        confidence intervals instead of symmetric sqrt(N) uncertainties.
+///        Assume bin width scaling
+/// @author Yashwanth S Prabhu
+std::unique_ptr<TGraphAsymmErrors> PoissonGraphScaled(const TH1D* h, double scale = 1.0, double cl = 0.683);
+

--- a/Plotting/PredictivePlotting.cpp
+++ b/Plotting/PredictivePlotting.cpp
@@ -325,9 +325,11 @@ void OverlayPredicitve(const YAML::Node& Settings,
 
       auto BinWidthScale = PlotMan->style().getBinWidthScale(hist->GetXaxis()->GetTitle());
       std::unique_ptr<TH1D> DataHist = M3::Clone(hist);
-      DataHist->GetYaxis()->SetTitle(fmt::format("Events/{:.0f}", BinWidthScale).c_str());
+      auto DataPoissonErrors = PoissonGraphScaled(DataHist.get(), BinWidthScale);
       M3::ScaleHistogram(DataHist.get(), BinWidthScale);
+
       DataHist->SetLineColor(kBlack);
+      DataPoissonErrors->SetLineColor(kBlack);
       //KS: +1 for data, we want to get integral before scaling of the histogram
       std::vector<double> Integral(nFiles+1);
       Integral[nFiles] = DataHist->Integral();
@@ -353,14 +355,13 @@ void OverlayPredicitve(const YAML::Node& Settings,
       pad1->cd();
 
       PredHist[0]->Draw("p e2");
-      for(int iFile = 1; iFile < nFiles; iFile++)
-      {
+      for(int iFile = 1; iFile < nFiles; iFile++) {
         PredHist[iFile]->Draw("p e2 same");
       }
-      DataHist->Draw("he same");
+      DataPoissonErrors->Draw("p same");
 
       auto legend = std::make_unique<TLegend>(0.50,0.52,0.90,0.88);
-      legend->AddEntry(DataHist.get(), Form("Data, #int=%.0f", Integral[nFiles]),"le");
+      legend->AddEntry(DataPoissonErrors.get(), Form("Data, #int=%.0f", Integral[nFiles]),"le");
       for(int ig = 0; ig < nFiles; ig++ ) {
         legend->AddEntry(PredHist[ig].get(), Form("%s, #int=%.2f", Titles[ig].c_str(), Integral[ig]), "lpf");
       }


### PR DESCRIPTION
# Pull request description
This came up during T2K review. But confirmed with Asher, and he thinks we should use Poisson instead of `sqrt(N)`

## Changes or fixes


## Examples
before
<img width="683" height="665" alt="image" src="https://github.com/user-attachments/assets/80a7f15f-e096-4826-ad77-d4a432112538" />

after
<img width="684" height="669" alt="image" src="https://github.com/user-attachments/assets/4e3df50b-101d-4120-bf26-65a80d07b6d5" />


---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
