### PR TITLE
tidy: remove unused variables for gcc16 compatibility

### DIFF
--- a/Fitters/PredictiveThrower.cpp
+++ b/Fitters/PredictiveThrower.cpp
@@ -422,7 +422,6 @@ void PredictiveThrower::WriteToy(TDirectory* ToyDirectory,
 void PredictiveThrower::WriteByModeToys(TDirectory* ByModeDirectory,
                                         const int iToy) {
 // *************************
-  int SampleCounter = 0;
   for (size_t iPDF = 0; iPDF < samples.size(); iPDF++)
   {
     auto* SampleHandler = samples[iPDF];
@@ -444,7 +443,6 @@ void PredictiveThrower::WriteByModeToys(TDirectory* ByModeDirectory,
           hist->Write();
         } // end loop over dimension
       } // end loop over mode
-      SampleCounter++;
     } // end loop over sample
   } // end loop over sample handler objects
 }

--- a/Fitters/SampleSummary.cpp
+++ b/Fitters/SampleSummary.cpp
@@ -988,7 +988,6 @@ void SampleSummary::MakePredictive() {
 
     // Count the -2LLH for each histogram
     double negLogL_Mean = 0.0;
-    double negLogL_Mode = 0.0;
 
     // Loop over each pmu cosmu bin
     for (int j = 1; j < maxBins[SampleNum]+1; ++j)
@@ -1019,7 +1018,6 @@ void SampleSummary::MakePredictive() {
       // Increment -2LLH
       //KS: do times 2 because banff reports chi2
       negLogL_Mean += 2*TempLLH_Mean;
-      negLogL_Mode += 2*TempLLH_Mode;
       
       // Set the content and error to the mean in the bin
       MeanHist[SampleNum]->SetBinContent(j, MeanHist[SampleNum]->GetBinContent(j)+nMean);

--- a/Splines/SplineStructs.h
+++ b/Splines/SplineStructs.h
@@ -810,14 +810,12 @@ inline std::vector<std::vector<TSpline3_red*> > ReduceTSpline3(std::vector<std::
   ReducedVector.reserve(MasterSpline.size());
 
   // Loop over each parameter
-  int OuterCounter = 0;
-  for (OuterIt = MasterSpline.begin(); OuterIt != MasterSpline.end(); ++OuterIt, ++OuterCounter) {
+  for (OuterIt = MasterSpline.begin(); OuterIt != MasterSpline.end(); ++OuterIt) {
     // Make the temp vector
     std::vector<TSpline3_red*> TempVector;
     TempVector.reserve(OuterIt->size());
-    int InnerCounter = 0;
     // Loop over each TSpline3 pointer
-    for (InnerIt = OuterIt->begin(); InnerIt != OuterIt->end(); ++InnerIt, ++InnerCounter) {
+    for (InnerIt = OuterIt->begin(); InnerIt != OuterIt->end(); ++InnerIt) {
       // Here's our delicious TSpline3 object
       TSpline3 *spline = (*InnerIt);
       // Now make the reduced TSpline3 pointer
@@ -848,14 +846,12 @@ inline std::vector<std::vector<TF1_red*> > ReduceTF1(std::vector<std::vector<TF1
   ReducedVector.reserve(MasterSpline.size());
 
   // Loop over each parameter
-  int OuterCounter = 0;
-  for (OuterIt = MasterSpline.begin(); OuterIt != MasterSpline.end(); ++OuterIt, ++OuterCounter) {
+  for (OuterIt = MasterSpline.begin(); OuterIt != MasterSpline.end(); ++OuterIt) {
     // Make the temp vector
     std::vector<TF1_red*> TempVector;
     TempVector.reserve(OuterIt->size());
-    int InnerCounter = 0;
     // Loop over each TSpline3 pointer
-    for (InnerIt = OuterIt->begin(); InnerIt != OuterIt->end(); ++InnerIt, ++InnerCounter) {
+    for (InnerIt = OuterIt->begin(); InnerIt != OuterIt->end(); ++InnerIt) {
       // Here's our delicious TSpline3 object
       TF1* spline = (*InnerIt);
       // Now make the reduced TSpline3 pointer (which deleted TSpline3)


### PR DESCRIPTION
# Removing unused variables for gcc16 compatibility

Changes to the `-Wunused-but-set-*` warnings in gcc16 (see [here](https://gcc.gnu.org/gcc-16/porting_to.html)) are now stricter and are picked up by `-Werror`, causing MaCh3 to not build with gcc16.

I found several variables that were set but unused, and as far as I could tell, had no reason for existing. I removed these variables, and now MaCh3 builds with gcc16. 

---

- [X] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
