### PR TITLE
feat: Tiny change to error when overwriting yaml settings

### DIFF
--- a/Fitters/MaCh3Factory.cpp
+++ b/Fitters/MaCh3Factory.cpp
@@ -80,6 +80,8 @@ std::unique_ptr<Manager> MaCh3ManagerFactory(int argc, char **argv) {
         Name.find("Samples") != std::string::npos)
     {
       MACH3LOG_CRITICAL("You are overwriting settings ({}) that are highly likely intended to be committed.", Name);
+      /// @todo DL: Should probably replace this with something that doesn't require modifying core code
+      MACH3LOG_CRITICAL("If you're sure you want to do this, e.g. for testing or step size tuning, you can remove the throw that lives here:");
       throw MaCh3Exception(__FILE__ , __LINE__ );
     }
   };


### PR DESCRIPTION
MaCh3Factory.cpp throws with error when overwriting yaml settings for samples or systematics. Since this is sometimes a useful feature, e.g. for running manual step size tuning, I've updated the message to point to where in the file the throw is, so if anyone does want to use this feature they can work around it.

This isn't a particularly good fix, and we should probably implement something more proper that doesn't require modifying core code to use this functionality, but this should be helpful for now.


---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
