### PR TITLE
breaking: Spline tokens no assume dimensionality

### DIFF
--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -1153,10 +1153,10 @@ std::vector< SplineIndex > SampleHandlerBase::GetSplineBins(int Event, BinnedSpl
   std::vector< SplineIndex > EventSplines;
   switch(GetNDim(SampleIndex)) {
     case 1:
-      EventSplines = BinnedSpline->GetEventSplines(SampleTitle, OscIndex, Mode, Etrue, *(MCEvents[Event].KinVar[0]), 0.);
+      EventSplines = BinnedSpline->GetEventSplines(SampleTitle, OscIndex, Mode, {Etrue, *(MCEvents[Event].KinVar[0]), 0.});
       break;
     case 2:
-      EventSplines = BinnedSpline->GetEventSplines(SampleTitle, OscIndex, Mode, Etrue, *(MCEvents[Event].KinVar[0]), *(MCEvents[Event].KinVar[1]));
+      EventSplines = BinnedSpline->GetEventSplines(SampleTitle, OscIndex, Mode, {Etrue, *(MCEvents[Event].KinVar[0]), *(MCEvents[Event].KinVar[1])});
       break;
     default:
       if(ThrowCrititcal) {
@@ -1164,7 +1164,7 @@ std::vector< SplineIndex > SampleHandlerBase::GetSplineBins(int Event, BinnedSpl
         MACH3LOG_CRITICAL("Will use 2D like approach");
         ThrowCrititcal = false;
       }
-      EventSplines = BinnedSpline->GetEventSplines(SampleTitle, OscIndex, Mode, Etrue, *(MCEvents[Event].KinVar[0]), *(MCEvents[Event].KinVar[1]));
+      EventSplines = BinnedSpline->GetEventSplines(SampleTitle, OscIndex, Mode, {Etrue, *(MCEvents[Event].KinVar[0]), *(MCEvents[Event].KinVar[1])});
       break;
   }
   return EventSplines;

--- a/Splines/BinnedSplineHandler.cpp
+++ b/Splines/BinnedSplineHandler.cpp
@@ -537,10 +537,10 @@ void BinnedSplineHandler::PrepForReweight() {
     if (FoundNonFlatSpline) {
       UniqueSystNames.push_back(SystName);
     } else {
-      MACH3LOG_INFO("{} syst has no response in sample {}", SystName, entry.iSample);
-      MACH3LOG_INFO("Whilst this isn't necessarily a problem, it seems odd");
+      MACH3LOG_DEBUG("{} syst has no response in sample {}", SystName, entry.iSample);
+      MACH3LOG_DEBUG("Whilst this isn't necessarily a problem, it seems odd");
     }
-  }  // end loop over indices
+  } // end loop over indices
   nParams = static_cast<short int>(UniqueSystSplines.size());
 
   // DB Find the number of splines knots which assumes each instance of the syst has the same number of knots
@@ -623,10 +623,9 @@ void BinnedSplineHandler::GetSplineCoeff_SepMany(int splineindex, M3::float_t* &
   splinevec_Monolith[splineindex] = nullptr;
 }
 
-
 //****************************************
 //Returns sample index in
-int BinnedSplineHandler::GetSampleIndex(const std::string& SampleTitle) const{
+int BinnedSplineHandler::GetSampleIndex(const std::string& SampleTitle) const {
 //****************************************
   for (size_t iSample = 0; iSample < SampleTitles.size(); ++iSample) {
     if (SampleTitle == SampleTitles[iSample]) {
@@ -705,8 +704,7 @@ void BinnedSplineHandler::PrintBinning(TAxis *Axis) const {
 
 //****************************************
 std::vector<SplineIndex> BinnedSplineHandler::GetEventSplines(const std::string& SampleTitle,
-                                                              int iOscChan, int EventMode, double Var1Val,
-                                                              double Var2Val, double Var3Val) {
+                                                              int iOscChan, int EventMode, const std::vector<double>& VarVals) {
 //****************************************
   std::vector<SplineIndex> ReturnVec;
   int SampleIndex = GetSampleIndex(SampleTitle);
@@ -724,9 +722,8 @@ std::vector<SplineIndex> BinnedSplineHandler::GetEventSplines(const std::string&
   }
 
   std::vector<int> var_bins;
-  std::vector<double> vars = {Var1Val, Var2Val, Var3Val};
-  for (size_t i = 0; i < vars.size(); ++i) {
-    int bin = SplineBinning[SampleIndex][iOscChan][i]->FindBin(vars[i]) - 1;
+  for (size_t i = 0; i < VarVals.size(); ++i) {
+    int bin = SplineBinning[SampleIndex][iOscChan][i]->FindBin(VarVals[i]) - 1;
     if (bin < 0 || bin >= SplineBinning[SampleIndex][iOscChan][i]->GetNbins()) {
       return ReturnVec;
     }
@@ -834,18 +831,15 @@ void BinnedSplineHandler::FillSampleArray(const std::string& SampleTitle, const 
       SplineFileNames.insert(FullSplineName);
 
       std::vector<std::string> Tokens = GetTokensFromSplineName(FullSplineName);
-
-      if (Tokens.size() != kNTokens) {
-        MACH3LOG_ERROR("Invalid tokens from spline name - Expected {} tokens. Check implementation in GetTokensFromSplineName()", static_cast<int>(kNTokens));
-        throw MaCh3Exception(__FILE__, __LINE__);
-      }
       
       TString Syst = Tokens[kSystToken];
       TString Mode = Tokens[kModeToken];
-      int Var1Bin = std::stoi(Tokens[kVar1BinToken]);
-      int Var2Bin = std::stoi(Tokens[kVar2BinToken]);
-      int Var3Bin = std::stoi(Tokens[kVar3BinToken]);
-      std::vector<int> VarBins = {Var1Bin, Var2Bin, Var3Bin};
+      std::vector<int> VarBins;
+      VarBins.reserve(Tokens.size() - kVarBinToken);
+      for (std::size_t i = kVarBinToken; i < Tokens.size(); ++i) {
+        VarBins.push_back(std::stoi(Tokens.at(i)));
+      }
+
       int SystNum = -1;
       for (unsigned iSyst = 0; iSyst < SplineFileParPrefixNames[iSample].size(); iSyst++) {
         if (Syst == SplineFileParPrefixNames[iSample][iSyst]) {
@@ -869,8 +863,8 @@ void BinnedSplineHandler::FillSampleArray(const std::string& SampleTitle, const 
       }
 
       if (ModeNum == -1) {
-      //DB - If you have splines in the root file that you don't want to use (e.g. removing a mode from a syst), this will cause a throw
-      //     Therefore include as debug warning and continue instead
+        //DB - If you have splines in the root file that you don't want to use (e.g. removing a mode from a syst), this will cause a throw
+        //     Therefore include as debug warning and continue instead
         MACH3LOG_DEBUG("Couldn't find mode for {} in {}. Problem Spline is : {} ", Mode, Syst, FullSplineName);
         continue;
       }

--- a/Splines/BinnedSplineHandler.h
+++ b/Splines/BinnedSplineHandler.h
@@ -34,7 +34,7 @@ class BinnedSplineHandler : public SplineBase {
     /// @note DB Add virtual so it can be overridden in experiment specific (if needed)
     virtual void FillSampleArray(const std::string& SampleTitle, const std::vector<std::string>& OscChanFileNames);
     /// @brief Return the splines which affect a given event
-    std::vector<SplineIndex> GetEventSplines(const std::string& SampleTitle, int iOscChan, int EventMode, double Var1Val, double Var2Val, double Var3Val);
+    std::vector<SplineIndex> GetEventSplines(const std::string& SampleTitle, int iOscChan, int EventMode, const std::vector<double>& VarVals);
     /// @brief KS: After calculations are done on GPU we copy memory to CPU. This operation is asynchronous meaning while memory is being copied some operations are being carried. Memory must be copied before actual reweight. This function make sure all has been copied.
     /// @note now is empty but once we add GPU support it will actually do something
     void SynchroniseMemTransfer() const final {return;}
@@ -138,7 +138,7 @@ class BinnedSplineHandler : public SplineBase {
 
     /// pointer to MaCh3 Mode from which we get spline suffix
     MaCh3Modes* Modes;
-    enum TokenOrdering{kSystToken,kModeToken,kVar1BinToken,kVar2BinToken,kVar3BinToken,kNTokens};
+    enum TokenOrdering{kSystToken,kModeToken,kVarBinToken};
     /// @brief Extract metadata tokens encoded in a spline name.
     /// allows experiment to have different formats of splines
     virtual std::vector<std::string> GetTokensFromSplineName(const std::string& FullSplineName) = 0;


### PR DESCRIPTION
# Pull request description
Spline tokens always assumed we have three kinematic variables.
For a while, we try to stop enforcing dimensionality to enable having splines with more dimensions.

Need frst merge:
https://github.com/mach3-software/MaCh3Tutorial/pull/290

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
