### PR TITLE
feat: LLHMap improvements

### DIFF
--- a/Diagnostics/PlotLLHMap.cpp
+++ b/Diagnostics/PlotLLHMap.cpp
@@ -69,7 +69,7 @@ std::pair<bool,std::vector<double>> ExtractBinning(std::string param, YAML::Node
     nExpBins = GetFromManager<unsigned int>(Settings["LLHScan"]["ScanPoints"][param], nExpBins, __FILE__, __LINE__);
 
 
-  // Preparing a histogram. Again, this now works only with uniform steps in LLHMap
+  // Preparing a histogram.
   auto values = Map.Take<double>(param.c_str());
 
   // remove duplicates
@@ -82,7 +82,7 @@ std::pair<bool,std::vector<double>> ExtractBinning(std::string param, YAML::Node
     nExpBins = static_cast<unsigned int>(unique.size());
   }
 
-  // Extract minimum and mximum
+  // Extract minimum and maximum
   double minx = *unique.begin();
   double maxx = *unique.rbegin();
 
@@ -173,7 +173,7 @@ int main(int argc, char *argv[]) {
   auto Map = ROOT::RDataFrame("llhmap", inpFileList);
 
   // Now prepare the L column
-  // TODO: Let
+  // TODO: Let the user choose whether they want the Total_LLH or something else... but why?
   auto LLHMap = Map.Define("L", "exp(-0.5*Total_LLH)");
 
   // Process what parameters to plot
@@ -285,20 +285,8 @@ int main(int argc, char *argv[]) {
     {
       for(auto p2 = std::next(p1); p2 != ParamsFiltered.end(); ++p2)
       {
-        // Skip whenever p1 == p2 or already profiled in reversed order (p1-p2 or p2-p1)
-        // if(p1 == p2)
-        //   continue;
-        // if(std::find(Strings2D.begin(), Strings2D.end(), p2+"_"+p1) != Strings2D.end())
-        //   continue;
-
-        // std::string hProf1Name = p1+"_LLHProf1D";
-        // std::string hProf2Name = p2+"_LLHProf1D";
-
-        // Get the binning info from 1D histograms
-
         auto h1 = DirProfile1D->Get<TH1D>((*p1+"_LLHProf1D").c_str());
         auto h2 = DirProfile1D->Get<TH1D>((*p2+"_LLHProf1D").c_str());
-
 
         std::string key = *p1+"_"+*p2;
         Keys2D.push_back(key);
@@ -353,10 +341,10 @@ int main(int argc, char *argv[]) {
             auto by_lo = hProfiles2d[key]->GetYaxis()->GetBinLowEdge(bidy);
             auto by_hi = by_lo + hProfiles2d[key]->GetYaxis()->GetBinWidth(bidy);
 
+            // TODO: Think how to do this smarter and faster
             double llhmin = LLHMap.Filter(*p1+">"+std::to_string(bx_lo)+"&&"+*p1+"<"+std::to_string(bx_hi)+"&&"+*p2+">"+std::to_string(by_lo)+"&&"+*p2+"<"+std::to_string(by_hi)).Min("Total_LLH").GetValue();
 
-            // Rather store a non-sensensical value if out of bounds
-            // TODO: Think how to do this smarter and faster
+            // Rather store a non-sensical value if out of bounds
             if(llhmin >= M3::_LARGE_LOGL_) llhmin = -12345;
             hProfiles2d[key]->SetBinContent(bidx, bidy, llhmin);
 

--- a/Diagnostics/PlotLLHMap.cpp
+++ b/Diagnostics/PlotLLHMap.cpp
@@ -59,6 +59,79 @@ std::vector<std::string> GetParams(std::vector<std::string> &PoIs, ROOT::RDataFr
 }
 
 // *******************
+// Extract binning
+std::pair<bool,std::vector<double>> ExtractBinning(std::string param, YAML::Node Settings, ROOT::RDataFrame Map)
+// *******************
+{
+  // Expected number of bins based on the config
+  long unsigned int nExpBins = GetFromManager<long unsigned int>(Settings["LLHScan"]["LLHScanPoints"], 20, __FILE__, __LINE__);
+  if(CheckNodeExists(Settings,"LLHScan","ScanPoints"))
+    nExpBins = GetFromManager<int>(Settings["LLHScan"]["ScanPoints"][param], nExpBins, __FILE__, __LINE__);
+
+
+  // Preparing a histogram. Again, this now works only with uniform steps in LLHMap
+  auto values = Map.Take<double>(param.c_str());
+
+  // remove duplicates
+  std::set<double> unique(values->begin(), values->end());
+
+  MACH3LOG_INFO("There are {} values (bins) for parameter {} inside LLHMap.", unique.size(), param);
+
+  if(nExpBins != unique.size()) {
+    MACH3LOG_WARN("The config expects different number of {} bins for parameter {} than {} values included in LLHMap!", nExpBins, param, unique.size());
+    nExpBins = unique.size();
+  }
+
+  // Extract minimum and mximum
+  double minx = *unique.begin();
+  double maxx = *unique.rbegin();
+
+  // What is the minimal difference between two unique values to construct a bin width
+  double minDiff = maxx - minx;
+
+  for (auto it = std::next(unique.begin()); it != unique.end(); ++it) {
+    auto prev = std::prev(it);
+    minDiff = std::min(minDiff, *it - *prev);
+  }
+
+  if (unique.size() > 1) {
+    int bins = int( 1 + std::abs(maxx-minx) / minDiff );
+    if (nExpBins != bins) {
+      MACH3LOG_WARN("The scan is not uniform! Instead, we will use bins based on unique scan values and minimal {:.3e} distance between them!", minDiff);
+      nExpBins = 0;
+    }
+  }
+
+  double half_w = std::max(1e-12*minx, .5*minDiff);
+  minx = minx-half_w;
+  maxx = maxx+half_w;
+
+  std::vector<double> binning = {minx, maxx};
+
+
+  if (nExpBins == 0) {
+    for (auto it = std::next(unique.begin()); std::next(it) != unique.end(); ++it)
+    {
+      // first, insert next edge
+      double next_edge = *it + half_w;
+      binning.insert(binning.end()-1, next_edge);
+
+      // now check, if it aligns with the next unique value
+      auto next = std::next(it);
+      if ( std::abs((next_edge - *next + half_w) / (next_edge + *next - half_w )) < 1e-12 )
+        continue;
+      else
+        binning.insert(binning.end()-1, *next-half_w);
+    }
+  } else {
+    for (auto it = unique.begin(); std::next(it) != unique.end(); ++it)
+      binning.insert(binning.end()-1, *it + half_w);
+  }
+
+  return std::make_pair(nExpBins>0, binning);
+}
+
+// *******************
 int main(int argc, char *argv[]) {
 // *******************
   SetMaCh3LoggerFormat();
@@ -72,14 +145,21 @@ int main(int argc, char *argv[]) {
 
   // Open the settings and output file
   YAML::Node Settings = M3OpenConfig(std::string(argv[1]));
-  auto OutFileName = GetFromManager<std::string>(Settings["General"]["OutputFile"], "LLHMap.root", __FILE__ , __LINE__);
+  auto OutFileName = GetFromManager<std::string>(Settings["General"]["OutputFile"], "LLHMap.root");
+  auto Plot2D = GetFromManager<bool>(Settings["LLHScan"]["Plot2D"], false, __FILE__, __LINE__);
 
   auto OutFile = new TFile(OutFileName.c_str(),"UPDATE");
   OutFile->cd();
 
   // Prepare dirs for profiled LLHs
   TDirectory* DirProfile1D = OutFile->mkdir("Profiled1D_LLH", "profile1D", true);
-  TDirectory* DirProfile2D = OutFile->mkdir("Profiled2D_LLH", "profile2D", true);
+  TDirectory* DirProfile2D;
+  if (Plot2D) DirProfile2D = OutFile->mkdir("Profiled2D_LLH", "profile2D", true);
+
+  TDirectory* DirMarginal1D = OutFile->mkdir("Marginal1D_L", "marginal1D", true);
+  TDirectory* DirMarginal2D;
+  if (Plot2D) DirMarginal2D = OutFile->mkdir("Marginal2D_L", "marginal2D", true);
+
 
   // Get the list of input files
   std::vector<std::string> inpFileList;
@@ -90,144 +170,213 @@ int main(int argc, char *argv[]) {
   }
 
   // Read the llhmap trees from the input files
-  ROOT::RDataFrame LLHMap("llhmap", inpFileList);
+  auto Map = ROOT::RDataFrame("llhmap", inpFileList);
+
+  // Now prepare the L column
+  // TODO: Let
+  auto LLHMap = Map.Define("L", "exp(-0.5*Total_LLH)");
 
   // Process what parameters to plot
-  auto ParamsOfInterest = GetFromManager<std::vector<std::string>>(Settings["LLHScan"]["LLHParameters"],{}, __FILE__ , __LINE__);
-  std::vector<std::string> ParamsToProfile = GetParams(ParamsOfInterest, LLHMap);
+  auto ParamsOfInterest = GetFromManager<std::vector<std::string>>(Settings["LLHScan"]["LLHParameters"],{});
+  std::vector<std::string> ParamsToProfile = GetParams(ParamsOfInterest, Map);
 
-  // This now only works for uniform LLHMaps
-  // TODO: Think how to allow for non-uniform LLHMaps
-  MACH3LOG_INFO("!!Assuming a uniform binning of the LLHScan!!");
+  MACH3LOG_INFO("... Starting generating 1D profiled and marginalized likelihoods ...");
+  MACH3LOG_WARN("!!! LLHMap numerical marginalization assumes uncorrelated priors !!!");
 
-  MACH3LOG_INFO("... Starting generating 1D profiled log likelihoods ...");
-
-  DirProfile1D->cd();
-  for(auto p : ParamsToProfile)
+  std::map<std::string, TH1D*> hProfiles1d;
+  std::map<std::string, TH1D*> hMarginals1d;
+  for(auto p = ParamsToProfile.begin(); p != ParamsToProfile.end(); ++p)
   {
-    // Find the binning for each histogram
+    // Find the binning for the histograms.
+    // ExtractBinning gives a pair of bool, bin_edges.
+    // The bool denotes whether binning is uniform or not.
+    std::pair<bool, std::vector<double>> binning = ExtractBinning(*p, Settings, Map);
 
-    // Expected number of bins based on the config
-    int nExpBins = GetFromManager<int>(Settings["LLHScan"]["LLHScanPoints"], 20, __FILE__, __LINE__);
-    if(CheckNodeExists(Settings,"LLHScan","ScanPoints"))
-      nExpBins = GetFromManager<int>(Settings["LLHScan"]["ScanPoints"][p], nExpBins, __FILE__, __LINE__);
+    std::string hProfTitle = *p+" profiled -2LogL";
+    std::string hProfName = *p+"_LLHProf1D";
+    std::string hMargTitle = *p+" marginalized L";
+    std::string hMargName = *p+"_LMarg1D";
 
-    // Calculate the number of bins from the LLHMap
-    std::set<double> cBins;
-    auto checkBin = [&cBins](double var) {
-      if(!(std::find(cBins.begin(), cBins.end(), var) != cBins.end())) cBins.emplace(var);
-    };
+    TH1D* hprof1d = new TH1D(hProfName.c_str(), hProfTitle.c_str(), binning.second.size()-1, binning.second.data());
+    TH1D* hmarg1d = new TH1D(hMargName.c_str(), hMargTitle.c_str(), binning.second.size()-1, binning.second.data());
+    if (binning.first)
+    {
+      MACH3LOG_INFO("Initializing 1D profiled -2LogL and marginalized L histograms for {} of {} bins from {:.3e} to {:.3e} (bin center at {:.3e} and {:.3e})", *p, hprof1d->GetNbinsX(), hprof1d->GetXaxis()->GetXmin(), hprof1d->GetXaxis()->GetXmax(), hprof1d->GetBinCenter(1), hprof1d->GetBinCenter(hprof1d->GetNbinsX()));
+    } else {
+      std::string binnies;
+      // TN: Waiting for C++ 20 std::format() function
+      for (auto binnie : binning.second)
+      {
+        std::ostringstream os;
+        os << std::scientific << std::setprecision(4) << binnie;
+        binnies += " "+os.str();
 
-    LLHMap.Foreach(checkBin, {p.c_str()});
+      }
 
-    if(nExpBins != int(cBins.size())) {
-      MACH3LOG_WARN("The config expects different number of {} bins for parameter {} than {} values included in LLHMap!", nExpBins, p, cBins.size());
-      nExpBins = int(cBins.size());
+      MACH3LOG_INFO("Initializing 1D profiled -2LogL and marginalized L histograms of {} bins with edges{}.", binning.second.size(), binnies);
     }
 
-    MACH3LOG_INFO("There are {} values (bins) for parameter {} inside LLHMap.", nExpBins, p);
+    hProfiles1d[*p]  = hprof1d;
+    hMarginals1d[*p] = hmarg1d;
+  }
 
-    // Preparing a histogram. Again, this now works only with uniform steps in LLHMap
-    double minx = LLHMap.Min(p.c_str()).GetValue();
-    double maxx = LLHMap.Max(p.c_str()).GetValue();
-    double binw = std::abs(maxx-minx)/double(nExpBins-1);
-
-    minx = minx-.5*binw;
-    maxx = maxx+.5*binw;
-
-    MACH3LOG_INFO("Generating a Profile1DLLH histogram for {} of {} bins from {} to {} (bin center at {} and {})", p, nExpBins, minx, maxx, minx+.5*binw, maxx-.5*binw);
-
-    std::string hTitle = p+" profiled LLH";
-    std::string hName = p+"_LLHProf1D";
-    TH1D* hprof1d = new TH1D(hName.c_str(), hTitle.c_str(), nExpBins, minx, maxx);
+  for(auto p = ParamsToProfile.begin(); p != ParamsToProfile.end(); ++p)
+  {
 
     // Now loop over the bins. For each bin, find the minimal Total_LLH over the rest of the parameter space.
     // TODO: Switch between different LLHs (sample, xsec, etc.)
-    for(int bidx = 1; bidx < hprof1d->GetNbinsX() + 1; ++bidx)
+    const int count = hProfiles1d[*p]->GetNbinsX() > 5 ? int(double(hProfiles1d[*p]->GetNbinsX())/double(5)) : 1;
+
+    // Profile over the rest of the parameters
+    MACH3LOG_INFO("Profiling 1D -2LogL and numerically profiling 1D L for parameter {}!", *p);
+    for(int bidx = 1; bidx < hProfiles1d[*p]->GetNbinsX() + 1; ++bidx)
     {
-      const int count = int(double(hprof1d->GetNbinsX())/double(5));
       if (bidx % count == 0)
-        M3::Utils::PrintProgressBar(bidx, hprof1d->GetNbinsX());
+        M3::Utils::PrintProgressBar(bidx, hProfiles1d[*p]->GetNbinsX());
 
-      auto b_lo = hprof1d->GetXaxis()->GetBinLowEdge(bidx);
-      auto b_hi = b_lo + hprof1d->GetXaxis()->GetBinWidth(bidx);
+      auto b_lo = hProfiles1d[*p]->GetXaxis()->GetBinLowEdge(bidx);
+      auto b_hi = b_lo + hProfiles1d[*p]->GetXaxis()->GetBinWidth(bidx);
 
-      double llhmin = LLHMap.Filter(p+">"+std::to_string(b_lo)+"&&"+p+"<"+std::to_string(b_hi)).Min("Total_LLH").GetValue();
+      double llhmin = LLHMap.Filter(*p+">"+std::to_string(b_lo)+"&&"+*p+"<"+std::to_string(b_hi)).Min("Total_LLH").GetValue();
 
-      if(llhmin > M3::_LARGE_LOGL_) llhmin = M3::_LARGE_LOGL_;
-      hprof1d->SetBinContent(bidx, llhmin);
+      // Rather store a non-sensensical value if out of bounds
+      if(llhmin >= M3::_LARGE_LOGL_) llhmin = -12345;
+      hProfiles1d[*p]->SetBinContent(bidx, llhmin);
+
+      auto L = LLHMap.Filter(*p+">"+std::to_string(b_lo)+"&&"+*p+"<"+std::to_string(b_hi)).Sum("L");
+
+      hMarginals1d[*p]->SetBinContent(bidx, *L);
     }
 
-    // Save the 1D profiled histogram
-    hprof1d->Write(hName.c_str(), TObject::kOverwrite);
+    // Save the 1D histograms
+    DirProfile1D->cd();
+    hProfiles1d[*p]->Write(hProfiles1d[*p]->GetName(), TObject::kOverwrite);
+
+    DirMarginal1D->cd();
+    hMarginals1d[*p]->Scale(1./hMarginals1d[*p]->Integral());
+    hMarginals1d[*p]->Write(hMarginals1d[*p]->GetName(), TObject::kOverwrite);
   }
 
-  MACH3LOG_INFO("... Starting generating 2D profiled log likelihoods ...");
 
-  DirProfile2D->cd();
-  std::vector<std::string> Strings2D;
-
-  // Similar as with 1D profiles, but looping over parameters twice
-  for(auto p1 : ParamsToProfile)
+  if (Plot2D)
   {
-    for(auto p2 : ParamsToProfile)
+    MACH3LOG_INFO("... Starting generating 2D profiled and marginalized likelihoods ...");
+    MACH3LOG_WARN("!!! THIS MIGHT TAKE QUITE A WHILE !!!");
+    MACH3LOG_WARN("!!! LLHMap numerical marginalization assumes uncorrelated priors !!!");
+
+    std::vector<std::string> Keys2D;
+    std::vector<std::string> ParamsFiltered;
+    std::map<std::string, TH2D*> hProfiles2d;
+    std::map<std::string, TH2D*> hMarginals2d;
+
+    for(auto p : ParamsToProfile)
     {
-      // Skip whenever p1 == p2 or already profiled in reversed order (p1-p2 or p2-p1)
-      if(p1 == p2)
-        continue;
-      if(std::find(Strings2D.begin(), Strings2D.end(), p2+"_"+p1) != Strings2D.end())
-        continue;
-
-      std::string h1Name = p1+"_LLHProf1D";
-      std::string h2Name = p2+"_LLHProf1D";
-
-      // Get the binning info from 1D histograms
-      auto h1 = DirProfile1D->Get<TH1D>(h1Name.c_str());
-      auto h2 = DirProfile1D->Get<TH1D>(h2Name.c_str());
-
-      // Auxiliary
-      int nx = h1->GetNbinsX();
-      double minx = h1->GetBinLowEdge(1);
-      double maxx = h1->GetBinLowEdge(nx)+h1->GetBinWidth(nx);
-
-      int ny = h2->GetNbinsX();
-      double miny = h2->GetBinLowEdge(1);
-      double maxy = h2->GetBinLowEdge(ny)+h2->GetBinWidth(ny);
-
-      std::string hTitle = p1+" vs. "+p2+" profiled LLH";
-      std::string hName = p1+"_"+p2+"_LLHProf2D";
-      TH2D* hprof2d = new TH2D(hName.c_str(), hTitle.c_str(), nx, minx, maxx, ny, miny, maxy);
-
-      MACH3LOG_INFO("The 2D histogram has {} x-bins from {} to {} and {} y-bins from {} to {}", nx, minx, maxx, ny, miny, maxy);
-      const Long64_t nBinsX = static_cast<Long64_t>(hprof2d->GetNbinsX());
-      const Long64_t nBinsY = static_cast<Long64_t>(hprof2d->GetNbinsY());
-      const Long64_t TotalBins = nBinsX * nBinsY;
-      for(int bidx = 1; bidx < nBinsX + 1; ++bidx)
+      auto h = DirProfile1D->Get<TH1D>((p+"_LLHProf1D").c_str());
+      if(h->GetNbinsX()<2)
       {
-        for(int bidy = 1; bidy < nBinsY + 1; ++bidy)
-        {
-          const int count = int(double(TotalBins)/double(5));
-          if ( ((bidx-1)*hprof2d->GetNbinsY() + bidy) % count == 0)
-            M3::Utils::PrintProgressBar((bidx-1)*hprof2d->GetNbinsY() + bidy, TotalBins);
-
-          auto bx_lo = hprof2d->GetXaxis()->GetBinLowEdge(bidx);
-          auto bx_hi = bx_lo + hprof2d->GetXaxis()->GetBinWidth(bidx);
-
-          auto by_lo = hprof2d->GetYaxis()->GetBinLowEdge(bidy);
-          auto by_hi = by_lo + hprof2d->GetYaxis()->GetBinWidth(bidy);
-
-          double llhmin = LLHMap.Filter(p1+">"+std::to_string(bx_lo)+"&&"+p1+"<"+std::to_string(bx_hi)+"&&"+p2+">"+std::to_string(by_lo)+"&&"+p2+"<"+std::to_string(by_hi)).Min("Total_LLH").GetValue();
-
-          if(llhmin > M3::_LARGE_LOGL_) llhmin = M3::_LARGE_LOGL_;
-          hprof2d->SetBinContent(bidx, bidy, llhmin);
-        }
+        MACH3LOG_WARN("There is less than 2 bins for {}, 2D is equivalent to 1D! Removing from 2D plots ...", p);
+      } else {
+        ParamsFiltered.push_back(p);
       }
-
-      hprof2d->Write(hName.c_str(), TObject::kOverwrite);
-
-      Strings2D.push_back(p1+"_"+p2);
     }
-  }
+
+    // Similar as with 1D profiles, but looping over parameters twice
+    for(auto p1 = ParamsFiltered.begin(); p1 != ParamsFiltered.end(); ++p1)
+    {
+      for(auto p2 = std::next(p1); p2 != ParamsFiltered.end(); ++p2)
+      {
+        // Skip whenever p1 == p2 or already profiled in reversed order (p1-p2 or p2-p1)
+        // if(p1 == p2)
+        //   continue;
+        // if(std::find(Strings2D.begin(), Strings2D.end(), p2+"_"+p1) != Strings2D.end())
+        //   continue;
+
+        // std::string hProf1Name = p1+"_LLHProf1D";
+        // std::string hProf2Name = p2+"_LLHProf1D";
+
+        // Get the binning info from 1D histograms
+
+        auto h1 = DirProfile1D->Get<TH1D>((*p1+"_LLHProf1D").c_str());
+        auto h2 = DirProfile1D->Get<TH1D>((*p2+"_LLHProf1D").c_str());
+
+
+        std::string key = *p1+"_"+*p2;
+        Keys2D.push_back(key);
+
+        MACH3LOG_INFO("Initializing 2D profiled -2LogL and marginalized L histograms for {} vs. {} based on previously generated 1D histograms.", *p1, *p2);
+
+        std::string hProfTitle = *p1+" vs. "+*p2+" profiled -2LogL";
+        std::string hProfName = key+"_LLHProf2D";
+        TH2D* hprof2d = new TH2D(
+            hProfName.c_str(), hProfTitle.c_str(),
+            h1->GetXaxis()->GetNbins(), h1->GetXaxis()->GetXbins()->GetArray(),
+            h2->GetXaxis()->GetNbins(), h2->GetXaxis()->GetXbins()->GetArray()
+        );
+
+        hProfiles2d[key] = hprof2d;
+
+        std::string hMargTitle = *p1+" vs. "+*p2+" marginalized L";
+        std::string hMargName = key+"_LMarg1D";
+        TH2D* hmarg2d = new TH2D(
+            hMargName.c_str(), hMargTitle.c_str(),
+            h1->GetXaxis()->GetNbins(), h1->GetXaxis()->GetXbins()->GetArray(),
+            h2->GetXaxis()->GetNbins(), h2->GetXaxis()->GetXbins()->GetArray()
+        );
+
+        hMarginals2d[key] = hmarg2d;
+      }
+    }
+
+    for(auto p1 = ParamsFiltered.begin(); p1 != ParamsFiltered.end(); ++p1)
+    {
+      for(auto p2 = std::next(p1); p2 != ParamsFiltered.end(); ++p2)
+      {
+        std::string key = *p1+"_"+*p2;
+
+        MACH3LOG_INFO("Numerically profiling 2D -2LogL and marginalizing 2D L for parameters {} and {}!",*p1, *p2);
+        const Long64_t nBinsX = static_cast<Long64_t>(hProfiles2d[key]->GetNbinsX());
+        const Long64_t nBinsY = static_cast<Long64_t>(hProfiles2d[key]->GetNbinsY());
+
+        const Long64_t TotalBins = nBinsX * nBinsY;
+        const int count = TotalBins > 5 ? int(double(TotalBins)/double(5)) : 1;
+
+        for(int bidx = 1; bidx < nBinsX + 1; ++bidx)
+        {
+          for(int bidy = 1; bidy < nBinsY + 1; ++bidy)
+          {
+            if ( ((bidx-1)*hProfiles2d[key]->GetNbinsY() + bidy) % count == 0)
+               M3::Utils::PrintProgressBar((bidx-1)*hProfiles2d[key]->GetNbinsY() + bidy, TotalBins);
+
+            auto bx_lo = hProfiles2d[key]->GetXaxis()->GetBinLowEdge(bidx);
+            auto bx_hi = bx_lo + hProfiles2d[key]->GetXaxis()->GetBinWidth(bidx);
+
+            auto by_lo = hProfiles2d[key]->GetYaxis()->GetBinLowEdge(bidy);
+            auto by_hi = by_lo + hProfiles2d[key]->GetYaxis()->GetBinWidth(bidy);
+
+            double llhmin = LLHMap.Filter(*p1+">"+std::to_string(bx_lo)+"&&"+*p1+"<"+std::to_string(bx_hi)+"&&"+*p2+">"+std::to_string(by_lo)+"&&"+*p2+"<"+std::to_string(by_hi)).Min("Total_LLH").GetValue();
+
+            // Rather store a non-sensensical value if out of bounds
+            // TODO: Think how to do this smarter and faster
+            if(llhmin >= M3::_LARGE_LOGL_) llhmin = -12345;
+            hProfiles2d[key]->SetBinContent(bidx, bidy, llhmin);
+
+            auto L = LLHMap.Filter(*p1+">"+std::to_string(bx_lo)+"&&"+*p1+"<"+std::to_string(bx_hi)+"&&"+*p2+">"+std::to_string(by_lo)+"&&"+*p2+"<"+std::to_string(by_hi)).Sum("L");
+
+            hMarginals2d[key]->SetBinContent(bidx,bidy, *L);
+          } // end bins y loop
+        } // end bins x loop
+
+        // Save the 2D histograms
+        DirProfile2D->cd();
+        hProfiles2d[key]->Write(hProfiles2d[key]->GetName(), TObject::kOverwrite);
+
+        DirMarginal2D->cd();
+        hMarginals2d[key]->Scale(1./hMarginals2d[key]->Integral());
+        hMarginals2d[key]->Write(hMarginals2d[key]->GetName(), TObject::kOverwrite);
+      } // end p2 loop
+    } // end p1 loop
+
+  } // end 2D plot
 
   OutFile->Close();
 

--- a/Diagnostics/PlotLLHMap.cpp
+++ b/Diagnostics/PlotLLHMap.cpp
@@ -183,8 +183,8 @@ int main(int argc, char *argv[]) {
   MACH3LOG_INFO("... Starting generating 1D profiled and marginalized likelihoods ...");
   MACH3LOG_WARN("!!! LLHMap numerical marginalization assumes uncorrelated priors !!!");
 
-  std::map<std::string, TH1D*> hProfiles1d;
-  std::map<std::string, TH1D*> hMarginals1d;
+  std::map<std::string, std::unique_ptr<TH1D>> hProfiles1d;
+  std::map<std::string, std::unique_ptr<TH1D>> hMarginals1d;
   for(auto p = ParamsToProfile.begin(); p != ParamsToProfile.end(); ++p)
   {
     // Find the binning for the histograms.
@@ -197,8 +197,13 @@ int main(int argc, char *argv[]) {
     std::string hMargTitle = *p+" marginalized L";
     std::string hMargName = *p+"_LMarg1D";
 
-    TH1D* hprof1d = new TH1D(hProfName.c_str(), hProfTitle.c_str(), int(binning.second.size()-1), binning.second.data());
-    TH1D* hmarg1d = new TH1D(hMargName.c_str(), hMargTitle.c_str(), int(binning.second.size()-1), binning.second.data());
+    // Prepare histograms and detach from ROOT
+    auto hprof1d = std::make_unique<TH1D>(hProfName.c_str(), hProfTitle.c_str(), int(binning.second.size()-1), binning.second.data());
+    hprof1d->SetDirectory(nullptr);
+
+    auto hmarg1d = std::make_unique<TH1D>(hMargName.c_str(), hMargTitle.c_str(), int(binning.second.size()-1), binning.second.data());
+    hmarg1d->SetDirectory(nullptr);
+
     if (binning.first)
     {
       MACH3LOG_INFO("Initializing 1D profiled -2LogL and marginalized L histograms for {} of {} bins from {:.3e} to {:.3e} (bin center at {:.3e} and {:.3e})", *p, hprof1d->GetNbinsX(), hprof1d->GetXaxis()->GetXmin(), hprof1d->GetXaxis()->GetXmax(), hprof1d->GetBinCenter(1), hprof1d->GetBinCenter(hprof1d->GetNbinsX()));
@@ -216,8 +221,8 @@ int main(int argc, char *argv[]) {
       MACH3LOG_INFO("Initializing 1D profiled -2LogL and marginalized L histograms of {} bins with edges{}.", binning.second.size(), binnies);
     }
 
-    hProfiles1d[*p]  = hprof1d;
-    hMarginals1d[*p] = hmarg1d;
+    hProfiles1d[*p]  = std::move(hprof1d);
+    hMarginals1d[*p] = std::move(hmarg1d);
   }
 
   for(auto p = ParamsToProfile.begin(); p != ParamsToProfile.end(); ++p)
@@ -266,8 +271,8 @@ int main(int argc, char *argv[]) {
 
     std::vector<std::string> Keys2D;
     std::vector<std::string> ParamsFiltered;
-    std::map<std::string, TH2D*> hProfiles2d;
-    std::map<std::string, TH2D*> hMarginals2d;
+    std::map<std::string, std::unique_ptr<TH2D>> hProfiles2d;
+    std::map<std::string, std::unique_ptr<TH2D>> hMarginals2d;
 
     for(auto p : ParamsToProfile)
     {
@@ -295,23 +300,25 @@ int main(int argc, char *argv[]) {
 
         std::string hProfTitle = *p1+" vs. "+*p2+" profiled -2LogL";
         std::string hProfName = key+"_LLHProf2D";
-        TH2D* hprof2d = new TH2D(
+        auto hprof2d = std::make_unique<TH2D>(
             hProfName.c_str(), hProfTitle.c_str(),
             h1->GetXaxis()->GetNbins(), h1->GetXaxis()->GetXbins()->GetArray(),
             h2->GetXaxis()->GetNbins(), h2->GetXaxis()->GetXbins()->GetArray()
         );
+        hprof2d->SetDirectory(nullptr);
 
-        hProfiles2d[key] = hprof2d;
+        hProfiles2d[key] = std::move(hprof2d);
 
         std::string hMargTitle = *p1+" vs. "+*p2+" marginalized L";
         std::string hMargName = key+"_LMarg1D";
-        TH2D* hmarg2d = new TH2D(
+        auto hmarg2d = std::make_unique<TH2D>(
             hMargName.c_str(), hMargTitle.c_str(),
             h1->GetXaxis()->GetNbins(), h1->GetXaxis()->GetXbins()->GetArray(),
             h2->GetXaxis()->GetNbins(), h2->GetXaxis()->GetXbins()->GetArray()
         );
+        hmarg2d->SetDirectory(nullptr);
 
-        hMarginals2d[key] = hmarg2d;
+        hMarginals2d[key] = std::move(hmarg2d);
       }
     }
 
@@ -348,7 +355,8 @@ int main(int argc, char *argv[]) {
             if(llhmin >= M3::_LARGE_LOGL_) llhmin = -12345;
             hProfiles2d[key]->SetBinContent(bidx, bidy, llhmin);
 
-            auto L = LLHMap.Filter(*p1+">"+std::to_string(bx_lo)+"&&"+*p1+"<"+std::to_string(bx_hi)+"&&"+*p2+">"+std::to_string(by_lo)+"&&"+*p2+"<"+std::to_string(by_hi)).Sum("L");
+            auto L = LLHMap.Filter(*p1+">"+std::to_string(bx_lo)+"&&"+*p1+"<"+std::to_string(bx_hi)
+                                  +"&&"+*p2+">"+std::to_string(by_lo)+"&&"+*p2+"<"+std::to_string(by_hi)).Sum("L");
 
             hMarginals2d[key]->SetBinContent(bidx,bidy, *L);
           } // end bins y loop

--- a/Diagnostics/PlotLLHMap.cpp
+++ b/Diagnostics/PlotLLHMap.cpp
@@ -64,9 +64,9 @@ std::pair<bool,std::vector<double>> ExtractBinning(std::string param, YAML::Node
 // *******************
 {
   // Expected number of bins based on the config
-  long unsigned int nExpBins = GetFromManager<long unsigned int>(Settings["LLHScan"]["LLHScanPoints"], 20, __FILE__, __LINE__);
+  unsigned int nExpBins = GetFromManager<unsigned int>(Settings["LLHScan"]["LLHScanPoints"], 20, __FILE__, __LINE__);
   if(CheckNodeExists(Settings,"LLHScan","ScanPoints"))
-    nExpBins = GetFromManager<int>(Settings["LLHScan"]["ScanPoints"][param], nExpBins, __FILE__, __LINE__);
+    nExpBins = GetFromManager<unsigned int>(Settings["LLHScan"]["ScanPoints"][param], nExpBins, __FILE__, __LINE__);
 
 
   // Preparing a histogram. Again, this now works only with uniform steps in LLHMap
@@ -77,9 +77,9 @@ std::pair<bool,std::vector<double>> ExtractBinning(std::string param, YAML::Node
 
   MACH3LOG_INFO("There are {} values (bins) for parameter {} inside LLHMap.", unique.size(), param);
 
-  if(nExpBins != unique.size()) {
+  if(nExpBins != static_cast<unsigned int>(unique.size())) {
     MACH3LOG_WARN("The config expects different number of {} bins for parameter {} than {} values included in LLHMap!", nExpBins, param, unique.size());
-    nExpBins = unique.size();
+    nExpBins = static_cast<unsigned int>(unique.size());
   }
 
   // Extract minimum and mximum
@@ -95,7 +95,7 @@ std::pair<bool,std::vector<double>> ExtractBinning(std::string param, YAML::Node
   }
 
   if (unique.size() > 1) {
-    int bins = int( 1 + std::abs(maxx-minx) / minDiff );
+    unsigned int bins = static_cast<unsigned int>( 1 + std::abs(maxx-minx) / minDiff );
     if (nExpBins != bins) {
       MACH3LOG_WARN("The scan is not uniform! Instead, we will use bins based on unique scan values and minimal {:.3e} distance between them!", minDiff);
       nExpBins = 0;
@@ -197,8 +197,8 @@ int main(int argc, char *argv[]) {
     std::string hMargTitle = *p+" marginalized L";
     std::string hMargName = *p+"_LMarg1D";
 
-    TH1D* hprof1d = new TH1D(hProfName.c_str(), hProfTitle.c_str(), binning.second.size()-1, binning.second.data());
-    TH1D* hmarg1d = new TH1D(hMargName.c_str(), hMargTitle.c_str(), binning.second.size()-1, binning.second.data());
+    TH1D* hprof1d = new TH1D(hProfName.c_str(), hProfTitle.c_str(), int(binning.second.size()-1), binning.second.data());
+    TH1D* hmarg1d = new TH1D(hMargName.c_str(), hMargTitle.c_str(), int(binning.second.size()-1), binning.second.data());
     if (binning.first)
     {
       MACH3LOG_INFO("Initializing 1D profiled -2LogL and marginalized L histograms for {} of {} bins from {:.3e} to {:.3e} (bin center at {:.3e} and {:.3e})", *p, hprof1d->GetNbinsX(), hprof1d->GetXaxis()->GetXmin(), hprof1d->GetXaxis()->GetXmax(), hprof1d->GetBinCenter(1), hprof1d->GetBinCenter(hprof1d->GetNbinsX()));

--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -1138,9 +1138,9 @@ void FitterBase::RunLLHMap() {
     if(CheckNodeExists(fitMan->raw(),"LLHScan","ScanRanges"))
       ParamsRanges[name].second = GetFromManager<std::pair<double,double>>(fitMan->raw()["LLHScan"]["ScanRanges"][name], ParamsRanges[name].second, __FILE__, __LINE__);
 
-    MACH3LOG_INFO("{} from {:.4f} to {:.4f} with a {:.5f} step ({} points total)",
+    MACH3LOG_INFO("{} from {:.4f} (lower bin edge) to {:.4f} (upper bin edge) with a {:.5f} step ({} points total)",
                   name, ParamsRanges[name].second.first, ParamsRanges[name].second.second,
-                  (ParamsRanges[name].second.second - ParamsRanges[name].second.first)/(ParamsRanges[name].first - 1.),
+                  (ParamsRanges[name].second.second - ParamsRanges[name].second.first)/(ParamsRanges[name].first),
                   ParamsRanges[name].first);
 
     TotalPoints *= ParamsRanges[name].first;
@@ -1222,8 +1222,8 @@ void FitterBase::RunLLHMap() {
       if (n > 0)
         idx[n] = idx[n] / ( dev / points );
 
-      // Parameter test value = low + ( high - low ) * idx / ( #points - 1 )
-      ParamsValues[n] = low + (high-low) * double(idx[n])/double(points-1);
+      // Parameter test value = low + ( high - low ) * idx / #points
+      ParamsValues[n] = low +  (2 * double(idx[n]) + 1) * (high-low) / (2 * double(points));
 
       // Now set the covariance objects
       // Auxiliary


### PR DESCRIPTION
# Pull request description

This PR covers several improvements to the LLHMap and PlotLLHMap functionality and plotting. Simplistic numerical marginalization to construct marginal likelihoods from an LLHMap is introduced.

## Changes or fixes

- Fixed binning and scan range logic to align with regular LLH scans. Now, the range specified corresponds to the histogram axis minimum and maximum, i.e. the LLHMap evaluated points fit in the bins centers.
- PlotLLHMap now deduces the histogram construction from the LLHMap by default, if LLHMap does not correspond to the provided yaml LLHScan config.
- PlotLLHMap constructs pseudo-non-uniform binnings based on the minimal distance of the scanned values:
  1. Define all unique values of the parameter _p_ in the LLHMap.
  2. Find the minimal difference among the unique values of _p_.
  3. The histogram is constructed as bins of the minimal distance width with the unique values in the center.
  4. Empty spaces between the bins are filled with -12345 to avoid wrong interpretation and to allow for filtering them out in case of interpolation and alike.
- PlotLLHMap now also uses a simplistic numerical marginalization, not accounting for prior correlations (useful for oscillation parameters scans and stuff).
- Restructuring the logic of looping over the parameters of interest.
- Allow user to skip 2D profiling and marginalization, which are computationally expensive.

## Examples
Examples of 1D and 2D numerical marginalization from a 20x20x20 LLHMap in (th13, th23, dcp) using MaCh3Tutorial beam samples. Useful enough to help you identify different modes of your likelihood.
<img width="1656" height="835" alt="1Dmarginal" src="https://github.com/user-attachments/assets/74793fb5-a165-4ee0-ba1c-559af602de22" />
<img width="1656" height="835" alt="2Dmarginal" src="https://github.com/user-attachments/assets/e25eb485-a34d-4397-ba7b-a5d09e5ca34d" />


## Future TODOs:
- **I HAVE TO FINALIZE THE TUTORIAL FOR THIS THING**
- Allow user to override the default histogram  construction to something of their liking (if they are brave enough). Is this even necessary?
- Think of better non-uniform binnings, maybe through adding the information about the binning as a TAxis info in the llhmap TTree.
- Think of smarter marginalization and profiling procedures (like sorting unique values, not summing entry-by-entry), deep-dive into RDataFrame possibilities.
- Account for priors correlations while marginalizing.

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
