### PR TITLE
bugfix: add special linking for older gcc to make it work with file system

### DIFF
--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@0337b99474cc604cc1c4737c1b419e6fb618172e  # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
         with:
           languages: c-cpp
           build-mode: manual
@@ -40,4 +40,4 @@ jobs:
           make
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@0337b99474cc604cc1c4737c1b419e6fb618172e  # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3

--- a/Manager/CMakeLists.txt
+++ b/Manager/CMakeLists.txt
@@ -30,6 +30,12 @@ endif()
 target_link_libraries(Manager PUBLIC MaCh3CompilerOptions MaCh3GPUCompilerOptions yaml-cpp spdlog NuOscillator ROOT::Tree ROOT::Hist ROOT::Physics)
 target_link_libraries(Manager PRIVATE MaCh3Warnings)
 
+# KS: To use std::filesystem for older gcc version this is needed
+# See https://en.cppreference.com/cpp/filesystem#Notes
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1)
+    target_link_libraries(Manager PUBLIC stdc++fs)
+endif()
+
 target_include_directories(Manager PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../>
   $<INSTALL_INTERFACE:include>)


### PR DESCRIPTION
# Pull request description
For gcc older than 9.1 which works with c++17 need special linking option for `std::filesystem`
https://en.cppreference.com/cpp/filesystem#Notes

## Changes or fixes


## Examples



---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
