### PR TITLE
feat: add meta data for umbrella solver output

### DIFF
--- a/Diagnostics/UmbrellaSampling/UmbrellaSolver.cpp
+++ b/Diagnostics/UmbrellaSampling/UmbrellaSolver.cpp
@@ -513,7 +513,7 @@ bool checkConvergenceStalled(const std::vector<double> &z_current, const std::ve
 }
 
 // Main function to run the umbrella sampling solver
-void UmbrellaSolver(const std::string &config_file = "umbrella_config.yaml") {
+void UmbrellaSolver(const std::string &config_file) {
   MACH3LOG_INFO("=== Umbrella Sampling Z-Factor Solver ===");
   // Debug OpenMP status first
   MACH3LOG_INFO("Debugging OpenMP availability...");
@@ -1109,6 +1109,15 @@ void UmbrellaSolver(const std::string &config_file = "umbrella_config.yaml") {
   Long64_t total_entries = combined_tree->GetEntries();
 
   output_file->cd();
+
+  YAML::Node yaml_config = M3OpenConfig(config_file);
+  YAML::Node umbrella_config;
+  umbrella_config["UmbrellaSolver"] = yaml_config["UmbrellaSolver"];
+
+  // Convert YAML -> TMacro
+  TMacro UmbrellaHeader = YAMLtoTMacro(umbrella_config, "Umbrella_Config");
+  UmbrellaHeader.Write();
+
   output_file->Close();
 
   // Close input files

--- a/Fitters/FitterBase.cpp
+++ b/Fitters/FitterBase.cpp
@@ -601,25 +601,23 @@ void FitterBase::GetParameterScanRange(const ParameterHandlerBase* cov, const in
   MACH3LOG_INFO("Scanning {} {} with {} steps, from [{:.2f} , {:.2f}], CV = {:.2f}", suffix, name, n_points, lower, upper, CentralValue);
 }
 
-
 // *************************                                                                      
 // Calculate bin edges for logarithmic LLH scans
-// *************************
 std::vector<double>FitterBase::CalculateBinEdges(double lowerlimit, double upperlimit, int n_points) const {
-     std::vector<double> binEdges(n_points + 1);
+// *************************
+  std::vector<double> binEdges(n_points + 1);
 
-     double logLower = TMath::Log10(lowerlimit);
-     double logUpper = TMath::Log10(upperlimit);
+  double logLower = std::log10(lowerlimit);
+  double logUpper = std::log10(upperlimit);
 
-     for (int j = 0; j <= n_points; ++j) {
-       binEdges[j] = TMath::Power(10.0, logLower + (logUpper - logLower) * double(j) / double(n_points));
-     }
-	 
-   return binEdges;
-  
+  for (int j = 0; j <= n_points; ++j) {
+    binEdges[j] = std::pow(10.0, logLower + (logUpper - logLower) * double(j) / double(n_points));
+  }
+
+  return binEdges;
 }
 
-
+// *************************
 // Run LLH scan
 void FitterBase::RunLLHScan() {
 // *************************
@@ -695,22 +693,20 @@ void FitterBase::RunLLHScan() {
       // Define the TH1D 
       std::unique_ptr<TH1D> hScan;
       // See if we want to do it logarithmically
-       if(LLHLogarithmic){
-
-	 //negative values break it
-	 if (lower < 0.0 || upper < 0.0) {
-	   MACH3LOG_WARN("Cannot perform logarithmic scan for {} "" with range [{}, {}], falling back to linear scan",name, lower, upper);
-	   hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, lower, upper);
-       }
-	 else {
-	  auto binEdges = CalculateBinEdges(lower, upper, n_points);
-	  hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, binEdges.data());
-	 }
-       }
-       //If not then just do the normal thing  
+      if(LLHLogarithmic){
+        //negative values break it
+        if (lower < 0.0 || upper < 0.0) {
+          MACH3LOG_WARN("Cannot perform logarithmic scan for {} "" with range [{}, {}], falling back to linear scan",name, lower, upper);
+          hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, lower, upper);
+        } else {
+          auto binEdges = CalculateBinEdges(lower, upper, n_points);
+          hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, binEdges.data());
+        }
+      }
+      //If not then just do the normal thing
       else {
-    hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, lower, upper);
-       }
+        hScan = std::make_unique<TH1D>((name + "_full").c_str(), (name + "_full").c_str(), n_points, lower, upper);
+      }
        
       hScan->SetTitle((std::string("2LLH_full, ") + name + ";" + name + "; -2(ln L_{sample} + ln L_{xsec+flux} + ln L_{det})").c_str());
       hScan->SetDirectory(nullptr);
@@ -1007,17 +1003,12 @@ void FitterBase::Run2DLLHScan() {
        
       //Logarithmic scan 
       if(LLHLogarithmic){
-
-	if (lower_x < 0.0 || upper_x < 0.0){
-	  MACH3LOG_WARN("Cannot perform logarithmic scan for {} "" with range [{}, {}], falling back to linear scan", name_x, lower_x, upper_x);
-	}
-
-	else{
-	binEdges_x = CalculateBinEdges(lower_x, upper_x, n_points);
-	}
-
+        if (lower_x < 0.0 || upper_x < 0.0){
+          MACH3LOG_WARN("Cannot perform logarithmic scan for {} "" with range [{}, {}], falling back to linear scan", name_x, lower_x, upper_x);
+        } else {
+          binEdges_x = CalculateBinEdges(lower_x, upper_x, n_points);
+        }
       }
-      
       // KS: Check if we want to skip this parameter
       if(CheckSkipParameter(SkipVector, name_x)) continue;
             
@@ -1028,37 +1019,33 @@ void FitterBase::Run2DLLHScan() {
         // KS: Check if we want to skip this parameter
         if(CheckSkipParameter(SkipVector, name_y)) continue;
 
-	 std::unique_ptr<TH2D> hScanSam;
-	 
+        std::unique_ptr<TH2D> hScanSam;
         // Get the parameter central and bounds
         double central_y, lower_y, upper_y;
         GetParameterScanRange(cov, j, central_y, lower_y, upper_y, n_points, "Y");
-	if(LLHLogarithmic){
+        if(LLHLogarithmic){
+          //negative values break it
+          if (lower_x < 0.0 || upper_x < 0.0 || lower_y < 0.0 || upper_y < 0.0 ) {
+            MACH3LOG_WARN("Cannot perform logarithmic scan for {} and {} "" with range [{}, {}], [{}, {}], falling back to linear scan", name_x, lower_x, upper_x, name_y, lower_y, upper_y);
+            hScanSam = std::make_unique<TH2D>((name_x + "_" + name_y + "_sam").c_str(), (name_x + "_" + name_y + "_sam").c_str(), n_points, lower_x, upper_x, n_points, lower_y, upper_y);
+            hScanSam->SetDirectory(nullptr);
+            hScanSam->GetXaxis()->SetTitle(name_x.c_str());
+            hScanSam->GetYaxis()->SetTitle(name_y.c_str());
+            hScanSam->GetZaxis()->SetTitle("2LLH_sam");
+          } else {
+            auto binEdges_y = CalculateBinEdges(lower_y, upper_y, n_points);
+            hScanSam = std::make_unique<TH2D>((name_x + "_" + name_y + "_sam").c_str(), (name_x + "_" + name_y + "_sam").c_str(), n_points, binEdges_x.data(), n_points, binEdges_y.data());
+          }
+        }
+        //If not then just do the normal thing
+        else {
+          hScanSam = std::make_unique<TH2D>((name_x + "_" + name_y + "_sam").c_str(), (name_x + "_" + name_y + "_sam").c_str(), n_points, lower_x, upper_x, n_points, lower_y, upper_y);
+          hScanSam->SetDirectory(nullptr);
+          hScanSam->GetXaxis()->SetTitle(name_x.c_str());
+          hScanSam->GetYaxis()->SetTitle(name_y.c_str());
+          hScanSam->GetZaxis()->SetTitle("2LLH_sam");
+        }
 
-	 //negative values break it
-	 if (lower_x < 0.0 || upper_x < 0.0 || lower_y < 0.0 || upper_y < 0.0 ) {
-	   MACH3LOG_WARN("Cannot perform logarithmic scan for {} and {} "" with range [{}, {}], [{}, {}], falling back to linear scan", name_x, lower_x, upper_x, name_y, lower_y, upper_y);
-	  hScanSam = std::make_unique<TH2D>((name_x + "_" + name_y + "_sam").c_str(), (name_x + "_" + name_y + "_sam").c_str(), n_points, lower_x, upper_x, n_points, lower_y, upper_y);
-	   hScanSam->SetDirectory(nullptr);
-	   hScanSam->GetXaxis()->SetTitle(name_x.c_str());
-	   hScanSam->GetYaxis()->SetTitle(name_y.c_str());
-	   hScanSam->GetZaxis()->SetTitle("2LLH_sam");
-       }
-	 else {
-	 auto binEdges_y = CalculateBinEdges(lower_y, upper_y, n_points);
-	 hScanSam = std::make_unique<TH2D>((name_x + "_" + name_y + "_sam").c_str(), (name_x + "_" + name_y + "_sam").c_str(), n_points, binEdges_x.data(), n_points, binEdges_y.data());
-       }
-    }
-       //If not then just do the normal thing  
-      else {
-
-        hScanSam = std::make_unique<TH2D>((name_x + "_" + name_y + "_sam").c_str(), (name_x + "_" + name_y + "_sam").c_str(), n_points, lower_x, upper_x, n_points, lower_y, upper_y);
-        hScanSam->SetDirectory(nullptr);
-        hScanSam->GetXaxis()->SetTitle(name_x.c_str());
-        hScanSam->GetYaxis()->SetTitle(name_y.c_str());
-        hScanSam->GetZaxis()->SetTitle("2LLH_sam");
-      }
-	 
         // Scan over the parameter space
         for (int x = 0; x < n_points; ++x)
         {

--- a/Fitters/MulticanonicalMCMCHandler.cpp
+++ b/Fitters/MulticanonicalMCMCHandler.cpp
@@ -102,7 +102,7 @@ void MulticanonicalMCMCHandler::InitializeMulticanonicalHandlerConfig(Manager* f
 
   // Get the multicanonical beta value from the configuration file
   // This acts as a global bias strength factor
-  multicanonicalBeta = mcmcConfig["Multicanonical"]["Beta"].as<double>();
+  multicanonicalBeta = Get<double>(mcmcConfig["Multicanonical"]["Beta"],  __FILE__, __LINE__);
   MACH3LOG_INFO("Setting multicanonical beta to {}", multicanonicalBeta);
 
   /// @todo DR: I realised this will fail if you set spline to true but don't
@@ -134,7 +134,6 @@ void MulticanonicalMCMCHandler::InitializeMulticanonicalHandlerConfig(Manager* f
   // setup for spline bias mode
   if (multicanonicalSpline) {
     auto splineFileName = Get<std::string>(mcmcConfig["Multicanonical"]["Spline"]["SplineFile"], __FILE__, __LINE__);
-
     TFile* splineFile = M3::Open(splineFileName.c_str(), "READ",__FILE__, __LINE__);
 
     // grab the splines and do a quick check that they are evaluatable


### PR DESCRIPTION
# Pull request description
Add umbrella solver config to output.
This allows to diagnose setting in finished job.
Highly relevant as in future we hopefully will pass it similarly as reweighted chains.

## Changes or fixes
- Fix indentation in fitter base
- replace TMath with STL

## Examples
<img width="964" height="407" alt="image" src="https://github.com/user-attachments/assets/605b6403-39a3-456f-9a46-ee97d64dc844" />

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
