### PR TITLE
feat: UmbrellaSolver no longer hardcodes output format

### DIFF
--- a/Diagnostics/RHat.cpp
+++ b/Diagnostics/RHat.cpp
@@ -87,7 +87,6 @@ void CapVariable(double var, double cap);
 // *******************
 int main(int argc, char *argv[]) {
 // *******************
-
   SetMaCh3LoggerFormat();
   M3::Utils::MaCh3Welcome();
 

--- a/Diagnostics/UmbrellaSampling/UmbrellaPlotting.cpp
+++ b/Diagnostics/UmbrellaSampling/UmbrellaPlotting.cpp
@@ -1912,6 +1912,7 @@ void UmbrellaPlotting(std::string InputFile,
 
 // Main function for compiled version
 int main(int argc, char *argv[]) {
+    SetMaCh3LoggerFormat();
     std::string InputFile = argv[1];
     std::string outputDir = argv[2];
 

--- a/Diagnostics/UmbrellaSampling/UmbrellaSolver.cpp
+++ b/Diagnostics/UmbrellaSampling/UmbrellaSolver.cpp
@@ -68,9 +68,9 @@ UmbrellaConfig parseYAMLConfig(const std::string &filename) {
         const YAML::Node &windows = yaml_config["windows"];
         for (size_t i = 0; i < windows.size(); i++) {
           WindowConfig window;
-          window.name = windows[i]["name"].as<std::string>();
-          window.center = windows[i]["center"].as<double>();
-          window.width = windows[i]["width"].as<double>();
+          window.name = Get<std::string>(windows[i]["name"], __FILE__, __LINE__);
+          window.center = Get<double>(windows[i]["center"], __FILE__, __LINE__);
+          window.width = Get<double>(windows[i]["width"], __FILE__, __LINE__);
           config.windows.push_back(window);
         }
       }
@@ -79,7 +79,7 @@ UmbrellaConfig parseYAMLConfig(const std::string &filename) {
       if (yaml_config["input_files"]) {
         const YAML::Node &input_files = yaml_config["input_files"];
         for (size_t i = 0; i < input_files.size() && i < config.windows.size(); i++) {
-          config.windows[i].input_file = input_files[i].as<std::string>();
+          config.windows[i].input_file = Get<std::string>(input_files[i], __FILE__, __LINE__);
         }
       }
     } else {
@@ -564,8 +564,6 @@ void UmbrellaSolver(const std::string &config_file = "umbrella_config.yaml") {
   MACH3LOG_INFO("Debugging OpenMP availability...");
 
   #ifdef MULTITHREAD
-  MACH3LOG_INFO("_OPENMP is defined with value: {}", _OPENMP);
-  MACH3LOG_INFO("OpenMP version: {}", _OPENMP);
   MACH3LOG_INFO("Max threads available: {}", omp_get_max_threads());
   #else
   MACH3LOG_WARN("_OPENMP is NOT defined - OpenMP not available");
@@ -700,11 +698,11 @@ void UmbrellaSolver(const std::string &config_file = "umbrella_config.yaml") {
         YAML::Node umbrellaConfig =
             macro_yaml["General"]["MCMC"]["Multicanonical"];
         // Extract window parameters
-        config.windows[i].center = umbrellaConfig["Umbrella"]["UmbrellaMean"].as<double>();
+        config.windows[i].center = Get<double>(umbrellaConfig["Umbrella"]["UmbrellaMean"], __FILE__, __LINE__);
         MACH3LOG_INFO("Window {} center updated to {}", i, config.windows[i].center);
 
         // Check if using von Mises distribution
-        std::string biasString = umbrellaConfig["Umbrella"]["UmbrellaBiasFunction"].as<std::string>();
+        auto biasString = Get<std::string>(umbrellaConfig["Umbrella"]["UmbrellaBiasFunction"], __FILE__, __LINE__);
         M3::BiasFunction biasMode;
         if (biasString == "gaussian") {
           biasMode = M3::BiasFunction::kGaussian;
@@ -723,14 +721,14 @@ void UmbrellaSolver(const std::string &config_file = "umbrella_config.yaml") {
 
         if (config.windows[i].umbrellaBiasFunction == M3::BiasFunction::kVonMises) {
           // Extract von Mises sigma and compute kappa
-          double vonMises_sigma = umbrellaConfig["Umbrella"]["UmbrellaWidth"].as<double>();
+          double vonMises_sigma = Get<double>(umbrellaConfig["Umbrella"]["UmbrellaWidth"], __FILE__, __LINE__);
           config.windows[i].vonMises_kappa = 1.0 / (vonMises_sigma * vonMises_sigma);
           config.windows[i].width = vonMises_sigma; // Store sigma in width for reference
           MACH3LOG_INFO("Window {} using von Mises: sigma = {}, kappa = {}",
                         i, vonMises_sigma, config.windows[i].vonMises_kappa);
         } else {
           // Extract Gaussian sigma
-          config.windows[i].width = umbrellaConfig["Umbrella"]["UmbrellaWidth"].as<double>();
+          config.windows[i].width = Get<double>(umbrellaConfig["Umbrella"]["UmbrellaWidth"], __FILE__, __LINE__);
           config.windows[i].vonMises_kappa = -1.0; // Not using von Mises
           MACH3LOG_INFO("Window {} using Gaussian: width = {}", i, config.windows[i].width);
         }
@@ -1002,7 +1000,7 @@ void UmbrellaSolver(const std::string &config_file = "umbrella_config.yaml") {
             z_perturbed[i] = abs(z_perturbed[i]); // Ensure no negative values
         }
         z_current = z_perturbed;
-          MACH3LOG_INFO("\nApplied random perturbation to z values for robustness check.\n");
+          MACH3LOG_INFO("Applied random perturbation to z values for robustness check.");
       } else {
         if (checkConvergence(z_current, z_prev, config.tolerance)) {
           MACH3LOG_INFO("Convergence achieved at iteration {}", iteration);
@@ -1029,7 +1027,7 @@ void UmbrellaSolver(const std::string &config_file = "umbrella_config.yaml") {
   }
 
   std::ostringstream oss;
-  oss << "\nFinal z values: [";
+  oss << "Final z values: [";
   for (size_t i = 0; i < z_current.size(); i++) {
     oss << std::fixed << std::setprecision(5) << z_current[i];
     if (i < z_current.size() - 1)
@@ -1046,35 +1044,13 @@ void UmbrellaSolver(const std::string &config_file = "umbrella_config.yaml") {
   output_file->cd();
 
   // Create combined tree with weights
-  TTree *combined_tree = new TTree("posteriors", "Combined Posterior Distributions");
+  TTree* combined_tree = input_trees[0]->CloneTree(0);
 
   // Variables for the combined tree
-  double sin2th_12, sin2th_23, sin2th_13, delm2_12, delm2_23, delta_cp;
-  double baseline, density, LogL, accProb, stepTime;
-  int step;
-  std::vector<double> LogL_samples(6);
-  double LogL_systematic_osc_cov;
   double umbrella_weight;
   int window_id;
+  double delta_cp;
 
-  /// @todo: MAJOR make this generic so that we can use systematics aswell
-  /// Set up branches
-  combined_tree->Branch("sin2th_12", &sin2th_12, "sin2th_12/D");
-  combined_tree->Branch("sin2th_23", &sin2th_23, "sin2th_23/D");
-  combined_tree->Branch("sin2th_13", &sin2th_13, "sin2th_13/D");
-  combined_tree->Branch("delm2_12", &delm2_12, "delm2_12/D");
-  combined_tree->Branch("delm2_23", &delm2_23, "delm2_23/D");
-  combined_tree->Branch("delta_cp", &delta_cp, "delta_cp/D");
-  combined_tree->Branch("baseline", &baseline, "baseline/D");
-  combined_tree->Branch("density", &density, "density/D");
-  combined_tree->Branch("LogL", &LogL, "LogL/D");
-  combined_tree->Branch("accProb", &accProb, "accProb/D");
-  combined_tree->Branch("step", &step, "step/I");
-  combined_tree->Branch("stepTime", &stepTime, "stepTime/D");
-  for (int i = 0; i < 6; i++) { 
-    combined_tree->Branch(Form("LogL_sample_%d", i), &LogL_samples[i], Form("LogL_sample_%d/D", i));
-  }
-  combined_tree->Branch("LogL_systematic_osc_cov", &LogL_systematic_osc_cov, "LogL_systematic_osc_cov/D");
   combined_tree->Branch("umbrella_weight", &umbrella_weight, "umbrella_weight/D");
   combined_tree->Branch("window_id", &window_id, "window_id/I");
 
@@ -1082,29 +1058,19 @@ void UmbrellaSolver(const std::string &config_file = "umbrella_config.yaml") {
   for (size_t i = 0; i < input_trees.size(); i++) {
     TTree *tree = input_trees[i];
 
-    // Set branch addresses for reading
-    tree->SetBranchAddress("sin2th_12", &sin2th_12);
-    tree->SetBranchAddress("sin2th_23", &sin2th_23);
-    tree->SetBranchAddress("sin2th_13", &sin2th_13);
-    tree->SetBranchAddress("delm2_12", &delm2_12);
-    tree->SetBranchAddress("delm2_23", &delm2_23);
-    tree->SetBranchAddress("delta_cp", &delta_cp);
-    tree->SetBranchAddress("baseline", &baseline);
-    tree->SetBranchAddress("density", &density);
-    tree->SetBranchAddress("LogL", &LogL);
-    tree->SetBranchAddress("accProb", &accProb);
-    tree->SetBranchAddress("step", &step);
-    tree->SetBranchAddress("stepTime", &stepTime);
-    for (int j = 0; j < 6; j++) {
-      tree->SetBranchAddress(Form("LogL_sample_%d", j), &LogL_samples[j]);
-    }
-    tree->SetBranchAddress("LogL_systematic_osc_cov", &LogL_systematic_osc_cov);
-
     Long64_t nentries = tree->GetEntries();
+    // KS: This is to avoid warnings about missing umbrella branches...
+    int oldLevel = gErrorIgnoreLevel;
+    gErrorIgnoreLevel = kError;
+    combined_tree->CopyAddresses(tree);
+    gErrorIgnoreLevel = oldLevel;
+    /// @todo code now assumes it is only for delta CP
+    tree->SetBranchAddress("delta_cp", &delta_cp);
 
     if (z_current[i] == 0) {
       MACH3LOG_WARN("Z value for window {} is zero, skipping weighting for this window to avoid division by zero.", i);
     }
+    window_id = static_cast<int>(i);
 
     for (Long64_t entry = 0; entry < nentries; entry++) {
       tree->GetEntry(entry);
@@ -1113,16 +1079,16 @@ void UmbrellaSolver(const std::string &config_file = "umbrella_config.yaml") {
         umbrella_weight = 0.0; // If z is zero, we cannot apply the umbrella weight, so we set it to 0 (completely downweigh this window's contribution)
       } else {
         // Calculate umbrella weight for this event
-        // The umbrella weight corrects for the bias introduced by the window function Weight is 1 / sum of all window contributions (equation 4 from paper) 
+        // The umbrella weight corrects for the bias introduced by the window function Weight is 1 / sum of all window contributions (equation 4 from paper)
         double denominator = 1 / summedWindowsWeighted(delta_cp, config.windows, z_current);
 
         // umbrella_weight = z_current[i] / denominator; // with or without z_current[i] / denominator? why did I have this originally
         umbrella_weight = denominator; // This is the correct form based on the paper - the z_current[i] factor is already included in the summedWindowsWeighted function
+      }
 
-        if (combined_tree->Fill() < 0) {
-          MACH3LOG_WARN("Failed writing output tree. Check disk quota/space and write permissions for: {}", config.output_file);
-          throw MaCh3Exception(__FILE__, __LINE__);
-        }
+      if (combined_tree->Fill() < 0) {
+        MACH3LOG_WARN("Failed writing output tree. Check disk quota/space and write permissions for: {}", config.output_file);
+        throw MaCh3Exception(__FILE__, __LINE__);
       }
     }
   }
@@ -1204,6 +1170,7 @@ void UmbrellaSolver(const std::string &config_file = "umbrella_config.yaml") {
 
 // Main function for compiled version
 int main(int argc, char *argv[]) {
+  SetMaCh3LoggerFormat();
   std::string config_file = "umbrella_config.yaml";
   if (argc > 1) {
     config_file = argv[1];


### PR DESCRIPTION
# Pull request description
Umbrella Solver has been tuned using T2K/HK chains and older version and also only Osc.
Which means that output chain had hard-coded output. Now using ROOT magic output is no longer hard-coded and is simply copy of input one. 

## Examples
[valid.pdf](https://github.com/user-attachments/files/30043803/valid.pdf)

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
