### PR TITLE
breaking: More Wildcards

### DIFF
--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -542,8 +542,7 @@ bool FitterBase::CheckSkipParameter(const std::vector<std::string>& SkipVector, 
   bool skip = false;
   for(unsigned int is = 0; is < SkipVector.size(); ++is)
   {
-    if(ParamName.substr(0, SkipVector[is].length()) == SkipVector[is])
-    {
+    if (M3::RegexMatch(ParamName, SkipVector[is])) {
       skip = true;
       break;
     }

--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -539,7 +539,7 @@ bool FitterBase::GetScanRange(std::map<std::string, std::vector<double>>& scanRa
 // *************************
 bool FitterBase::CheckSkipParameter(const std::vector<std::string>& SkipVector, const std::string& ParamName) const {
 // *************************
-  return M3::RegexMatch(ParamName, SkipVector);
+  return M3::CaseInsensitiveMatchAny(ParamName, SkipVector);
 }
 
 

--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -539,15 +539,7 @@ bool FitterBase::GetScanRange(std::map<std::string, std::vector<double>>& scanRa
 // *************************
 bool FitterBase::CheckSkipParameter(const std::vector<std::string>& SkipVector, const std::string& ParamName) const {
 // *************************
-  bool skip = false;
-  for(unsigned int is = 0; is < SkipVector.size(); ++is)
-  {
-    if (M3::RegexMatch(ParamName, SkipVector[is])) {
-      skip = true;
-      break;
-    }
-  }
-  return skip;
+  return M3::RegexMatch(ParamName, SkipVector);
 }
 
 

--- a/Fitters/MCMCProcessor.cpp
+++ b/Fitters/MCMCProcessor.cpp
@@ -2612,7 +2612,7 @@ void MCMCProcessor::ReadModelFile() {
     bool rejected = false;
     for (unsigned int ik = 0; ik < ExcludedNames.size(); ++ik)
     {
-      if (ParName.rfind(ExcludedNames[ik], 0) == 0)
+      if (M3::RegexMatch(ParName, ExcludedNames[ik]))
       {
         MACH3LOG_DEBUG("Excluding param {}, from group {}", ParName, Group);
         rejected = true;

--- a/Fitters/MCMCProcessor.cpp
+++ b/Fitters/MCMCProcessor.cpp
@@ -2612,7 +2612,7 @@ void MCMCProcessor::ReadModelFile() {
     bool rejected = false;
     for (unsigned int ik = 0; ik < ExcludedNames.size(); ++ik)
     {
-      if (M3::RegexMatch(ParName, ExcludedNames[ik]))
+      if (M3::CaseInsentiveMatch(ParName, ExcludedNames[ik]))
       {
         MACH3LOG_DEBUG("Excluding param {}, from group {}", ParName, Group);
         rejected = true;

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -1008,12 +1008,7 @@ void ParameterHandlerBase::InitialiseAdaption(const YAML::Node& adapt_manager) {
   // Build a list of skip flags
   param_skip_adapt_flags.resize(_fNumPar, false);
   for (int i = 0; i <_fNumPar; ++i) {
-    for (const auto& name : params_to_skip) {
-      if(M3::RegexMatch(_fFancyNames[i], name)) {
-        param_skip_adapt_flags[i] = true;
-        break;
-      }
-    }
+    param_skip_adapt_flags[i] = M3::RegexMatch(_fFancyNames[i], params_to_skip);
   }
 
   // Now we read the general settings [these SHOULD be common across all matrices!]

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -1009,7 +1009,7 @@ void ParameterHandlerBase::InitialiseAdaption(const YAML::Node& adapt_manager) {
   param_skip_adapt_flags.resize(_fNumPar, false);
   for (int i = 0; i <_fNumPar; ++i) {
     for (const auto& name : params_to_skip) {
-      if(name == _fFancyNames[i]) {
+      if(M3::RegexMatch(_fFancyNames[i], name)) {
         param_skip_adapt_flags[i] = true;
         break;
       }

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -1008,7 +1008,7 @@ void ParameterHandlerBase::InitialiseAdaption(const YAML::Node& adapt_manager) {
   // Build a list of skip flags
   param_skip_adapt_flags.resize(_fNumPar, false);
   for (int i = 0; i <_fNumPar; ++i) {
-    param_skip_adapt_flags[i] = M3::RegexMatch(_fFancyNames[i], params_to_skip);
+    param_skip_adapt_flags[i] = M3::CaseInsensitiveMatchAny(_fFancyNames[i], params_to_skip);
   }
 
   // Now we read the general settings [these SHOULD be common across all matrices!]

--- a/Parameters/ParameterHandlerGeneric.cpp
+++ b/Parameters/ParameterHandlerGeneric.cpp
@@ -546,15 +546,7 @@ bool ParameterHandlerGeneric::AppliesToSample(const int SystIndex, const std::st
     MACH3LOG_ERROR("Wildcards ('*') are not supported in sample name: '{}'", SampleName);
     throw MaCh3Exception(__FILE__ , __LINE__ );
   }
-
-  bool Applies = false;
-  for (size_t i = 0; i < _fSampleNames[SystIndex].size(); i++) {
-    if (M3::RegexMatch(SampleName, _fSampleNames[SystIndex][i])) {
-      Applies = true;
-      break;
-    }
-  }
-  return Applies;
+  return M3::RegexMatch(SampleName, _fSampleNames[SystIndex]);
 }
 
 // ********************************************

--- a/Parameters/ParameterHandlerGeneric.cpp
+++ b/Parameters/ParameterHandlerGeneric.cpp
@@ -546,7 +546,7 @@ bool ParameterHandlerGeneric::AppliesToSample(const int SystIndex, const std::st
     MACH3LOG_ERROR("Wildcards ('*') are not supported in sample name: '{}'", SampleName);
     throw MaCh3Exception(__FILE__ , __LINE__ );
   }
-  return M3::RegexMatch(SampleName, _fSampleNames[SystIndex]);
+  return M3::CaseInsensitiveMatchAny(SampleName, _fSampleNames[SystIndex]);
 }
 
 // ********************************************

--- a/Parameters/ParameterHandlerGeneric.cpp
+++ b/Parameters/ParameterHandlerGeneric.cpp
@@ -541,15 +541,15 @@ bool ParameterHandlerGeneric::AppliesToSample(const int SystIndex, const std::st
   // Empty means apply to all
   if (_fSampleNames[SystIndex].size() == 0) return true;
 
-  // Check for unsupported wildcards in SampleNameCopy
-  if (SampleNameCopy.find('*') != std::string::npos) {
+  // Check for unsupported wildcards in SampleName
+  if (SampleName.find('*') != std::string::npos) {
     MACH3LOG_ERROR("Wildcards ('*') are not supported in sample name: '{}'", SampleName);
     throw MaCh3Exception(__FILE__ , __LINE__ );
   }
 
   bool Applies = false;
   for (size_t i = 0; i < _fSampleNames[SystIndex].size(); i++) {
-    if (M3::RegexMatch(SampleNameCopy, pattern)) {
+    if (M3::RegexMatch(SampleName, _fSampleNames[SystIndex][i])) {
       Applies = true;
       break;
     }

--- a/Parameters/ParameterHandlerGeneric.cpp
+++ b/Parameters/ParameterHandlerGeneric.cpp
@@ -541,10 +541,6 @@ bool ParameterHandlerGeneric::AppliesToSample(const int SystIndex, const std::st
   // Empty means apply to all
   if (_fSampleNames[SystIndex].size() == 0) return true;
 
-  // Make a copy and to lower case to not be case sensitive
-  std::string SampleNameCopy = SampleName;
-  std::transform(SampleNameCopy.begin(), SampleNameCopy.end(), SampleNameCopy.begin(), ::tolower);
-
   // Check for unsupported wildcards in SampleNameCopy
   if (SampleNameCopy.find('*') != std::string::npos) {
     MACH3LOG_ERROR("Wildcards ('*') are not supported in sample name: '{}'", SampleName);
@@ -552,23 +548,10 @@ bool ParameterHandlerGeneric::AppliesToSample(const int SystIndex, const std::st
   }
 
   bool Applies = false;
-
   for (size_t i = 0; i < _fSampleNames[SystIndex].size(); i++) {
-    // Convert to low case to not be case sensitive
-    std::string pattern = _fSampleNames[SystIndex][i];
-    std::transform(pattern.begin(), pattern.end(), pattern.begin(), ::tolower);
-
-    // Replace '*' in the pattern with '.*' for regex matching
-    std::string regexPattern = "^" + std::regex_replace(pattern, std::regex("\\*"), ".*") + "$";
-    try {
-      std::regex regex(regexPattern);
-      if (std::regex_match(SampleNameCopy, regex)) {
-        Applies = true;
-        break;
-      }
-    } catch (const std::regex_error& e) {
-      // Handle regex error (for invalid patterns)
-      MACH3LOG_ERROR("Regex error: {}", e.what());
+    if (M3::RegexMatch(SampleNameCopy, pattern)) {
+      Applies = true;
+      break;
     }
   }
   return Applies;

--- a/Parameters/ParameterHandlerUtils.h
+++ b/Parameters/ParameterHandlerUtils.h
@@ -42,7 +42,7 @@ namespace M3
 /// @brief Matches a string against a simple wildcard Pattern using regex. Is not case sensitive
 /// @param Text    Input string to test.
 /// @param Pattern Wildcard pattern to match against.
-inline bool RegexMatch(std::string Text, std::string Pattern) {
+inline bool CaseInsentiveMatch(std::string Text, std::string Pattern) {
   // Make a copy and to lower case to not be case sensitive
   std::transform(Text.begin(), Text.end(), Text.begin(), ::tolower);
 
@@ -63,9 +63,9 @@ inline bool RegexMatch(std::string Text, std::string Pattern) {
 /// @brief Matches a string against a simple wildcard Pattern using regex. Is not case sensitive
 /// @param Text    Input string to test.
 /// @param Patterns Collection wildcard patterns to match against.
-inline bool RegexMatch(std::string Text, const std::vector<std::string>& Patterns) {
+inline bool CaseInsensitiveMatchAny(std::string Text, const std::vector<std::string>& Patterns) {
   for (size_t i = 0; i < Patterns.size(); i++) {
-    if (M3::RegexMatch(Text, Patterns[i])) {
+    if (M3::CaseInsentiveMatch(Text, Patterns[i])) {
       return true;
     }
   }

--- a/Parameters/ParameterHandlerUtils.h
+++ b/Parameters/ParameterHandlerUtils.h
@@ -39,6 +39,27 @@ _MaCh3_Safe_Include_End_ //}
 
 namespace M3
 {
+/// @brief Matches a string against a simple wildcard Pattern using regex. Is not case sensitive
+/// @param Text    Input string to test.
+/// @param Pattern Wildcard pattern to match against.
+inline bool RegexMatch(std::string Text, std::string Pattern) {
+  // Make a copy and to lower case to not be case sensitive
+  std::transform(Text.begin(), Text.end(), Text.begin(), ::tolower);
+
+  // Convert to low case to not be case sensitive
+  std::transform(Pattern.begin(), Pattern.end(), Pattern.begin(), ::tolower);
+  try {
+    // Replace '*' in the Pattern with '.*' for regex matching
+    std::string RegexPattern = "^" + std::regex_replace(Pattern, std::regex("\\*"), ".*") + "$";
+    std::regex Regex(RegexPattern);
+    return std::regex_match(text, Regex);
+  }
+  catch (const std::regex_error& e) {
+    MACH3LOG_ERROR("Regex error: {}", e.what());
+    return false;
+  }
+}
+
 /// @brief CW: Multi-threaded matrix multiplication
 inline double* MatrixMult(double *A, double *B, int n) {
   //CW: First transpose to increse cache hits

--- a/Parameters/ParameterHandlerUtils.h
+++ b/Parameters/ParameterHandlerUtils.h
@@ -60,6 +60,18 @@ inline bool RegexMatch(std::string Text, std::string Pattern) {
   }
 }
 
+/// @brief Matches a string against a simple wildcard Pattern using regex. Is not case sensitive
+/// @param Text    Input string to test.
+/// @param Patterns Collection wildcard patterns to match against.
+inline bool RegexMatch(std::string Text, const std::vector<std::string>& Patterns) {
+  for (size_t i = 0; i < Patterns.size(); i++) {
+    if (M3::RegexMatch(Text, Patterns[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /// @brief CW: Multi-threaded matrix multiplication
 inline double* MatrixMult(double *A, double *B, int n) {
   //CW: First transpose to increse cache hits

--- a/Parameters/ParameterHandlerUtils.h
+++ b/Parameters/ParameterHandlerUtils.h
@@ -52,7 +52,7 @@ inline bool RegexMatch(std::string Text, std::string Pattern) {
     // Replace '*' in the Pattern with '.*' for regex matching
     std::string RegexPattern = "^" + std::regex_replace(Pattern, std::regex("\\*"), ".*") + "$";
     std::regex Regex(RegexPattern);
-    return std::regex_match(text, Regex);
+    return std::regex_match(Text, Regex);
   }
   catch (const std::regex_error& e) {
     MACH3LOG_ERROR("Regex error: {}", e.what());


### PR DESCRIPTION
# Pull request description
MaCh3 analysis are becoming increasingly more complex.
Wildcards helps to remove desired parameters from plotting etc more easily.

This add wildcard support to 
- LLH Skip vector
- Adaptive Skip
- Process MCMC skip

Previously, they worked based on either string starting with or equality.
Hence, marked as breaking.

## Examples
default
<img width="678" height="218" alt="default" src="https://github.com/user-attachments/assets/112a8338-f27f-4b38-a481-aafdb9a4b0c2" />
after applying Norm_*
<img width="682" height="182" alt="exclude" src="https://github.com/user-attachments/assets/0ffef8e6-e5d6-48b5-a752-4727a9d0120a" />

default
<img width="924" height="646" alt="before" src="https://github.com/user-attachments/assets/392ff3b1-ac19-4f22-80d5-e5ab79b63434" />


after applying Norm_*
<img width="952" height="720" alt="after" src="https://github.com/user-attachments/assets/476f0412-216c-46cc-8d54-f73a859a513f" />


---
- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
