### PR TITLE
bugfix: Matrix shift now scales with parameters original value

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -850,14 +850,19 @@ void ParameterHandlerBase::PrintIndivStepScale() const {
 
 // ********************************************
 //Makes sure that matrix is positive-definite by adding a small number to on-diagonal elements
-void ParameterHandlerBase::MakePosDef(TMatrixDSym *cov) {
+void ParameterHandlerBase::MakePosDef(TMatrixDSym *cov, bool verbose) {
 // ********************************************
   if(cov == nullptr){
     cov = &*covMatrix;
     MACH3LOG_WARN("Passed nullptr to cov matrix in {}", matrixName);
   }
 
-  M3::MakeMatrixPosDef(cov);
+  int n_attempts = M3::MakeMatrixPosDef(cov);
+
+  if(n_attempts > 0 && verbose) {
+    MACH3LOG_WARN("Covariance matrix {} was not positive-definite, made it positive-definite after {} attempts", matrixName, n_attempts);
+  }
+
 }
 
 // ********************************************
@@ -903,7 +908,11 @@ void ParameterHandlerBase::SetThrowMatrix(const TMatrixDSym *cov) {
 
   throwMatrix = static_cast<TMatrixDSym*>(cov->Clone());
   if(use_adaptive && AdaptiveHandler->AdaptionUpdate()) MakeClosestPosDef(throwMatrix);
-  else MakePosDef(throwMatrix);
+  else {
+    // HW: Prevent spam from adaptive handler
+    bool verbose = AdaptiveHandler ? AdaptiveHandler->GetTotalSteps() < 2 : true;
+    MakePosDef(throwMatrix, verbose);
+  }
 
   auto throwMatrix_CholDecomp = M3::GetCholeskyDecomposedMatrix(*throwMatrix, matrixName);
 

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -353,6 +353,7 @@ class ParameterHandlerBase {
 
   /// @brief Make matrix positive definite by adding small values to diagonal, necessary for inverting matrix
   /// @param cov Matrix which we evaluate Positive Definitiveness
+  /// @param verbose Do we want it to print warning if it was not positive definite and we had to fix it
   void MakePosDef(TMatrixDSym *cov = nullptr, bool verbose = true);
 
   /// @brief HW: Finds closest possible positive definite matrix in Frobenius Norm ||.||_frob Where ||X||_frob=sqrt[sum_ij(x_ij^2)] (basically just turns an n,n matrix into vector in n^2 space then does Euclidean norm)

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -8,7 +8,6 @@
 #include "Parameters/ParameterTunes.h"
 
 /// @brief Base class for handling systematic uncertainty parameters.
-///verbose
 /// @details Provides core functionality for managing systematic parameters,
 /// including likelihood evaluation and covariance handling.
 ///

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -8,7 +8,7 @@
 #include "Parameters/ParameterTunes.h"
 
 /// @brief Base class for handling systematic uncertainty parameters.
-///
+///verbose
 /// @details Provides core functionality for managing systematic parameters,
 /// including likelihood evaluation and covariance handling.
 ///
@@ -354,7 +354,7 @@ class ParameterHandlerBase {
 
   /// @brief Make matrix positive definite by adding small values to diagonal, necessary for inverting matrix
   /// @param cov Matrix which we evaluate Positive Definitiveness
-  void MakePosDef(TMatrixDSym *cov = nullptr);
+  void MakePosDef(TMatrixDSym *cov = nullptr, bool verbose = true);
 
   /// @brief HW: Finds closest possible positive definite matrix in Frobenius Norm ||.||_frob Where ||X||_frob=sqrt[sum_ij(x_ij^2)] (basically just turns an n,n matrix into vector in n^2 space then does Euclidean norm)
   void MakeClosestPosDef(TMatrixDSym *cov);

--- a/Parameters/ParameterHandlerUtils.h
+++ b/Parameters/ParameterHandlerUtils.h
@@ -549,7 +549,7 @@ inline bool CanDecomposeMatrix(const TMatrixDSym& matrix) {
 
 // *************************************
 /// @brief Makes sure that matrix is positive-definite by adding a small number to on-diagonal elements
-inline void MakeMatrixPosDef(TMatrixDSym *cov) {
+inline int MakeMatrixPosDef(TMatrixDSym *cov) {
 // *************************************
   //DB Save original warning state and then increase it in this function to suppress 'matrix not positive definite' messages
   //Means we no longer need to overload
@@ -568,15 +568,14 @@ inline void MakeMatrixPosDef(TMatrixDSym *cov) {
     original_diagonal[iVar] = (*cov)(iVar, iVar);
   }
 
+  int attempts = 0;
+
   for (iAttempt = 0; iAttempt < MaxAttempts; iAttempt++) {
     if (CanDecomposeMatrix(*cov)) {
-      if(iAttempt > 0){
-      	MACH3LOG_WARN("Matrix now positive definite, took {} shifts to fix", iAttempt+1);
-      }
 
       CanDecomp = true;
-      break;
-    } 
+      attempts = iAttempt;
+    }
     else {
       #ifdef MULTITHREAD
       #pragma omp parallel for
@@ -600,6 +599,7 @@ inline void MakeMatrixPosDef(TMatrixDSym *cov) {
 
   //DB Resetting warning level
   gErrorIgnoreLevel = originalErrorWarning;
+  return attempts;
 }
 
 

--- a/Parameters/ParameterHandlerUtils.h
+++ b/Parameters/ParameterHandlerUtils.h
@@ -572,9 +572,9 @@ inline int MakeMatrixPosDef(TMatrixDSym *cov) {
 
   for (iAttempt = 0; iAttempt < MaxAttempts; iAttempt++) {
     if (CanDecomposeMatrix(*cov)) {
-
       CanDecomp = true;
       attempts = iAttempt;
+      break;
     }
     else {
       #ifdef MULTITHREAD

--- a/Parameters/ParameterHandlerUtils.h
+++ b/Parameters/ParameterHandlerUtils.h
@@ -561,6 +561,12 @@ inline void MakeMatrixPosDef(TMatrixDSym *cov) {
   const int matrixSize = cov->GetNrows();
   int iAttempt = 0;
   bool CanDecomp = false;
+  
+  // HW: We'll store the diagonal *1e-9 first to prevent inflating the matrix too much!
+  std::vector<double> matrix_shift(matrixSize);
+  for (int iVar = 0 ; iVar < matrixSize; iVar++) {
+    matrix_shift[iVar] = (*cov)(iVar, iVar)*1e-9;
+  }
 
   for (iAttempt = 0; iAttempt < MaxAttempts; iAttempt++) {
     if (CanDecomposeMatrix(*cov)) {
@@ -571,7 +577,7 @@ inline void MakeMatrixPosDef(TMatrixDSym *cov) {
       #pragma omp parallel for
       #endif
       for (int iVar = 0 ; iVar < matrixSize; iVar++) {
-        (*cov)(iVar, iVar) += 1e-9;
+        (*cov)(iVar, iVar) += matrix_shift[iVar];
       }
     }
   }

--- a/Parameters/ParameterHandlerUtils.h
+++ b/Parameters/ParameterHandlerUtils.h
@@ -562,22 +562,32 @@ inline void MakeMatrixPosDef(TMatrixDSym *cov) {
   int iAttempt = 0;
   bool CanDecomp = false;
   
-  // HW: We'll store the diagonal *1e-9 first to prevent inflating the matrix too much!
-  std::vector<double> matrix_shift(matrixSize);
+  // HW: We'll store the diagonal first to prevent inflating the matrix too much!
+  std::vector<double> original_diagonal(matrixSize, 0.0);
   for (int iVar = 0 ; iVar < matrixSize; iVar++) {
-    matrix_shift[iVar] = (*cov)(iVar, iVar)*1e-9;
+    original_diagonal[iVar] = (*cov)(iVar, iVar);
   }
 
   for (iAttempt = 0; iAttempt < MaxAttempts; iAttempt++) {
     if (CanDecomposeMatrix(*cov)) {
+      if(iAttempt > 0){
+      	MACH3LOG_WARN("Matrix now positive definite, took {} shifts to fix", iAttempt+1);
+      }
+
       CanDecomp = true;
       break;
-    } else {
+    } 
+    else {
       #ifdef MULTITHREAD
       #pragma omp parallel for
-      #endif
+      #endif 
       for (int iVar = 0 ; iVar < matrixSize; iVar++) {
-        (*cov)(iVar, iVar) += matrix_shift[iVar];
+        if( (*cov)(iVar, iVar)/10 > original_diagonal[iVar]) {
+          MACH3LOG_DEBUG("Diagonal element {} has been shifted too much (> original value/10). Stopping further shifts.", iVar);
+          original_diagonal[iVar] = 0; // Prevent further shifts for this element
+          continue;
+        }
+        (*cov)(iVar, iVar) += 1e-9;
       }
     }
   }


### PR DESCRIPTION
# Pull request description
Previously we added a flat 1e-9 to the diagonal of our covariance matrix, now this is 1e-9 * [the nominal error of that parameter].

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
