### PR TITLE
bugfix: Safer TCanvas

### DIFF
--- a/Fitters/MCMCProcessor.cpp
+++ b/Fitters/MCMCProcessor.cpp
@@ -196,10 +196,16 @@ void MCMCProcessor::GetCovariance(TMatrixDSym *&Cov, TMatrixDSym *&Corr) {
 void MCMCProcessor::MakeOutputFile() {
 // ***************
   //KS: ROOT hates me... but we can create several instances of MCMC Processor, each with own TCanvas ROOT is mad and will delete if there is more than one canvas with the same name, so we add random number to avoid issue
+  // KS: Update, now we also check if such canvas already exist, hence while/do loop
   auto rand = std::make_unique<TRandom3>(0);
-  const int uniform = int(rand->Uniform(0, 10000));
+  std::string name = "";
+  do {
+    const int uniform = int(rand->Uniform(0, 10000));
+    name = "Posterior" + std::to_string(uniform);
+  } while (gROOT->GetListOfCanvases()->FindObject(name.c_str()) != nullptr);
+
   // Open a TCanvas to write the posterior onto
-  Posterior = std::make_unique<TCanvas>(("Posterior" + std::to_string(uniform)).c_str(), ("Posterior" + std::to_string(uniform)).c_str(), 0, 0, 1024, 1024);
+  Posterior = std::make_unique<TCanvas>(name.c_str(), name.c_str(), 0, 0, 1024, 1024);
   //KS: No idea why but ROOT changed treatment of violin in R6. If you have non uniform binning this will results in very hard to see violin plots.
   TCandle::SetScaledViolin(false);
 


### PR DESCRIPTION
# Pull request description
In very rare cases we can create several MCMC Processors and in VERY rare several TCanvases with same name causing VERY random crash.

We still add random number to avoid duplicates, however if random number are same then we have crash.
Hence, this PR we draw random number until name is not visible by ROOT.

## Examples
Example of issue
```
[MCMCProcessor.cpp][info] # FD params (legacy):     0 starting at 0  
[MCMCProcessor.cpp][info] ************************************************
Warning in <TCanvas::Constructor>: Deleting canvas with same name: Posterior1615
[InputManager.cpp][info] ....Searching for MCMC related things
[InputManager.cpp][info] ........ Found 18 parameters in MCMC chain
[InputManager.cpp][info] This is a FITTER_1 file!
[InputManager.cpp][info] ....getting data from file MCMC_Test.root
[PlotLLH.cpp][info] Parameters: 
[MCMCProcessor.cpp][info] Closing pdf in MCMCProcessor: MCMC_Test_PlottingTemp.pdf
```
https://github.com/mach3-software/MaCh3/actions/runs/29284899590/job/86934956348

---
- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
