### PR TITLE
feat: add parameter flip groups

### DIFF
--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -118,14 +118,26 @@ void ParameterHandlerBase::EnableSpecialProposal(const YAML::Node& param, const 
   doSpecialStepProposal = true;
 
   bool CircEnabled = false;
+  std::pair<double, double> circular_bounds;
+
   bool FlipEnabled = false;
+  std::string flip_group;
+  double flip_point;
 
   if (param["CircularBounds"]) {
     CircEnabled = true;
+    circular_bounds = Get<std::pair<double, double>>(param["CircularBounds"], __FILE__, __LINE__);
   }
 
   if (param["FlipParameter"]) {
     FlipEnabled = true;
+    // grab flip group if it exists, otherwise use the parameter name as the group
+    if (param["FlipGroup"]) {
+      flip_group = Get<std::string>(param["FlipGroup"], __FILE__, __LINE__);
+    } else {
+      flip_group = GetParFancyName(Index);
+    }
+    flip_point = Get<double>(param["FlipParameter"], __FILE__, __LINE__);
   }
 
   if (!CircEnabled && !FlipEnabled) {
@@ -135,15 +147,15 @@ void ParameterHandlerBase::EnableSpecialProposal(const YAML::Node& param, const 
 
   if (CircEnabled) {
     CircularBoundsIndex.push_back(Index);
-    CircularBoundsValues.push_back(Get<std::pair<double, double>>(param["CircularBounds"], __FILE__, __LINE__));
+    CircularBoundsValues.push_back(circular_bounds);
     MACH3LOG_INFO("Enabling CircularBounds for parameter {} with range [{}, {}]",
                   GetParFancyName(Index),
-                  CircularBoundsValues.back().first,
-                  CircularBoundsValues.back().second);
+                  circular_bounds.first,
+                  circular_bounds.second);
     // KS: Make sure circular bounds are within physical bounds. If we are outside of physics bound MCMC will never explore such phase space region
-    if (CircularBoundsValues.back().first < _fLowBound.at(Index) || CircularBoundsValues.back().second > _fUpBound.at(Index)) {
+    if (circular_bounds.first < _fLowBound.at(Index) || circular_bounds.second > _fUpBound.at(Index)) {
       MACH3LOG_ERROR("Circular bounds [{}, {}] for parameter {} exceed physical bounds [{}, {}]",
-                     CircularBoundsValues.back().first, CircularBoundsValues.back().second,
+                     circular_bounds.first, circular_bounds.second,
                      GetParFancyName(Index),
                      _fLowBound.at(Index), _fUpBound.at(Index));
       throw MaCh3Exception(__FILE__, __LINE__);
@@ -158,32 +170,35 @@ void ParameterHandlerBase::EnableSpecialProposal(const YAML::Node& param, const 
   }
 
   if (FlipEnabled) {
-    FlipParameterIndex.push_back(Index);
-    FlipParameterPoint.push_back(Get<double>(param["FlipParameter"], __FILE__, __LINE__));
-    MACH3LOG_INFO("Enabling Flipping for parameter {} with value {}",
+    FlipGroup& group = FlipGroups[flip_group];
+    group.FlipParameterIndex.push_back(Index);
+    group.FlipParameterPoint.push_back(flip_point);
+
+    MACH3LOG_INFO("Enabling Flipping for parameter {} in group {} with value {}",
                   GetParFancyName(Index),
-                  FlipParameterPoint.back());
+                  flip_group,
+                  flip_point);
   }
 
   if (CircEnabled && FlipEnabled) {
-    if (FlipParameterPoint.back() < CircularBoundsValues.back().first || FlipParameterPoint.back() > CircularBoundsValues.back().second) {
+    if (flip_point < circular_bounds.first || flip_point > circular_bounds.second) {
       MACH3LOG_ERROR("FlipParameter value {} for parameter {} is outside the CircularBounds [{}, {}]",
-                     FlipParameterPoint.back(), GetParFancyName(Index), CircularBoundsValues.back().first, CircularBoundsValues.back().second);
+                     flip_point, GetParFancyName(Index), circular_bounds.first, circular_bounds.second);
       throw MaCh3Exception(__FILE__, __LINE__);
     }
 
-    const double low = CircularBoundsValues.back().first;
-    const double high = CircularBoundsValues.back().second;
+    const double low = circular_bounds.first;
+    const double high = circular_bounds.second;
 
     // Sanity check: ensure flipping any x in [low, high] keeps the result in [low, high]
-    const double flipped_low = 2 * FlipParameterPoint.back() - low;
-    const double flipped_high = 2 * FlipParameterPoint.back() - high;
+    const double flipped_low = 2 * flip_point - low;
+    const double flipped_high = 2 * flip_point - high;
     const double min_flip = std::min(flipped_low, flipped_high);
     const double max_flip = std::max(flipped_low, flipped_high);
 
     if (min_flip < low || max_flip > high) {
       MACH3LOG_ERROR("Flipping about point {} for parameter {} would leave circular bounds [{}, {}]",
-                     FlipParameterPoint.back(), GetParFancyName(Index), low, high);
+                     flip_point, GetParFancyName(Index), low, high);
       throw MaCh3Exception(__FILE__, __LINE__);
     }
   }
@@ -427,11 +442,9 @@ void ParameterHandlerBase::SpecialStepProposal() {
       CircularParBounds(index, CircularBoundsValues[i].first, CircularBoundsValues[i].second);
   }
 
-  // Okay now we've done the standard steps, we can add in our nice flips hierarchy flip first
-  for (size_t i = 0; i < FlipParameterIndex.size(); ++i) {
-    const int index = FlipParameterIndex[i];
-    if(!IsParameterFixed(index))
-      FlipParameterValue(FlipParameterIndex[i], FlipParameterPoint[i]);
+  // // Okay now we've done the standard steps, we can add in our nice flips hierarchy flip first
+  for (const auto& [group_name, group] : FlipGroups) {
+    FlipParameterGroup(group_name);
   }
 }
 
@@ -533,12 +546,20 @@ void ParameterHandlerBase::CircularParBounds(const int index, const double LowBo
 }
 
 // *************************************
-void ParameterHandlerBase::FlipParameterValue(const int index, const double FlipPoint) {
+void ParameterHandlerBase::FlipParameterGroup(const std::string group) {
 // *************************************
   if(random_number[0]->Uniform() < 0.5) {
-    _fPropVal[index] = static_cast<M3::float_t>(2 * FlipPoint - _fPropVal[index]);
+    for (size_t i = 0; i < FlipGroups[group].FlipParameterIndex.size(); ++i) {
+      const int index = FlipGroups[group].FlipParameterIndex[i];
+      if(!IsParameterFixed(index)) {
+        const double flip_point = FlipGroups[group].FlipParameterPoint[i];
+        _fPropVal[index] = static_cast<M3::float_t>(2 * flip_point - _fPropVal[index]);
+      }
+    }
   }
 }
+
+
 #pragma GCC diagnostic pop
 // ********************************************
 // Function to print the prior values
@@ -964,13 +985,15 @@ void ParameterHandlerBase::UpdateThrowMatrix(TMatrixDSym *cov) {
 // ********************************************
 void ParameterHandlerBase::SanitizeAdaption() const {
 // ********************************************
-  for (size_t i = 0; i < FlipParameterIndex.size(); ++i) {
-    const int index = FlipParameterIndex[i];
-    if(!param_skip_adapt_flags[index]) {
-      MACH3LOG_ERROR("You enabled adaption for parameter which has enabled flipping ({})", _fFancyNames[index]);
-      MACH3LOG_ERROR("Right now flipping and adapting doesn't work very well");
-      MACH3LOG_ERROR("Please skip adaption for param {}, using ParametersToSkip option in config", _fFancyNames[index]);
-      throw MaCh3Exception(__FILE__, __LINE__);
+  for (const auto& [_, group] : FlipGroups) {
+    for (size_t i = 0; i < group.FlipParameterIndex.size(); ++i) {
+      const int index = group.FlipParameterIndex[i];
+      if(!param_skip_adapt_flags[index]) {
+        MACH3LOG_ERROR("You enabled adaption for parameter which has enabled flipping ({})", _fFancyNames[index]);
+        MACH3LOG_ERROR("Right now flipping and adapting doesn't work very well");
+        MACH3LOG_ERROR("Please skip adaption for param {}, using ParametersToSkip option in config", _fFancyNames[index]);
+        throw MaCh3Exception(__FILE__, __LINE__);
+      }
     }
   }
 

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -366,10 +366,10 @@ class ParameterHandlerBase {
   void SetThrowMatrixFromFile(const std::string& matrix_file_name, const std::string& matrix_name, const std::string& means_name);
   /// @brief Perform sanity check to ensure adaption isn't misbehaving before fit starts
   void SanitizeAdaption() const;
-  /// @brief KS: Flip parameter around given value, for example mass ordering around 0
-  /// @param index parameter index you want to flip
-  /// @param FlipPoint Value around which flipping is done
-  void FlipParameterValue(const int index, const double FlipPoint);
+
+  /// @brief With a 50% chance, flip all parameters in a group around their respective flip points
+  /// @param group Name of the flip group
+  void FlipParameterGroup(std::string group);
 
   /// @brief HW :: This method is a tad hacky but modular arithmetic gives me a headache.
   /// @author Henry Wallace
@@ -461,10 +461,22 @@ class ParameterHandlerBase {
   /// Struct containing information about adaption
   std::unique_ptr<ParameterTunes> Tunes;
 
-  /// Indices of parameters with flip symmetry
-  std::vector<int>    FlipParameterIndex;
-  /// Central points around which parameters are flipped
-  std::vector<double> FlipParameterPoint;
+  // /// Indices of parameters with flip symmetry
+  // std::vector<int>    FlipParameterIndex;
+  // /// Central points around which parameters are flipped
+  // std::vector<double> FlipParameterPoint;
+
+  /// @brief Struct to hold information about a group of parameters that flip together at the same time
+  struct FlipGroup {
+    /// Indices of parameters with flip symmetry
+    std::vector<int> FlipParameterIndex;  
+    /// Central points around which parameters are flipped
+    std::vector<double> FlipParameterPoint; 
+  };
+
+  /// @brief Map of flip groups, where the key is the group name and the value is a FlipGroup struct
+  std::map<std::string, FlipGroup> FlipGroups;
+
   /// Indices of parameters with circular bounds
   std::vector<int>    CircularBoundsIndex;
   /// Circular bounds for each parameter (lower, upper)

--- a/Parameters/ParameterHandlerBase.h
+++ b/Parameters/ParameterHandlerBase.h
@@ -461,11 +461,6 @@ class ParameterHandlerBase {
   /// Struct containing information about adaption
   std::unique_ptr<ParameterTunes> Tunes;
 
-  // /// Indices of parameters with flip symmetry
-  // std::vector<int>    FlipParameterIndex;
-  // /// Central points around which parameters are flipped
-  // std::vector<double> FlipParameterPoint;
-
   /// @brief Struct to hold information about a group of parameters that flip together at the same time
   struct FlipGroup {
     /// Indices of parameters with flip symmetry


### PR DESCRIPTION
# Pull request description

The current parameter flip special proposal helps us move between separated regions of high likelihood where it is a single parameter causing a discrepancy. Examples include sin2th_23 and delm2_23 (mass ordering). 

However, if there are correlations with another parameter, then to reach the other region of high likelihood, one needs to flip both parameters simultaneously. See page 11 of https://arxiv.org/pdf/2608.04059. In other words, the exploration of the likelihood can be more efficient if we create a feature where two parameters are flipped at the same time, rather than independently. 

This PR introduces "FlipGroups", which are configured in the yaml files describing your parameters. This option lives under `Systematic:SpecialProposal:FlipGroup`, and here is an example.

```
- Systematic:
    Names:
      FancyName: sin2th_23
      ParameterName: sin2th_23

    SampleNames: ["Tutorial_*"]
    Error: 0.021
    FlatPrior: true
    ParameterBounds: [0, 1]
    # flip octant around point of maximal disappearance (0.5112)
    # this ensures we move to a parameter value which has the same oscillation probability
    SpecialProposal:
        FlipParameter: 0.5112
        FlipGroup: "sin2th_23_sin2th_13"
    ParameterGroup: Osc
    ParameterValues:
      Generated: 0.546
      PreFitValue: 0.546
      PostND: 0.546
    StepScale:
      MCMC: 0.9
    Type: Oscillation

- Systematic:
    Names:
      FancyName: sin2th_13
      ParameterName: sin2th_13

    SampleNames: ["Tutorial_*"]
    Error: 0.0007
    FlatPrior: true
    ParameterBounds: [0, 1]
    SpecialProposal:
        FlipParameter: 0.025
        FlipGroup: "sin2th_23_sin2th_13"
    ParameterGroup: Osc
    ParameterValues:
      Generated: 0.0220
      PreFitValue: 0.0220
      PostND: 0.0220
    StepScale:
      MCMC: 5.0
    Type: Oscillation
```

One can choose whatever name for a group they want; it does not have to include the names of the parameters in that group. Parameters that have not been assigned a group in the config will be assigned a group according to their parameter name.

To implement this, a new `FlipGroup` struct has been added to `ParameterHandlerBase` that contains the indices and flip points for all the parameters in the group. Now, when performing flipping, instead of iterating over all flip parameter indices, we now iterate over groups, and then iterate over indices within the group. And the random number used to decide whether to flip is universal to all parameters in a group.

I tried this in MaCh3Tutorial with the example config shown above. Here is the distribution of the first 20 steps in the chain, illustrating that things are working as expected.

<img width="1166" height="852" alt="image" src="https://github.com/user-attachments/assets/194df41b-7e74-4b60-abc3-d4cd4a967e76" />





---

- [X] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
