### PR TITLE
bugfix: Change from GetDiagonalError to GetError in python

### DIFF
--- a/python/parameters.h
+++ b/python/parameters.h
@@ -174,7 +174,7 @@ void initParametersModule(py::module &m_parameters){
             "Is the parameter at index i flat?. \n\
             :param index: index of the parameter")
 
-        .def("get_par_error", &ParameterHandlerBase::GetDiagonalError, py::arg("index"), 
+        .def("get_par_error", &ParameterHandlerBase::GetError, py::arg("index"), 
             "The prior error on parameter at index i \n\
             :param index: index of the parameter")
 


### PR DESCRIPTION
# Pull request description
Getting the error in python used the diagonal error in the covariance matrix. This resulted in numerical instability for parameters like `delm2_12` when large number of parameters are loaded. 

i.e. The nominal of delm2_12 is 0.000018 which was stable when O(80) params are included. When the DUNE flux matrix is used, this changes to  3.167396407145781e-05 which is wildly incorrect.

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
