### PR TITLE
feat: Adding shell  tab completion

### DIFF
--- a/CLI/API/m3argparse.hpp
+++ b/CLI/API/m3argparse.hpp
@@ -45,5 +45,23 @@ namespace M3 {
                 }
                 return (*this);
             }
+
+            /// @brief Return all long option names (--xxx) registered with this parser
+            std::vector<std::string> get_long_option_names() const {
+                std::vector<std::string> names;
+                for (const auto& [name, _] : this->m_argument_map) {
+                    if (name.size() >= 2 && name[0] == '-' && name[1] == '-')
+                        names.push_back(name);
+                }
+                return names;
+            }
+
+            /// @brief Return true if the named option expects a value (not a flag)
+            bool option_takes_value(const std::string& name) const {
+                auto it = this->m_argument_map.find(name);
+                if (it == this->m_argument_map.end()) return false;
+                // get_usage_full() appends a metavar when max nargs > 0
+                return it->second->get_usage_full().find(' ') != std::string::npos;
+            }
     };
 }

--- a/CLI/MaCh3Program.cpp
+++ b/CLI/MaCh3Program.cpp
@@ -49,28 +49,96 @@ namespace M3{
             return;
         }
 
+        // Resolve the absolute path of this binary so the completion script
+        // works even when mach3 is not on PATH.
+        std::string binary_path = "mach3";
+        try {
+            binary_path = fs::read_symlink("/proc/self/exe").string();
+        } catch (...) {}
+
+        // Replace the generic "mach3" invocation in the template with the
+        // absolute binary path so the script is self-contained.
+        auto embed_path = [&](std::string_view tmpl) -> std::string {
+            std::string s(tmpl);
+            const std::string placeholder = "mach3 --complete";
+            const std::string replacement = binary_path + " --complete";
+            for (std::size_t pos = s.find(placeholder); pos != std::string::npos;
+                 pos = s.find(placeholder, pos + replacement.size()))
+                s.replace(pos, placeholder.size(), replacement);
+            return s;
+        };
+
         fs::path home_path(home);
 
         if (shell == "bash") {
             fs::path path = home_path / ".local/share/bash-completion/completions/mach3";
-            if (write_file(path, MaCh3Program::BASH_COMPLETION))
+            if (write_file(path, embed_path(MaCh3Program::BASH_COMPLETION)))
                 std::cout << "Installed bash completions → " << path << "\n";
             return;
         }
 
         if (shell == "zsh") {
             fs::path path = home_path / ".local/share/zsh/site-functions/_mach3";
-            if (write_file(path, MaCh3Program::ZSH_COMPLETION))
+            if (write_file(path, embed_path(MaCh3Program::ZSH_COMPLETION)))
                 std::cout << "Installed zsh completions → " << path << "\n";
             return;
         }
     }
-                
-    void MaCh3Program::completions(const std::string& prefix) const{
-        for (const std::string& cmd : m_subcommands) {
-            if (cmd.rfind(prefix, 0) == 0)
-                std::cout << cmd << "\n";
+
+    void MaCh3Program::completions(const std::string& prefix, const std::vector<std::string>& context) const {
+        // Find the active subcommand from previously typed context words
+        std::string active_subcommand;
+        for (const auto& word : context) {
+            for (const auto& sub : m_subcommands) {
+                if (word == sub) {
+                    active_subcommand = sub;
+                    break;
+                }
+            }
+            if (!active_subcommand.empty()) break;
         }
+
+        if (active_subcommand.empty()) {
+            // No subcommand typed yet — complete top-level subcommand names
+            for (const auto& cmd : m_subcommands) {
+                if (cmd.rfind(prefix, 0) == 0)
+                    std::cout << cmd << "\n";
+            }
+            return;
+        }
+
+        // Find the parser for the active subcommand
+        const MaCh3ArgumentParser* sub_parser = nullptr;
+        for (const auto& [parser, mod] : m_module_map) {
+            if (parser->name() == active_subcommand) { sub_parser = parser; break; }
+        }
+        if (!sub_parser) {
+            for (const auto& [parser, plug] : m_dynamic_plugin_map) {
+                if (parser->name() == active_subcommand) { sub_parser = parser; break; }
+            }
+        }
+        if (!sub_parser) return; // unknown subcommand — fall back to files
+
+        // If the last context word is an option that expects a value argument,
+        // output nothing so the shell falls back to file completion.
+        if (!context.empty()) {
+            const std::string& prev = context.back();
+            if (prev.size() >= 2 && prev[0] == '-') {
+                if (sub_parser->option_takes_value(prev)) {
+                    return; // option takes a value — let the shell complete files
+                }
+            }
+        }
+
+        // Complete long option names when the prefix starts with '-'
+        if (!prefix.empty() && prefix[0] == '-') {
+            for (const auto& name : sub_parser->get_long_option_names()) {
+                if (name.rfind(prefix, 0) == 0)
+                    std::cout << name << "\n";
+            }
+            return;
+        }
+        // Non-option prefix (or empty) — output nothing, shell falls back to files
     }
 
     // void MaCh3Program::parse_args(int argc, const char *const argv[]) {

--- a/CLI/MaCh3Program.hpp
+++ b/CLI/MaCh3Program.hpp
@@ -43,9 +43,10 @@ namespace M3{
             /// @brief Install shell completion scripts for bash and zsh
             void install_completions() const;
 
-            /// @brief Generate completion suggestions for the given prefix
-            /// @param prefix The prefix string to match against available subcommands
-            void completions(const std::string& prefix) const;
+            /// @brief Generate completion suggestions given the current prefix and preceding words
+            /// @param prefix   The partially-typed word being completed
+            /// @param context  Words already typed after the program name but before prefix
+            void completions(const std::string& prefix, const std::vector<std::string>& context) const;
 
             /// @brief Unload all dynamically loaded plugins
             void unload_dynamic_plugins();
@@ -79,17 +80,39 @@ namespace M3{
 _mach3_complete() {
     local cur prev words cword
     _init_completion || return
-    COMPREPLY=( $(mach3 --complete "$cur" "${words[@]:1:$cword}") )
+
+    # Pass current prefix + preceding words as context; binary filters by prefix
+    local -a raw
+    mapfile -t raw < <(mach3 --complete "$cur" "${words[@]:1:$((cword-1))}" 2>/dev/null)
+
+    if [[ ${#raw[@]} -eq 0 ]]; then
+        # No completions from binary — fall back to default (file) completion
+        compopt -o default 2>/dev/null
+        return
+    fi
+    COMPREPLY=( "${raw[@]}" )
 }
 complete -F _mach3_complete mach3
 )";
             static constexpr std::string_view ZSH_COMPLETION = R"(
 #compdef mach3
 
-local -a completions
-local cur="$words[-1]"
-completions=("${(@f)$(mach3 --complete "$cur" "${words[@]:1}")}")
-compadd -a completions
+_mach3() {
+    local cur="${words[$CURRENT]}"
+    local -a ctx
+    ctx=("${words[@]:1:$((CURRENT-2))}")
+
+    local -a completions
+    completions=("${(@f)$(mach3 --complete "$cur" "${ctx[@]}" 2>/dev/null)}")
+
+    if [[ ${#completions[@]} -eq 0 ]]; then
+        _files
+        return
+    fi
+    compadd -a completions
+}
+
+_mach3
 )";
     };
-}
+};

--- a/CLI/mach3.cpp
+++ b/CLI/mach3.cpp
@@ -20,15 +20,15 @@
 int main(int argc, char *argv[]) {
     M3::MaCh3Program program("mach3");
 
-    // // Hidden completion option
-    // program.add_argument("--complete")
-    //     .hidden()
-    //     .nargs(1);
+    // Hidden completion option — accepts prefix + preceding words as context
+    program.add_argument("--complete")
+        .hidden()
+        .nargs(argparse::nargs_pattern::any);
 
-    // // Hidden installer option
-    // program.add_argument("--install-completions")
-    //     .help("")
-    //     .flag();
+    // Hidden installer option
+    program.add_argument("--install-completions")
+        .help("")
+        .flag();
 
     M3::ProcessMCMCModule proc;
     M3::DiagMCMCModule diag;
@@ -39,15 +39,24 @@ int main(int argc, char *argv[]) {
     program.add_core_module(penterm);
     program.load_dynamic_plugins();
 
+    // Pre-scan for --complete before argparse processes the full command line,
+    // so incomplete commands (missing required args) still produce completions.
+    for (int i = 1; i < argc; i++) {
+        if (std::string_view(argv[i]) == "--complete") {
+            std::string prefix = (i + 1 < argc) ? argv[i + 1] : "";
+            std::vector<std::string> context;
+            for (int j = i + 2; j < argc; j++) {
+                context.emplace_back(argv[j]);
+            }
+            program.completions(prefix, context);
+            return 0;
+        }
+    }
+
     try {
         program.parse_args(argc, argv);
     }
     catch (const std::exception& err) {
-        // // completions count as parsing error
-        // if (auto prefix = program.present<std::string>("--complete")) {
-        //     program.completions(*prefix);
-        //     return 0;
-        // }
 
         std::cerr << err.what() << std::endl;
         std::cerr << program.get_subcommand_used();
@@ -66,10 +75,10 @@ int main(int argc, char *argv[]) {
     }
 
 
-    // if (program.get<bool>("--install-completions")) {
-    //     program.install_completions();
-    //     return 0;
-    // }
+    if (program.get<bool>("--install-completions")) {
+        program.install_completions();
+        return 0;
+    }
 
     try{
         program.Run();

--- a/cmake/Templates/setup.MaCh3.sh.in
+++ b/cmake/Templates/setup.MaCh3.sh.in
@@ -151,4 +151,6 @@ if test -d ${MaCh3_ROOT}/pyMaCh3; then
   add_to_PYTHONPATH ${MaCh3_ROOT}
 fi
 
+${MaCh3_ROOT}/bin/mach3 --install-completions
+
 unset SCRIPT_PATH


### PR DESCRIPTION
This PR automatically installs shell tab completions when running the setup script.

```shell
$ source setup.MaCh3.sh
Installed bash completions → "/home/mach3/.local/share/bash-completion/completions/mach3"
```

This will allow you to get both sub command and option tab completion help as below:
```shell
$ mach3 <tab>
diag     penterm  process
```
```shell
$ mach3 process --<tab>
--CalcBayesFactor         --CalcBipolarPlot         --CalcParameterEvolution  --CalcSavageDickey        --MakeCredibleIntervals   --corr                    --help
```