### PR TITLE
tidy: Make Valgrind bot montlhy

### DIFF
--- a/.github/workflows/MonthlyValgrind.yml
+++ b/.github/workflows/MonthlyValgrind.yml
@@ -3,7 +3,7 @@ name: MaCh3 Valgrind
 
 on:
   schedule:
-    - cron: '0 12 * * 1' # KS: Every Monday at 12:00 PM (noon) to not disturb during weekend...
+    - cron: '0 12 1 * *' # Every 1st of the month at 12:00 PM (noon)
 
 permissions:
   # Required permissions for GitHub Pages deployment and content updates

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,7 +36,7 @@ Summary of currently implemented bots
 * Nothing to add, cool meme for PR
 
 ## Newsletter
-* Make weekly summary of
+* Make monthly summary of commits to MaCh3 repos
 
 ## PRtitleChecker
 * Ensures each PR starts with suffix like tidy: for example
@@ -50,8 +50,8 @@ Summary of currently implemented bots
 ## Telemetry
 * Add telemetry like RAM and CPU usage for each PR
 
-## WeeklyValgrind
-* Runs Valgrind over tutorial weekly so we always have up to date info about memory leaks etc.
+## MonthlyValgrind
+* Runs Valgrind over tutorial monthly so we always have up to date info about memory leaks etc.
 
 ## TaskChecker
 * We require every user before merging PR to tick that they have read contributing. This simply ensures people actually ticked it. We can't check people actually read it, for now ;)

--- a/.mailmap
+++ b/.mailmap
@@ -68,5 +68,9 @@ Hank Hua <h.hua23@imperial.ac.uk> hank-hua <146197275+hank-hua@users.noreply.git
 #Dominic Langridge
 Dominic Langridge  <92931431+DomLangridge@users.noreply.github.com> DomLangridge <92931431+DomLangridge@users.noreply.github.com>
 Dominic Langridge  <92931431+DomLangridge@users.noreply.github.com> Dominic Langridge <dominic.langridge.2023@live.rhul.ac.uk>
+
 #Menai Lamers James
 Menai Lamers James <menai.james@warwick.ac.uk> menailj <77395579+menailj@users.noreply.github.com>
+
+#Luke Pickering
+Luke Pickering <luketpickering@gmail.com> Luke Pickering <luketpickering@googlemail.com>


### PR DESCRIPTION
# Pull request description
As the process of making bots less spammy, now Valgrind bot is monthly instead of weekly.


---
- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
