### PR TITLE
tidy: Avoid contamination of headers

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,6 +10,7 @@ Plotting 📊:
       - any-glob-to-any-file: 
           - Plotting/**
           - Diagnostics/**
+          - CLI/**
 
 Parameters ⚙️:
   - changed-files:
@@ -32,6 +33,8 @@ Documentation 📚:
   - changed-files:
       - any-glob-to-any-file: 
           - Doc/**
+          - .mailmap
+
 Cmake 🛠️:
   - changed-files:
       - any-glob-to-any-file:

--- a/.mailmap
+++ b/.mailmap
@@ -14,6 +14,7 @@ Daniel Barrow <danbarrow257@gmail.com> Daniel Barrow <daniel.barrow@physics.ox.a
 David Riley <davidriley12345@gmail.com> driley <davidriley12345@gmail.com>
 David Riley <davidriley12345@gmail.com> daveriley <davidriley12345@gmail.com>
 David Riley <davidriley12345@gmail.com> daveriley <d.riley.1@research.gla.ac.uk>
+David Riley <davidriley12345@gmail.com> David Riley <d.riley.1@research.gla.ac.uk>
 
 # Kamil Skwarczynski
 Kamil Skwarczynski <skwarczynskikamil@gmail.com> Kamil <45295406+KSkwarczynski@users.noreply.github.com>

--- a/python/splines.h
+++ b/python/splines.h
@@ -12,11 +12,11 @@
 #include "Splines/UnbinnedSplineHandler.h"
 #include "Splines/SplineStructs.h"
 #include "Samples/SampleStructs.h" // <- The spline stuff that's in here should really be moved to splineStructs.h but I ain't doing that right now
+
+_MaCh3_Safe_Include_Start_ //{
 // ROOT includes
 #include "TSpline.h"
-
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#pragma GCC diagnostic ignored "-Wfloat-conversion"
+_MaCh3_Safe_Include_End_ //}
 
 namespace py = pybind11;
 


### PR DESCRIPTION
# Pull request description
We use pragma diagnostic to suppress warnings for a give code line or whole file.
Adding them to header file without start/end means we contaminate large part of codebase.

This is .py file so not huge problem, but fixing nevertheless.


---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
