### PR TITLE
feat: Allow for 1d+2d combination

### DIFF
--- a/Diagnostics/ReweightMCMC.cpp
+++ b/Diagnostics/ReweightMCMC.cpp
@@ -27,11 +27,22 @@ _MaCh3_Safe_Include_End_ //}
 /// @author David Riley
 /// @author Evan Goodman
 
+
+namespace M3 {
+  /// @brief Types of chain reweighting available
+  enum kReweightType {
+    kGaussian,     //!< Assumes gaussian prior
+    kTGraph,       //!< Calculates Likelihood based on TGraph
+    kTGraph2D,     //!< Calculates Likelihood based on TGraph2D
+    kReweightTypes //!< This only enumerates
+  };
+}
+
 /// Structure to hold reweight configuration
 struct ReweightConfig {
   std::string key;       ///< The YAML key for this reweight
   std::string name;
-  std::string type;  ///< "Gaussian", "TGraph2D"
+  M3::kReweightType type;  ///< "Gaussian", "TGraph2D"
   int dimension;     ///< 1 or 2
   std::vector<std::string> paramNames; ///< Parameter names.
   std::vector<std::vector<double>> newPriorValues; ///< new [mean, sigma] pairs
@@ -170,21 +181,22 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
 
     ReweightConfig reweightConfig;
     reweightConfig.key = reweightKey;
-    reweightConfig.name = GetFromManager<std::string>(reweightConfigNode["ReweightName"], reweightKey, __FILE__ , __LINE__);
-    reweightConfig.type = GetFromManager<std::string>(reweightConfigNode["ReweightType"], "Gaussian", __FILE__ , __LINE__);
-    reweightConfig.dimension = GetFromManager<int>(reweightConfigNode["ReweightDim"], 1);
-    // reweightConfig.weightBranchName = "Weight_" + reweightKey; // for now all weights will be stored in branches called Weight until multi weight support
-    reweightConfig.weightBranchName = "Weight";
+    reweightConfig.name = Get<std::string>(reweightConfigNode["ReweightName"], __FILE__ , __LINE__);
+    auto ReweightType = Get<std::string>(reweightConfigNode["ReweightType"], __FILE__ , __LINE__);
+    reweightConfig.dimension = Get<int>(reweightConfigNode["ReweightDim"], __FILE__ , __LINE__);
+
+    reweightConfig.weightBranchName = reweightKey;
     reweightConfig.enabled = true;
 
-    auto paramNames = GetFromManager<std::vector<std::string>>(reweightConfigNode["ReweightVar"], {}, __FILE__ , __LINE__);
+    auto paramNames = Get<std::vector<std::string>>(reweightConfigNode["ReweightVar"], __FILE__ , __LINE__);
     reweightConfig.paramNames = paramNames;
     reweightConfig.oldPriorValues.resize(paramNames.size());
     reweightConfig.flatPrior.resize(paramNames.size());
 
     // Handle different reweight types as they fill different members
     if (reweightConfig.dimension == 1) {
-      if (reweightConfig.type == "Gaussian") {
+      if (ReweightType == "Gaussian") {
+        reweightConfig.type = M3::kGaussian;
         // For Gaussian reweights, we need the parameter name(s) and prior values (mean, sigma pairs)
         // Get prior values - handle both single [mean, sigma] pair and list of pairs for safety
         auto priorNode = reweightConfigNode["ReweightPrior"];
@@ -194,14 +206,14 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
           // Check if first element is a number (single [mean, sigma] pair) or sequence (list of pairs)
           if (priorNode[0].IsScalar()) {
             // Single [mean, sigma] pair - convert to list format
-            auto newPriorValues = GetFromManager<std::vector<double>>(priorNode, {}, __FILE__ , __LINE__);
+            auto newPriorValues = Get<std::vector<double>>(priorNode, __FILE__ , __LINE__);
             if (newPriorValues.size() == 2) {
               allPriorValues.push_back(newPriorValues);
             }
           } else {
             // List of [mean, sigma] pairs
             for (const auto& priorPair : priorNode) {
-              auto newPriorValues = GetFromManager<std::vector<double>>(priorPair, {}, __FILE__ , __LINE__);
+              auto newPriorValues = Get<std::vector<double>>(priorPair, __FILE__ , __LINE__);
               if (newPriorValues.size() == 2) {
                 allPriorValues.push_back(newPriorValues);
               }
@@ -216,10 +228,11 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
                           reweightKey, paramNames.size(), allPriorValues.size());
           continue;
         }
-      } else if (reweightConfig.type == "TGraph") {
+      } else if (ReweightType == "TGraph") {
+        reweightConfig.type = M3::kTGraph;
         // For TGraph reweights, we need the parameter name and the TGraph file and name
-        auto fileName = GetFromManager<std::string>(reweightConfigNode["ReweightPrior"]["file"], "", __FILE__ , __LINE__);
-        auto graphName = GetFromManager<std::string>(reweightConfigNode["ReweightPrior"]["graph_name"], "", __FILE__ , __LINE__);
+        auto fileName = Get<std::string>(reweightConfigNode["ReweightPrior"]["file"], __FILE__ , __LINE__);
+        auto graphName = Get<std::string>(reweightConfigNode["ReweightPrior"]["graph_name"], __FILE__ , __LINE__);
         reweightConfig.fileName = fileName;
         reweightConfig.graphName = graphName;
 
@@ -248,7 +261,7 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
           continue;
         }
       } else {
-        MACH3LOG_ERROR("Unknown 1D reweight type: {} for {}", reweightConfig.type, reweightKey);
+        MACH3LOG_ERROR("Unknown 1D reweight type: {} for {}", ReweightType, reweightKey);
         throw MaCh3Exception(__FILE__, __LINE__);
       }
     } else if (reweightConfig.dimension == 2) {
@@ -258,10 +271,11 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
           continue;
         }
 
-        if (reweightConfig.type == "TGraph2D") {
+        if (ReweightType == "TGraph2D") {
+          reweightConfig.type = M3::kTGraph2D;
           auto priorConfig = reweightConfigNode["ReweightPrior"];
-          reweightConfig.fileName = GetFromManager<std::string>(priorConfig["file"], "", __FILE__ , __LINE__);
-          reweightConfig.graphName = GetFromManager<std::string>(priorConfig["graph_name"], "", __FILE__ , __LINE__);
+          reweightConfig.fileName = Get<std::string>(priorConfig["file"], __FILE__ , __LINE__);
+          reweightConfig.graphName = Get<std::string>(priorConfig["graph_name"], __FILE__ , __LINE__);
           reweightConfig.hierarchyType = GetFromManager<std::string>(priorConfig["hierarchy"], "auto", __FILE__ , __LINE__);
 
           if (reweightConfig.fileName.empty() || reweightConfig.graphName.empty()) {
@@ -313,7 +327,7 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
 
           constraintFile->Close();
         } else {
-          MACH3LOG_ERROR("Unknown 2D reweight type: {} for {}", reweightConfig.type, reweightKey);
+          MACH3LOG_ERROR("Unknown 2D reweight type: {} for {}", ReweightType, reweightKey);
           continue;
         }
     } else {
@@ -322,14 +336,11 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
     } // end check over dimensions
 
     reweightConfigs.push_back(std::move(reweightConfig));
-    MACH3LOG_INFO("Added reweight configuration: {} ({}D, type: {})", reweightConfigs.back().name, reweightConfigs.back().dimension, reweightConfigs.back().type);
+    MACH3LOG_INFO("Added reweight configuration: {} ({}D, type: {})", reweightConfigs.back().name, reweightConfigs.back().dimension, ReweightType);
   }
 
   if (reweightConfigs.empty()) {
     MACH3LOG_ERROR("No valid reweight configurations found in config file");
-    throw MaCh3Exception(__FILE__, __LINE__);
-  } else if (reweightConfigs.size() > 1) {    // check number of ReweightConfigs, currently maximum supported is 1 due to structure of ProcessMCMC
-    MACH3LOG_ERROR("Currently only one reweight configuration is supported at a time, found {}", reweight_settings.size());
     throw MaCh3Exception(__FILE__, __LINE__);
   }
 }
@@ -338,7 +349,7 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
 [[nodiscard]] double Get1DWeight(const ReweightConfig& rwConfig,
                                  const std::map<std::string, double>& paramValues) {
   double weight = 1.;
-  if(rwConfig.type == "Gaussian") {
+  if(rwConfig.type == M3::kGaussian) {
     auto& paramNames = rwConfig.paramNames;
     //KS: Calculate reweight weight. Weights are multiplicative so we can do several reweights at once.
     /// @warning Big limitation is that code only works for uncorrelated parameters :(
@@ -367,12 +378,9 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
       }
       weight *= new_prior/old_prior;
     }
-  } else if (rwConfig.type == "TGraph") {
+  } else if (rwConfig.type == M3::kTGraph) {
     double paramValue = paramValues.at(rwConfig.paramNames.at(0));
     weight = Graph_interpolate1D(rwConfig.graph_1D.get(), paramValue);
-  } else {
-    MACH3LOG_ERROR("Unsupported 1D reweight type: {} for {}", rwConfig.type, rwConfig.key);
-    throw MaCh3Exception(__FILE__, __LINE__);
   }
   return weight;
 }
@@ -381,7 +389,7 @@ void LoadReweightingSettings(std::vector<ReweightConfig>& reweightConfigs, const
 [[nodiscard]] double Get2DWeight(const ReweightConfig& rwConfig,
                                  const std::map<std::string, double>& paramValues) {
   double weight = 1.;
-  if (rwConfig.type == "TGraph2D") {
+  if (rwConfig.type == M3::kTGraph2D) {
     double dm32 = paramValues.at(rwConfig.paramNames.at(0));
     double theta13 = paramValues.at(rwConfig.paramNames.at(1));
     if (dm32 > 0) {

--- a/Fitters/MCMCProcessor.cpp
+++ b/Fitters/MCMCProcessor.cpp
@@ -82,6 +82,7 @@ MCMCProcessor::MCMCProcessor(const std::string &InputFile) :
   CovNamePos.resize(kNParameterEnum);
   CovConfig.resize(kNParameterEnum);
 
+  ReweightNames = {"Weight"};
   for(int i = 0; i < kNParameterEnum; i++)
   {
     ParamTypeStartPos[i] = 0;
@@ -359,7 +360,9 @@ void MCMCProcessor::MakePostfit(const std::map<std::string, std::pair<double, do
 
   // Apply reweighting
   if (ReweightPosterior) {
-    CutPosterior1D = "(" + CutPosterior1D + ")*(" + ReweightName + ")";
+    for (const auto& name : ReweightNames) {
+      CutPosterior1D = "(" + CutPosterior1D + ")*(" + name + ")";
+    }
   }
   MACH3LOG_DEBUG("Using following cut {}", CutPosterior1D);
   
@@ -1024,7 +1027,9 @@ void MCMCProcessor::MakeCovariance() {
 
       std::string SelectionStr = StepCut;
       if (ReweightPosterior) {
-        SelectionStr = "(" + StepCut + ")*(" + ReweightName + ")";
+        for (const auto& name : ReweightNames) {
+          SelectionStr = "(" + StepCut + ")*(" + name + ")";
+        }
       }
       // The draw command we want, i.e. draw param j vs param i
       Chain->Project(DrawMe, DrawMe, SelectionStr.c_str());
@@ -1116,12 +1121,14 @@ void MCMCProcessor::CacheSteps() {
   Chain->SetBranchStatus("step", true);
   Chain->SetBranchAddress("step", &stepBranch);
 
-  double ReweightWeight = 1.;
-  if(ReweightPosterior)
+  std::vector<double> ReweightWeight(ReweightNames.size(), 1.0);
+  if (ReweightPosterior)
   {
     WeightValue = new double[nEntries]();
-    Chain->SetBranchStatus(ReweightName.c_str(), true);
-    Chain->SetBranchAddress(ReweightName.c_str(), &ReweightWeight);
+    for (size_t i = 0; i < ReweightNames.size(); ++i) {
+      Chain->SetBranchStatus(ReweightNames[i].c_str(), true);
+      Chain->SetBranchAddress(ReweightNames[i].c_str(), &ReweightWeight[i]);
+    }
   }
 
   const Long64_t countwidth = nEntries/10;
@@ -1141,9 +1148,11 @@ void MCMCProcessor::CacheSteps() {
     for (int i = 0; i < nDraw; ++i) {
       ParStep[i][j] = ParValBranch[i];
     }
-
-    if(ReweightPosterior){
-      WeightValue[j] = ReweightWeight;
+    if (ReweightPosterior) {
+      WeightValue[j] = 1.0;
+      for (size_t i = 0; i < ReweightWeight.size(); ++i) {
+        WeightValue[j] *= ReweightWeight[i];
+      }
     }
   }
   // Set all the branches to on
@@ -2529,14 +2538,18 @@ void MCMCProcessor::FindInputFiles() {
 
   TMacro *ReweightConfig = TempFile->Get<TMacro>("Reweight_Config");
   if (ReweightConfig != nullptr) {
+    ReweightPosterior = true;
     YAML::Node ReweightSettings = TMacroToYAML(*ReweightConfig);
-
-    if (ReweightSettings["Weight"]) {
-      ReweightName = "Weight";
-      ReweightPosterior = true;
-      MACH3LOG_INFO("Enabling reweighting with following Config");
-    } else {
-      MACH3LOG_WARN("Found reweight config but without field ''Weight''");
+    for (size_t i = 0; i < ReweightNames.size(); ++i) {
+      if (ReweightSettings[ReweightNames[i]]) {
+        MACH3LOG_INFO("Found reweight config for {}", ReweightNames[i]);
+      } else {
+        MACH3LOG_WARN("Found reweight config but without field for {}", ReweightNames[i]);
+        ReweightPosterior = false;
+      }
+    }
+    if (ReweightPosterior) {
+      MACH3LOG_INFO("Enabling reweighting with configured weights.");
     }
     M3::Utils::PrintConfig(ReweightSettings);
   }
@@ -3221,7 +3234,9 @@ void MCMCProcessor::ParameterEvolution(const std::vector<std::string>& Names,
 
       // Apply reweighting if requested
       if (ReweightPosterior) {
-        CutPosterior1D = "(" + CutPosterior1D + ")*(" + ReweightName + ")";
+        for (const auto& name : ReweightNames) {
+          CutPosterior1D = "(" + CutPosterior1D + ")*(" + name + ")";
+        }
       }
 
       std::string TextTitle = "Steps = 0 - "+std::to_string(Counter*IntervalsSize+IntervalsSize);

--- a/Fitters/MCMCProcessor.h
+++ b/Fitters/MCMCProcessor.h
@@ -280,6 +280,8 @@ class MCMCProcessor {
       MACH3LOG_WARN("This may behave not as expected when using merged multiple chains");
       nEntries = NewEntries;
     }
+    /// @brief Set reweight branch names
+    void SetReweightNames(std::vector<std::string> NewName) { ReweightNames = NewName; }
     /// @brief Set the step cutting by string
     /// @param Cuts string telling cut value
     void SetStepCut(const std::string& Cuts);
@@ -593,7 +595,7 @@ class MCMCProcessor {
     /// Whether to apply reweighting weight or not
     bool ReweightPosterior;
     /// Name of branch used for chain reweighting
-    std::string ReweightName;
+    std::vector<std::string> ReweightNames;
     /// Stores value of weight for each step
     double* WeightValue;
 

--- a/Fitters/OscProcessor.cpp
+++ b/Fitters/OscProcessor.cpp
@@ -135,20 +135,24 @@ double OscProcessor::SamplePriorForParam(const int paramIndex, const std::unique
 // ***************
 void OscProcessor::Get1DReactorConstraintInfo(std::pair<double, double>& Sin13_NewPrior, bool& DoReweight) const {
 // ***************
+  if(ReweightNames.size() != 1){
+    MACH3LOG_INFO("Found more than 1 weight for Jarlskog analysis");
+    return;
+  }
   // Now read the MCMC file
   TFile *TempFile = M3::Open((MCMCFile + ".root"), "open", __FILE__, __LINE__);
 
   // Get the settings for the MCMC
   TMacro *Config = TempFile->Get<TMacro>("Reweight_Config");
 
+  DoReweight = false;
   if (Config != nullptr) {
     MACH3LOG_INFO("Found Reweight_Config in chain");
-
     // Print the reweight configuration for user info
     YAML::Node Settings = TMacroToYAML(*Config);
     // Simple check: only enable DoReweight if it's a 1D sin2th_13 Gaussian reweight since Savage Dickey process later on generates values from the Gaussian
-    if(CheckNodeExists(Settings, "Weight")) {
-      YAML::Node firstReweight = Settings["Weight"];
+    if(CheckNodeExists(Settings, ReweightNames.back())) {
+      YAML::Node firstReweight = Settings[ReweightNames.back()];
       int dimension = Get<int>(firstReweight["ReweightDim"], __FILE__ , __LINE__);
       std::string reweightType = Get<std::string>(firstReweight["ReweightType"],__FILE__ , __LINE__);
       auto paramNames = Get<std::vector<std::string>>(firstReweight["ReweightVar"], __FILE__ , __LINE__);
@@ -216,8 +220,8 @@ void OscProcessor::PerformJarlskogAnalysis() {
   Chain->SetBranchAddress("step", &step);
 
   if(DoReweight) {
-    Chain->SetBranchStatus("Weight", true);
-    Chain->SetBranchAddress("Weight", &weight);
+    Chain->SetBranchStatus(ReweightNames.back().c_str(), true);
+    Chain->SetBranchAddress(ReweightNames.back().c_str(), &weight);
   } else {
     MACH3LOG_WARN("Not applying reweighting weight");
     weight = 1.0;
@@ -916,7 +920,7 @@ void OscProcessor::ProducePMNSElements() {
   MACH3LOG_INFO("Starting {}", __func__);
 
   double s2th13, s2th23, s2th12, dcp = M3::_BAD_DOUBLE_;
-  double weight = 1.0;
+
 
   TDirectory *PMNSElementsDir = OutputFile->mkdir("PMNSElements");
   PMNSElementsDir->cd();
@@ -939,12 +943,21 @@ void OscProcessor::ProducePMNSElements() {
   Chain->SetBranchStatus("step", true);
   Chain->SetBranchAddress("step", &step);
 
-  if (Chain->GetBranch("Weight")) {
-    Chain->SetBranchStatus("Weight", true);
-    Chain->SetBranchAddress("Weight", &weight);
-  } else {
-    MACH3LOG_WARN("No Weight branch found — defaulting to 1.0");
-    weight = 1.0;
+  double weight = 1.0;
+  std::vector<double> reweights(ReweightNames.size(), 1.0);
+  bool anyMissing = false;
+  for (size_t i = 0; i < ReweightNames.size(); ++i) {
+    const auto& name = ReweightNames[i];
+    if (Chain->GetBranch(name.c_str())) {
+      Chain->SetBranchStatus(name.c_str(), true);
+      Chain->SetBranchAddress(name.c_str(), &reweights[i]);
+    } else {
+      anyMissing = true;
+    }
+  }
+  if (anyMissing) {
+    MACH3LOG_WARN("Some reweight branches were missing — using partial weight");
+    reweights.clear();
   }
   constexpr int n_bins = 1000;
 
@@ -1066,7 +1079,11 @@ void OscProcessor::ProducePMNSElements() {
     if(step < BurnInCut) continue; // burn-in cut
 
     const std::array<std::array<TComplex, 3>, 3> U = CalculatePMNSElements(s2th13, s2th23, s2th12, dcp);
-    
+    // KS: Calculate total weight
+    weight = 1.0;
+    for (const auto& w : reweights) {
+      weight *= w;
+    }
     for(int iU = 0; iU < 3; iU++){
       h_ue[iU]->Fill(TComplex::Abs(U[0][iU]), weight);
       h_umu[iU]->Fill(TComplex::Abs(U[1][iU]), weight);
@@ -1169,7 +1186,6 @@ void OscProcessor::ProduceUnitarityTriangles() {
   MACH3LOG_INFO("Starting {}", __func__);
 
   double s2th13, s2th23, s2th12, dcp = M3::_BAD_DOUBLE_;
-  double weight = 1.0;
 
   TComplex tr_emu_num, tr_etau_num, tr_mutau_num, tr_12_num, tr_13_num, tr_23_num;
   TComplex tr_emu_denom, tr_etau_denom, tr_mutau_denom, tr_12_denom, tr_13_denom, tr_23_denom;
@@ -1196,12 +1212,21 @@ void OscProcessor::ProduceUnitarityTriangles() {
   Chain->SetBranchStatus("step", true);
   Chain->SetBranchAddress("step", &step);
 
-  if (Chain->GetBranch("Weight")) {
-    Chain->SetBranchStatus("Weight", true);
-    Chain->SetBranchAddress("Weight", &weight);
-  } else {
-    MACH3LOG_WARN("No Weight branch found — defaulting to 1.0");
-    weight = 1.0;
+  double weight = 1.0;
+  std::vector<double> reweights(ReweightNames.size(), 1.0);
+  bool anyMissing = false;
+  for (size_t i = 0; i < ReweightNames.size(); ++i) {
+    const auto& name = ReweightNames[i];
+    if (Chain->GetBranch(name.c_str())) {
+      Chain->SetBranchStatus(name.c_str(), true);
+      Chain->SetBranchAddress(name.c_str(), &reweights[i]);
+    } else {
+      anyMissing = true;
+    }
+  }
+  if (anyMissing) {
+    MACH3LOG_WARN("Some reweight branches were missing — using partial weight");
+    reweights.clear();
   }
   constexpr int n_bins = 1000;
 
@@ -1237,6 +1262,12 @@ void OscProcessor::ProduceUnitarityTriangles() {
     }
 
     if(step < BurnInCut) continue; // burn-in cut
+
+    // KS: Calculate total weight
+    weight = 1.0;
+    for (const auto& w : reweights) {
+      weight *= w;
+    }
 
     const std::array<std::array<TComplex, 3>, 3> U = CalculatePMNSElements(s2th13, s2th23, s2th12, dcp);
 

--- a/Fitters/PredictiveThrower.cpp
+++ b/Fitters/PredictiveThrower.cpp
@@ -562,13 +562,13 @@ void PredictiveThrower::ProduceToys() {
     PosteriorFile->Add(PosteriorFileName.c_str());
 
     PosteriorFile->SetBranchAddress("step", &Step);
-    std::vector<double> ReweightWeight(ReweightNames.size(), 1.0);
+    std::vector<double> reweight_weight(ReweightNames.size(), 1.0);
     bool doReweight = true;
     for (size_t i = 0; i < ReweightNames.size(); ++i) {
       const auto& name = ReweightNames[i];
       if (PosteriorFile->GetBranch(name.c_str())) {
         PosteriorFile->SetBranchStatus(name.c_str(), true);
-        PosteriorFile->SetBranchAddress(name.c_str(), &ReweightWeight[i]);
+        PosteriorFile->SetBranchAddress(name.c_str(), &reweight_weight[i]);
       } else {
         MACH3LOG_WARN("Missing reweight branch '{}' -> disabling ALL reweighting", name);
         doReweight = false;
@@ -650,8 +650,8 @@ void PredictiveThrower::ProduceToys() {
     PenaltyTerm[i] = Penalty;
     Weight = 1.;
     if(doReweight) {
-      for (size_t i = 0; i < ReweightWeight.size(); ++i) {
-        Weight *= ReweightWeight[i];
+      for (size_t i = 0; i < reweight_weight.size(); ++i) {
+        Weight *= reweight_weight[i];
       }
     }
     ReweightWeight[i] = Weight;

--- a/Fitters/PredictiveThrower.cpp
+++ b/Fitters/PredictiveThrower.cpp
@@ -544,9 +544,10 @@ void PredictiveThrower::ProduceToys() {
   auto doByMode = GetFromManager<bool>(fitMan->raw()["Predictive"]["ByMode"], false, __FILE__, __LINE__);
   TDirectory* ByModeDirectory = nullptr;
   if(doByMode) ByModeDirectory = outputFile->mkdir("Toys_ByMode");
-
   auto ReweightNames = GetFromManager<std::vector<std::string>>(fitMan->raw()["Predictive"]["ReweightNames"],
                                                                 {"Weight"}, __FILE__, __LINE__);
+  bool doReweight = false;
+  std::vector<double> reweight_weight(ReweightNames.size(), 1.0);
 
   /// this store value of parameters sampled from a chain
   std::vector<std::vector<double>> branch_vals(systematics.size());
@@ -562,8 +563,7 @@ void PredictiveThrower::ProduceToys() {
     PosteriorFile->Add(PosteriorFileName.c_str());
 
     PosteriorFile->SetBranchAddress("step", &Step);
-    std::vector<double> reweight_weight(ReweightNames.size(), 1.0);
-    bool doReweight = true;
+    doReweight = true;
     for (size_t i = 0; i < ReweightNames.size(); ++i) {
       const auto& name = ReweightNames[i];
       if (PosteriorFile->GetBranch(name.c_str())) {
@@ -650,8 +650,8 @@ void PredictiveThrower::ProduceToys() {
     PenaltyTerm[i] = Penalty;
     Weight = 1.;
     if(doReweight) {
-      for (size_t i = 0; i < reweight_weight.size(); ++i) {
-        Weight *= reweight_weight[i];
+      for (size_t iWeight = 0; iWeight < reweight_weight.size(); ++iWeight) {
+        Weight *= reweight_weight[iWeight];
       }
     }
     ReweightWeight[i] = Weight;

--- a/Fitters/PredictiveThrower.cpp
+++ b/Fitters/PredictiveThrower.cpp
@@ -488,7 +488,7 @@ void PredictiveThrower::ProduceToys() {
   MACH3LOG_INFO("Starting {}", __func__);
 
   outputFile->cd();
-  double Penalty = 0, Weight = 1;
+  double Penalty = 0, Weight = 1.;
   int Draw = 0;
 
   TTree *ToyTree = new TTree("ToySummary", "ToySummary");
@@ -545,6 +545,9 @@ void PredictiveThrower::ProduceToys() {
   TDirectory* ByModeDirectory = nullptr;
   if(doByMode) ByModeDirectory = outputFile->mkdir("Toys_ByMode");
 
+  auto ReweightNames = GetFromManager<std::vector<std::string>>(fitMan->raw()["Predictive"]["ReweightNames"],
+                                                                {"Weight"}, __FILE__, __LINE__);
+
   /// this store value of parameters sampled from a chain
   std::vector<std::vector<double>> branch_vals(systematics.size());
   std::vector<std::vector<std::string>> branch_name(systematics.size());
@@ -559,12 +562,17 @@ void PredictiveThrower::ProduceToys() {
     PosteriorFile->Add(PosteriorFileName.c_str());
 
     PosteriorFile->SetBranchAddress("step", &Step);
-    if (PosteriorFile->GetBranch("Weight")) {
-      PosteriorFile->SetBranchStatus("Weight", true);
-      PosteriorFile->SetBranchAddress("Weight", &Weight);
-    } else {
-      MACH3LOG_WARN("Not applying reweighting weight");
-      Weight = 1.0;
+    std::vector<double> ReweightWeight(ReweightNames.size(), 1.0);
+    bool doReweight = true;
+    for (size_t i = 0; i < ReweightNames.size(); ++i) {
+      const auto& name = ReweightNames[i];
+      if (PosteriorFile->GetBranch(name.c_str())) {
+        PosteriorFile->SetBranchStatus(name.c_str(), true);
+        PosteriorFile->SetBranchAddress(name.c_str(), &ReweightWeight[i]);
+      } else {
+        MACH3LOG_WARN("Missing reweight branch '{}' -> disabling ALL reweighting", name);
+        doReweight = false;
+      }
     }
 
     for (size_t s = 0; s < systematics.size(); ++s) {
@@ -640,6 +648,12 @@ void PredictiveThrower::ProduceToys() {
     }
 
     PenaltyTerm[i] = Penalty;
+    Weight = 1.;
+    if(doReweight) {
+      for (size_t i = 0; i < ReweightWeight.size(); ++i) {
+        Weight *= ReweightWeight[i];
+      }
+    }
     ReweightWeight[i] = Weight;
 
     for (size_t iPDF = 0; iPDF < samples.size(); iPDF++) {


### PR DESCRIPTION
# Pull request description
One cool feature that David tested on T2K was ability to apply 1D and 2D RC simultaneously.
This hasn't been possible in core until now.

Other than changing reweight code to produce more than one weight, which was easy because David wrote it in such a away to support it, the main challenge was tweaking MCMC Processor.

## Changes or fixes
- In reweight config type is now enum to avoid lot of string comparisons

## Examples
<img width="462" height="82" alt="Example1" src="https://github.com/user-attachments/assets/574c98c7-be5f-46a1-8fbf-afe260c1a4a8" />
<img width="1292" height="772" alt="Example2" src="https://github.com/user-attachments/assets/a3781792-e2fc-49db-9417-024e52cddd53" />

Here I applied separate weight to sin and sin 12 and sin 13
<img width="674" height="653" alt="image" src="https://github.com/user-attachments/assets/d3121de6-eb1c-4515-9df9-f30190701cd7" />
<img width="669" height="648" alt="image" src="https://github.com/user-attachments/assets/47c050c7-c0c4-499f-bf3f-a417f4b3e3fb" />


---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
