### PR TITLE
bugfix: Stop double load of stepStart in start from previous fit

### DIFF
--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -348,9 +348,7 @@ void FitterBase::StartFromPreviousFit(const std::string& FitName) {
   MACH3LOG_INFO("Getting starting position from {}", FitName);
   TFile *infile = M3::Open(FitName, "READ", __FILE__, __LINE__);
   TTree *posts = infile->Get<TTree>("posteriors");
-  unsigned int step_val = 0;
   double log_val = M3::_LARGE_LOGL_;
-  posts->SetBranchAddress("step",&step_val);
   posts->SetBranchAddress("LogL",&log_val);
 
   for (size_t s = 0; s < systematics.size(); ++s)
@@ -388,22 +386,17 @@ void FitterBase::StartFromPreviousFit(const std::string& FitName) {
     MACH3LOG_INFO("Printing new starting values for: {}", systematics[s]->GetName());
     systematics[s]->PrintPreFitCurrPropValues();
 
-    // Resetting branch addressed to nullptr as we don't want to write into a delected vector out of scope...
+    // Resetting branch addressed to nullptr as we don't want to write into a deleted vector out of scope...
     for (int i = 0; i < systematics[s]->GetNumParams(); ++i) {
       posts->SetBranchAddress(systematics[s]->GetParName(i).c_str(), nullptr);
     }
   }
   logLCurr = log_val;
   logLProp = log_val;
+
   delete posts;
   infile->Close();
   delete infile;
-
-  for (size_t s = 0; s < systematics.size(); ++s) {
-    if(systematics[s]->GetDoAdaption()){ //Use separate throw matrix for xsec
-      systematics[s]->SetNumberOfSteps(step_val);
-    }
-  }
 }
 
 // *******************

--- a/Fitters/FitterBase.h
+++ b/Fitters/FitterBase.h
@@ -23,6 +23,8 @@ class TDirectory;
 /// It serves as a base for different fitting algorithms and for validation techniques
 /// such as LLH scans.
 ///
+/// @author Asher Kaboth
+/// @author Kamil Skwarczynski
 /// @ingroup CoreClasses
 class FitterBase {
  public:

--- a/Fitters/MCMCBase.cpp
+++ b/Fitters/MCMCBase.cpp
@@ -161,11 +161,9 @@ void MCMCBase::StartFromPreviousFit(const std::string &FitName) {
 
     stepStart = step_val;
     // KS: Also update number of steps if using adaption
-    for (unsigned int i = 0; i < systematics.size(); ++i)
-    {
-        if (systematics[i]->GetDoAdaption())
-        {
-            systematics[i]->SetNumberOfSteps(step_val);
+    for (unsigned int i = 0; i < systematics.size(); ++i) {
+        if (systematics[i]->GetDoAdaption()) {
+            systematics[i]->SetNumberOfSteps(stepStart);
         }
     }
     infile->Close();


### PR DESCRIPTION
# Pull request description
StepStart is only used by MCMC, however it was loaded in FitterBase and in MCMC base.
Problem was it wasn't loaded correctly in FitterBase.

**It isn't a bug fix per se as it doesn't affect anything, however it is not desired and confusing behaviour**

This has been notice while Henry and me were looking at StartFromPrevious for adaptive to help Abi.

---
- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
