### PR TITLE
feat: Logarithmic LLH Scan

### DIFF
--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -1,4 +1,7 @@
 #include "FitterBase.h"
+#include "TMath.h"
+#include <vector>
+#include <memory>
 
 _MaCh3_Safe_Include_Start_ //{
 #include "TRandom.h"
@@ -676,18 +679,24 @@ void FitterBase::RunLLHScan() {
       std::unique_ptr<TH1D> hScan;
       // See if we want to do it logarithmically
        if(LLHLogarithmic){
-	 
+
+	 //negative values break it
+	 if (lower <= 0.0 || upper <= 0.0) {
+	   MACH3LOG_WARN("Cannot perform logarithmic scan for {} "" with range [{}, {}], falling back to linear scan",name, lower, upper);
+	   hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, lower, upper);
+       }
+	 else {
 	 std::vector<double> binEdges(n_points + 1);
 
-	 double logLower = std::log10(lower);
-	 double logUpper = std::log10(upper);
+	 double logLower = TMath::Log10(lower);
+	 double logUpper = TMath::Log10(upper);
 
 	 for (int j = 0; j <= n_points; ++j) {
-	   binEdges[j] = std::pow( 10.0, logLower + (logUpper - logLower) * double(j) / double(n_points));
+	   binEdges[j] = TMath::Power(10.0, logLower + (logUpper - logLower) * double(j) / double(n_points));
 	 }
     hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, binEdges.data());
        }
-    
+    }
        //If not then just do the normal thing  
       else {
     hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, lower, upper);

--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -601,7 +601,24 @@ void FitterBase::GetParameterScanRange(const ParameterHandlerBase* cov, const in
   MACH3LOG_INFO("Scanning {} {} with {} steps, from [{:.2f} , {:.2f}], CV = {:.2f}", suffix, name, n_points, lower, upper, CentralValue);
 }
 
+
+// *************************                                                                      
+// Calculate bin edges for logarithmic LLH scans
 // *************************
+std::vector<double>FitterBase::CalculateBinEdges(double lowerlimit, double upperlimit, int n_points) const {
+     std::vector<double> binEdges(n_points + 1);
+
+     double logLower = TMath::Log10(lowerlimit);
+     double logUpper = TMath::Log10(upperlimit);
+
+     for (int j = 0; j <= n_points; ++j) {
+       binEdges[j] = TMath::Power(10.0, logLower + (logUpper - logLower) * double(j) / double(n_points));
+     }
+	 
+   return binEdges;
+  
+}
+
 
 // Run LLH scan
 void FitterBase::RunLLHScan() {
@@ -686,17 +703,10 @@ void FitterBase::RunLLHScan() {
 	   hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, lower, upper);
        }
 	 else {
-	 std::vector<double> binEdges(n_points + 1);
-
-	 double logLower = TMath::Log10(lower);
-	 double logUpper = TMath::Log10(upper);
-
-	 for (int j = 0; j <= n_points; ++j) {
-	   binEdges[j] = TMath::Power(10.0, logLower + (logUpper - logLower) * double(j) / double(n_points));
+	  auto binEdges = CalculateBinEdges(lower, upper, n_points);
+	  hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, binEdges.data());
 	 }
-    hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, binEdges.data());
        }
-    }
        //If not then just do the normal thing  
       else {
     hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, lower, upper);
@@ -992,8 +1002,8 @@ void FitterBase::Run2DLLHScan() {
       if (IsPCA) name_x += "_PCA";
       // Get the parameter central and bounds
       double central_x, lower_x, upper_x;
-      std::vector<double> binEdges_x;
       GetParameterScanRange(cov, i, central_x, lower_x, upper_x, n_points, "X");
+      std::vector<double> binEdges_x;
        
       //Logarithmic scan 
       if(LLHLogarithmic){
@@ -1003,13 +1013,7 @@ void FitterBase::Run2DLLHScan() {
 	}
 
 	else{
-	 binEdges_x.resize(n_points + 1);
-
-         double logLower_x = TMath::Log10(lower_x);
-         double logUpper_x = TMath::Log10(upper_x);
-	 for (int k = 0; k <= n_points; ++k) {
-	   binEdges_x[k] = TMath::Power(10.0, logLower_x + (logUpper_x - logLower_x) * double(k) / double(n_points));
-	 }
+	binEdges_x = CalculateBinEdges(lower_x, upper_x, n_points);
 	}
 
       }
@@ -1041,15 +1045,7 @@ void FitterBase::Run2DLLHScan() {
 	   hScanSam->GetZaxis()->SetTitle("2LLH_sam");
        }
 	 else {
-	   
-	 std::vector<double> binEdges_y(n_points + 1);
-	 
-	 double logLower_y = TMath::Log10(lower_y);
-         double logUpper_y = TMath::Log10(upper_y);
-
-	 for (int l = 0; l <= n_points; ++l) {
-	   binEdges_y[l] = TMath::Power(10.0, logLower_y + (logUpper_y - logLower_y) * double(l) / double(n_points));
-	 }
+	 auto binEdges_y = CalculateBinEdges(lower_y, upper_y, n_points);
 	 hScanSam = std::make_unique<TH2D>((name_x + "_" + name_y + "_sam").c_str(), (name_x + "_" + name_y + "_sam").c_str(), n_points, binEdges_x.data(), n_points, binEdges_y.data());
        }
     }

--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -599,6 +599,7 @@ void FitterBase::GetParameterScanRange(const ParameterHandlerBase* cov, const in
 }
 
 // *************************
+
 // Run LLH scan
 void FitterBase::RunLLHScan() {
 // *************************
@@ -610,7 +611,9 @@ void FitterBase::RunLLHScan() {
   //KS: Turn it on if you want LLH scan for each ND sample separately, which increase time significantly but can be useful for validating new samples or dials.
   bool PlotLLHScanBySample = GetFromManager<bool>(fitMan->raw()["LLHScan"]["LLHScanBySample"], false, __FILE__ , __LINE__);
   auto SkipVector = GetFromManager<std::vector<std::string>>(fitMan->raw()["LLHScan"]["LLHScanSkipVector"], {}, __FILE__ , __LINE__);
-
+  //Do we want a logarithmic LLH scan                                    
+  bool LLHLogarithmic = GetFromManager<bool>(fitMan->raw()["LLHScan"]["LLHLogarithmic"], false, __FILE__ , __LINE__);
+  
   // Now finally get onto the LLH scan stuff
   // Very similar code to MCMC but never start MCMC; just scan over the parameter space
   std::vector<TDirectory *> Cov_LLH(systematics.size());
@@ -669,8 +672,27 @@ void FitterBase::RunLLHScan() {
       // Get the parameter central and bounds
       double CentralValue, lower, upper;
       GetParameterScanRange(cov, i, CentralValue, lower, upper, n_points);
-      // Make the TH1D
-      auto hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, lower, upper);
+      // Define the TH1D 
+      std::unique_ptr<TH1D> hScan;
+      // See if we want to do it logarithmically
+       if(LLHLogarithmic){
+	 
+	 std::vector<double> binEdges(n_points + 1);
+
+	 double logLower = std::log10(lower);
+	 double logUpper = std::log10(upper);
+
+	 for (int j = 0; j <= n_points; ++j) {
+	   binEdges[j] = std::pow( 10.0, logLower + (logUpper - logLower) * double(j) / double(n_points));
+	 }
+    hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, binEdges.data());
+       }
+    
+       //If not then just do the normal thing  
+      else {
+    hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, lower, upper);
+       }
+       
       hScan->SetTitle((std::string("2LLH_full, ") + name + ";" + name + "; -2(ln L_{sample} + ln L_{xsec+flux} + ln L_{det})").c_str());
       hScan->SetDirectory(nullptr);
 
@@ -718,8 +740,9 @@ void FitterBase::RunLLHScan() {
           }
         }
       }
-
+      
       // Scan over the parameter space
+       
       for (int j = 0; j < n_points; ++j)
       {
         if (j % countwidth == 0)

--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -681,7 +681,7 @@ void FitterBase::RunLLHScan() {
        if(LLHLogarithmic){
 
 	 //negative values break it
-	 if (lower <= 0.0 || upper <= 0.0) {
+	 if (lower < 0.0 || upper < 0.0) {
 	   MACH3LOG_WARN("Cannot perform logarithmic scan for {} "" with range [{}, {}], falling back to linear scan",name, lower, upper);
 	   hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, lower, upper);
        }
@@ -968,7 +968,10 @@ void FitterBase::Run2DLLHScan() {
 
   TDirectory *Sample_2DLLH = outputFile->mkdir("Sample_2DLLH");
   auto SkipVector = GetFromManager<std::vector<std::string>>(fitMan->raw()["LLHScan"]["LLHScanSkipVector"], {}, __FILE__ , __LINE__);;
-
+  
+  //Do we want a logarithmic LLH scan                                    
+  bool LLHLogarithmic = GetFromManager<bool>(fitMan->raw()["LLHScan"]["LLHLogarithmic"], false, __FILE__ , __LINE__);
+  
   // Number of points we do for each LLH scan
   const int n_points = GetFromManager<int>(fitMan->raw()["LLHScan"]["2DLLHScanPoints"], 20, __FILE__ , __LINE__);
   // We print 5 reweights
@@ -989,11 +992,31 @@ void FitterBase::Run2DLLHScan() {
       if (IsPCA) name_x += "_PCA";
       // Get the parameter central and bounds
       double central_x, lower_x, upper_x;
+      std::vector<double> binEdges_x;
       GetParameterScanRange(cov, i, central_x, lower_x, upper_x, n_points, "X");
+       
+      //Logarithmic scan 
+      if(LLHLogarithmic){
 
+	if (lower_x < 0.0 || upper_x < 0.0){
+	  MACH3LOG_WARN("Cannot perform logarithmic scan for {} and {} "" with range [{}, {}], [{}, {}], falling back to linear scan", name_x, lower_x, upper_x);
+	}
+
+	else{
+	 binEdges_x.resize(n_points + 1);
+
+         double logLower_x = TMath::Log10(lower_x);
+         double logUpper_x = TMath::Log10(upper_x);
+	 for (int k = 0; k <= n_points; ++k) {
+	   binEdges_x[k] = TMath::Power(10.0, logLower_x + (logUpper_x - logLower_x) * double(k) / double(n_points));
+	 }
+	}
+
+      }
+      
       // KS: Check if we want to skip this parameter
       if(CheckSkipParameter(SkipVector, name_x)) continue;
-
+            
       for (int j = 0; j < i; ++j)
       {
         std::string name_y = cov->GetParFancyName(j);
@@ -1001,17 +1024,45 @@ void FitterBase::Run2DLLHScan() {
         // KS: Check if we want to skip this parameter
         if(CheckSkipParameter(SkipVector, name_y)) continue;
 
+	 std::unique_ptr<TH2D> hScanSam;
+	 
         // Get the parameter central and bounds
         double central_y, lower_y, upper_y;
         GetParameterScanRange(cov, j, central_y, lower_y, upper_y, n_points, "Y");
+	if(LLHLogarithmic){
 
-        auto hScanSam = std::make_unique<TH2D>((name_x + "_" + name_y + "_sam").c_str(), (name_x + "_" + name_y + "_sam").c_str(),
-                                                n_points, lower_x, upper_x, n_points, lower_y, upper_y);
+	 //negative values break it
+	 if (lower_x < 0.0 || upper_x < 0.0 || lower_y < 0.0 || upper_y < 0.0 ) {
+	   MACH3LOG_WARN("Cannot perform logarithmic scan for {} and {} "" with range [{}, {}], [{}, {}], falling back to linear scan", name_x, lower_x, upper_x, name_y, lower_y, upper_y);
+	  hScanSam = std::make_unique<TH2D>((name_x + "_" + name_y + "_sam").c_str(), (name_x + "_" + name_y + "_sam").c_str(), n_points, lower_x, upper_x, n_points, lower_y, upper_y);
+	   hScanSam->SetDirectory(nullptr);
+	   hScanSam->GetXaxis()->SetTitle(name_x.c_str());
+	   hScanSam->GetYaxis()->SetTitle(name_y.c_str());
+	   hScanSam->GetZaxis()->SetTitle("2LLH_sam");
+       }
+	 else {
+	   
+	 std::vector<double> binEdges_y(n_points + 1);
+	 
+	 double logLower_y = TMath::Log10(lower_y);
+         double logUpper_y = TMath::Log10(upper_y);
+
+	 for (int l = 0; l <= n_points; ++l) {
+	   binEdges_y[l] = TMath::Power(10.0, logLower_y + (logUpper_y - logLower_y) * double(l) / double(n_points));
+	 }
+	 hScanSam = std::make_unique<TH2D>((name_x + "_" + name_y + "_sam").c_str(), (name_x + "_" + name_y + "_sam").c_str(), n_points, binEdges_x.data(), n_points, binEdges_y.data());
+       }
+    }
+       //If not then just do the normal thing  
+      else {
+
+        hScanSam = std::make_unique<TH2D>((name_x + "_" + name_y + "_sam").c_str(), (name_x + "_" + name_y + "_sam").c_str(), n_points, lower_x, upper_x, n_points, lower_y, upper_y);
         hScanSam->SetDirectory(nullptr);
         hScanSam->GetXaxis()->SetTitle(name_x.c_str());
         hScanSam->GetYaxis()->SetTitle(name_y.c_str());
         hScanSam->GetZaxis()->SetTitle("2LLH_sam");
-
+      }
+	 
         // Scan over the parameter space
         for (int x = 0; x < n_points; ++x)
         {

--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -1,5 +1,4 @@
 #include "FitterBase.h"
-#include "TMath.h"
 #include <vector>
 #include <memory>
 
@@ -8,6 +7,7 @@ _MaCh3_Safe_Include_Start_ //{
 #include "TStopwatch.h"
 #include "TTree.h"
 #include "TGraphAsymmErrors.h"
+#include "TMath.h"
 _MaCh3_Safe_Include_End_ //}
 
 #pragma GCC diagnostic ignored "-Wuseless-cast"
@@ -1009,7 +1009,7 @@ void FitterBase::Run2DLLHScan() {
       if(LLHLogarithmic){
 
 	if (lower_x < 0.0 || upper_x < 0.0){
-	  MACH3LOG_WARN("Cannot perform logarithmic scan for {} and {} "" with range [{}, {}], [{}, {}], falling back to linear scan", name_x, lower_x, upper_x);
+	  MACH3LOG_WARN("Cannot perform logarithmic scan for {} "" with range [{}, {}], falling back to linear scan", name_x, lower_x, upper_x);
 	}
 
 	else{

--- a/Fitters/FitterBase.h
+++ b/Fitters/FitterBase.h
@@ -48,7 +48,7 @@ class FitterBase {
   /// @brief Calculates the required time for each sample or covariance object in a drag race simulation. Inspired by Dan's feature
   /// @param NLaps number of laps, every part of Fitter will be tested with given number of laps and you will get total and average time
   void DragRace(const int NLaps = 100);
-
+  
   /// @brief Perform a 1D likelihood scan.
   void RunLLHScan();
 
@@ -99,6 +99,7 @@ class FitterBase {
   /// @brief KS: Check whether we want to skip parameter using skip vector
   bool CheckSkipParameter(const std::vector<std::string>& SkipVector, const std::string& ParamName) const;
 
+  
   /// @brief For comparison with other fitting frameworks (like P-Theta) we usually have to apply different parameter values then usual 1, 3 sigma
   ///
   /// Example YAML format:
@@ -109,6 +110,9 @@ class FitterBase {
   /// @endcode
   void CustomRange(const std::string& ParName, const double sigma, double& ParamShiftValue) const;
 
+  //Bin edges needed for logarithmic LLH scans
+  std::vector<double> CalculateBinEdges(double lowerlimit,double upperlimit, int n_points) const;
+  
   /// The manager for configuration handling
   Manager *fitMan;
 


### PR DESCRIPTION
# Pull request description
Adds a feature to FitterBase that allows users to run an LLH scan using a logarithmic scale, which is especially useful for exotics analyses such as sterile neutrino fits. 

## Changes or fixes
`FitterBase::CalculateBinEdges` calculates logarithmic scale points using the scan ranges defined in a yaml. These are then used in `RunLLHScan` and `Run2DLLHScan` if an option `LLHLogarithmic` is set to true in a yaml. This option is default set to false since I anticipate most people won’t need this feature. If the scan range includes negative values or zero the code just defaults back to a normal LLH scan.

## Examples
[LogLLHExample.pdf](https://github.com/user-attachments/files/30421039/LogLLHExample.pdf)

These are LLH scans made using tutorial for Norm_param_0 (scan range [0.1, 2], generated value 1) and baseline ([1, 300], generated value 295) using both non-log and log scales. 


---

- [X] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
