### PR TITLE
Feat: Acceptance Rate sanitizer

### DIFF
--- a/Fitters/MCMCBase.cpp
+++ b/Fitters/MCMCBase.cpp
@@ -174,6 +174,11 @@ void MCMCBase::CheckAcceptanceRates() {
 // *******************
     const auto StepEnd = stepStart + chainLength;
 
+    // Skip check for reallllly early steps
+    if(step - stepStart < std::min(10, StepEnd/10)) {
+        return;
+    }
+
     if(accCount==0 && step - stepStart > StepEnd/10) {
         MACH3LOG_ERROR("No steps were accepted in the MCMC chain after {} steps. Please check your  step sizes.", step - stepStart);
         throw MaCh3Exception(__FILE__, __LINE__);

--- a/Fitters/MCMCBase.cpp
+++ b/Fitters/MCMCBase.cpp
@@ -150,6 +150,7 @@ void MCMCBase::PrintProgress(bool StepsPrint) {
 // *******************
     if(StepsPrint) MACH3LOG_INFO("Step:\t{}/{}, current: {:.2f}, proposed: {:.2f}", step - stepStart, chainLength, logLCurr, logLProp);
     if(StepsPrint) MACH3LOG_INFO("Accepted/Total steps: {}/{} = {:.2f}", accCount, step - stepStart, static_cast<double>(accCount) / static_cast<double>(step - stepStart));
+    CheckAcceptanceRates();
 
     for (size_t i = 0; i < samples.size(); ++i) {
         samples[i]->PrintRates();
@@ -165,6 +166,24 @@ void MCMCBase::PrintProgress(bool StepsPrint) {
         debugFile << "Step:\t" << step + 1 << "/" << chainLength << "  |  current: " << logLCurr << " proposed: " << logLProp << std::endl;
     }
 #endif
+}
+
+// *******************
+// Handles warnings for low acceptance rates
+void MCMCBase::CheckAcceptanceRates() {
+// *******************
+    if(accCount==0 && step - stepStart > StepEnd/10) {
+        MACH3LOG_CRITICAL("No steps were accepted in the MCMC chain after {} steps. This is likely due to a very low acceptance rate.
+                            Please check your proposal distributions and step sizes.", step - stepStart);
+        throw MaCh3Exception(__FILE__, __LINE__);
+    }
+
+    double acc_rate = static_cast<double>(accCount) / static_cast<double>(step - stepStart);
+    if (acc_rate < 0.01) {
+        MACH3LOG_WARNING("Acceptance rate is very low: {:.2f}. This may indicate that the proposal distribution is not well-tuned. Consider adjusting the step sizes or proposal distributions.", acc_rate);
+    } else if (acc_rate > 0.5) {
+        MACH3LOG_WARNING("Acceptance rate is very high: {:.2f}. This may indicate that the proposal distribution is too narrow. Consider adjusting the step sizes or proposal distributions.", acc_rate);
+    }
 }
 
 // *******************

--- a/Fitters/MCMCBase.cpp
+++ b/Fitters/MCMCBase.cpp
@@ -118,6 +118,7 @@ void MCMCBase::PreStepProcess() {
     // Print 10 steps in total
     if ((step - stepStart) % (chainLength / 10) == 0)
     {
+        CheckAcceptanceRates();
         PrintProgress();
     }
 }
@@ -150,7 +151,6 @@ void MCMCBase::PrintProgress(bool StepsPrint) {
 // *******************
     if(StepsPrint) MACH3LOG_INFO("Step:\t{}/{}, current: {:.2f}, proposed: {:.2f}", step - stepStart, chainLength, logLCurr, logLProp);
     if(StepsPrint) MACH3LOG_INFO("Accepted/Total steps: {}/{} = {:.2f}", accCount, step - stepStart, static_cast<double>(accCount) / static_cast<double>(step - stepStart));
-    CheckAcceptanceRates();
 
     for (size_t i = 0; i < samples.size(); ++i) {
         samples[i]->PrintRates();

--- a/Fitters/MCMCBase.cpp
+++ b/Fitters/MCMCBase.cpp
@@ -175,7 +175,7 @@ void MCMCBase::CheckAcceptanceRates() {
     const auto StepEnd = stepStart + chainLength;
 
     // Skip check for reallllly early steps
-    if(step - stepStart < std::min(10, StepEnd/10)) {
+    if(step - stepStart < std::min(10.0, static_cast<double>(StepEnd)/10)) {
         return;
     }
 

--- a/Fitters/MCMCBase.cpp
+++ b/Fitters/MCMCBase.cpp
@@ -172,17 +172,19 @@ void MCMCBase::PrintProgress(bool StepsPrint) {
 // Handles warnings for low acceptance rates
 void MCMCBase::CheckAcceptanceRates() {
 // *******************
+    const auto StepEnd = stepStart + chainLength;
+
     if(accCount==0 && step - stepStart > StepEnd/10) {
-        MACH3LOG_CRITICAL("No steps were accepted in the MCMC chain after {} steps. This is likely due to a very low acceptance rate.
-                            Please check your proposal distributions and step sizes.", step - stepStart);
+        MACH3LOG_ERROR("No steps were accepted in the MCMC chain after {} steps. Please check your  step sizes.", step - stepStart);
         throw MaCh3Exception(__FILE__, __LINE__);
     }
 
     double acc_rate = static_cast<double>(accCount) / static_cast<double>(step - stepStart);
+
     if (acc_rate < 0.01) {
-        MACH3LOG_WARNING("Acceptance rate is very low: {:.2f}. This may indicate that the proposal distribution is not well-tuned. Consider adjusting the step sizes or proposal distributions.", acc_rate);
+        MACH3LOG_WARN("Acceptance rate is very low: {:.4f}. This may indicate that the proposal distribution is not well-tuned. Consider reducing the step size.", acc_rate);
     } else if (acc_rate > 0.5) {
-        MACH3LOG_WARNING("Acceptance rate is very high: {:.2f}. This may indicate that the proposal distribution is too narrow. Consider adjusting the step sizes or proposal distributions.", acc_rate);
+        MACH3LOG_WARN("Acceptance rate is very high: {:.4f}. This may indicate that the proposal distribution is too narrow. Consider increasing the step sizes.", acc_rate);
     }
 }
 

--- a/Fitters/MCMCBase.h
+++ b/Fitters/MCMCBase.h
@@ -57,6 +57,9 @@ class MCMCBase : public FitterBase {
     /// @param StepsPrint whether to print info about accepted steps and -LogL
     void PrintProgress(const bool StepsPrint = true);
 
+    /// @brief Check the acceptance rates
+    void CheckAcceptanceRates();
+
     /// multicanonical handler for umbrella sampling    
     std::unique_ptr<MulticanonicalMCMCHandler> multicanonicalHandler;
 


### PR DESCRIPTION
# Pull request description
Add small sanitiser to MCMCBase in the event of too low/high step acceptance. Throws error if no steps have been accepted for <1/10 of the chain's length

Targets recurring "ROOT Buffer" not filled issue that's confused several students and due to an acceptance rate of 0.

## Changes or fixes
* Adds sanitiser

## Examples
```
With 100x “optimal” step scale we get
[MCMCBase.cpp][error] No steps were accepted in the MCMC chain after 200 steps. Please check your  step sizes.
[error] Find me here: MCMCBase.cpp::184with 10x “optimal” we get
[MCMCBase.cpp][warning] Acceptance rate is very low: 0.0088. This may indicate that the proposal distribution is not well-tuned. Consider reducing the step size.with 0.1x we get
[MCMCBase.cpp][warning] Acceptance rate is very high: 0.5040. This may indicate that the proposal distribution is too narrow. Consider increasing the step sizes.
```

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
