### PR TITLE
feat: Add ability to set histogram range via style config

### DIFF
--- a/CLI/Plotting/PlotSigmaVariation.cpp
+++ b/CLI/Plotting/PlotSigmaVariation.cpp
@@ -294,6 +294,7 @@ void PlotRatio(const std::vector<std::unique_ptr<TH1D>>& Poly,
     Poly[ik]->SetLineWidth(2.);
     Poly[ik]->SetLineColor(Colours[ik]);
     Poly[ik]->SetLineStyle(Style[ik]);
+    PlotMan->style().setTH1XRange(Poly[ik].get());
     auto BinWidthScale = PlotMan->style().getBinWidthScale(Poly[ik]->GetXaxis()->GetTitle());
     Poly[ik]->GetYaxis()->SetTitle(fmt::format("Events/{:.0f}", BinWidthScale).c_str());
     M3::ScaleHistogram(Poly[ik].get(), BinWidthScale);
@@ -332,6 +333,7 @@ void PlotRatio(const std::vector<std::unique_ptr<TH1D>>& Poly,
   MakeRatio(Poly, Ratio);
 
   auto PrettyX = PlotMan->style().prettifyKinematicName(Ratio[0]->GetXaxis()->GetTitle());
+  PlotMan->style().setTH1XRange(Ratio[0].get());
   Ratio[0]->GetXaxis()->SetTitle(PrettyX.c_str());
   Ratio[0]->GetXaxis()->SetTitleSize(0.12);
   Ratio[0]->GetYaxis()->SetTitleOffset(0.4);
@@ -706,6 +708,7 @@ void PlotSigVar1D(const std::vector<std::vector<std::unique_ptr<TH1D>>>& Project
   M3::ScaleHistogram(PriorHist, BinWidthScale);
 
   auto PrettyX = PlotMan->style().prettifyKinematicName(PriorHist->GetXaxis()->GetTitle());
+  PlotMan->style().setTH1XRange(PriorHist);
   PriorHist->GetXaxis()->SetTitle(PrettyX.c_str());
   for(int ik = 0; ik < static_cast<int>(sigmaArray.size()); ++ik)
   {

--- a/CLI/Plotting/PredictivePlotting.cpp
+++ b/CLI/Plotting/PredictivePlotting.cpp
@@ -134,6 +134,7 @@ void PretifyHistogram(TH1* Hist, const std::string& SampleName) {
   Hist->SetTitle(PlotMan->style().prettifySampleName(SampleName).c_str());
   auto BinWidthScale = PlotMan->style().getBinWidthScale(Hist->GetXaxis()->GetTitle());
   auto PrettyX = PlotMan->style().prettifyKinematicName(Hist->GetXaxis()->GetTitle());
+  PlotMan->style().setTH1XRange(Hist);
   Hist->GetXaxis()->SetTitle(PrettyX.c_str());
   Hist->GetYaxis()->SetTitle(fmt::format("Events/{:.0f}", BinWidthScale).c_str());
   M3::ScaleHistogram(Hist, BinWidthScale);
@@ -252,6 +253,7 @@ void OverlayViolin(const YAML::Node& Settings,
         ViolinHist[iFile]->SetMarkerColor(PosteriorColor[iFile]);
         ViolinHist[iFile]->SetFillColorAlpha(PosteriorColor[iFile], 0.35);
         ViolinHist[iFile]->SetFillStyle(1001);
+        PlotMan->style().setTH1XRange(ViolinHist[iFile].get());
         ViolinHist[iFile]->GetXaxis()->SetTitle(PlotMan->style().prettifyKinematicName(
                                                 ViolinHist[iFile]->GetXaxis()->GetTitle()).c_str());
         ViolinHist[iFile]->GetYaxis()->SetTitle("Events");
@@ -346,6 +348,7 @@ void OverlayPredicitve(const YAML::Node& Settings,
         }
         PredHist[iFile] = M3::Clone(InputFiles[iFile]->Get<TH1D>((HistLocation).c_str()));
         Integral[iFile] = PredHist[iFile]->Integral();
+        PlotMan->style().setTH1XRange(PredHist[iFile].get());
         PredHist[iFile]->SetLineColor(PosteriorColor[iFile]);
         PredHist[iFile]->SetMarkerColor(PosteriorColor[iFile]);
         PredHist[iFile]->SetFillColorAlpha(PosteriorColor[iFile], 0.35);
@@ -389,6 +392,7 @@ void OverlayPredicitve(const YAML::Node& Settings,
         RatioPlot[ig]->SetFillColorAlpha(PosteriorColor[ig], 0.35);
         RatioPlot[ig]->SetFillStyle(1001);
         RatioPlot[ig]->GetYaxis()->SetTitle("Data/MC");
+        PlotMan->style().setTH1XRange(RatioPlot[ig].get());
         auto PrettyX = PlotMan->style().prettifyKinematicName(PredHist[0]->GetXaxis()->GetTitle());
         RatioPlot[ig]->GetXaxis()->SetTitle(PrettyX.c_str());
         RatioPlot[ig]->SetBit(TH1D::kNoTitle);

--- a/Utils/Plotting/StyleManager.cpp
+++ b/Utils/Plotting/StyleManager.cpp
@@ -74,6 +74,26 @@ void StyleManager::setTH1Style(TH1 *hist, const std::string& styleName) const {
   hist->SetLineStyle(GetFromManager<Color_t>(styleDef["LineStyle"], 1, __FILE__, __LINE__));
 }
 
+void StyleManager::setTH1XRange(TH1 *hist) const {
+  YAML::Node ranges = _styleConfig["HistogramRange"];
+  if (!ranges) {
+    return;
+  }
+  const auto name = hist->GetXaxis()->GetTitle();
+  YAML::Node rangeNode = ranges[name];
+  if (!rangeNode) {
+    return;
+  }
+
+  auto range = Get<std::vector<double>>(rangeNode, __FILE__, __LINE__);
+  if (range.size() != 2) {
+    return;
+  }
+
+  MACH3LOG_TRACE("Setting range for kinem: {} with range: [{}, {}]", name, range[0], range[1]);
+  hist->GetXaxis()->SetRangeUser(range[0], range[1]);
+}
+
 double StyleManager::getBinWidthScale(const std::string &Name) const {
   constexpr const double DefaultScalingFactor = 10;
   if(!_styleConfig["BinWidthScaleFactor"]) return DefaultScalingFactor;

--- a/Utils/Plotting/StyleManager.h
+++ b/Utils/Plotting/StyleManager.h
@@ -79,6 +79,9 @@ public:
   /// @param styleName The name of the style you want to use, as it appears in the config file
   void setTH1Style(TH1 *hist, const std::string& styleName) const;
 
+  /// @brief Set plotting range for histogram
+  /// @param hist The TH1 that you wish to modify
+  void setTH1XRange(TH1 *hist) const;
 private:
   YAML::Node _styleConfig;
 


### PR DESCRIPTION
# Pull request description
We often have very wide bin range for fitting but for plotting we want to restrict range.
This PR allows setting plotting range using usual style config.

## Examples
Config example:
https://github.com/mach3-software/MaCh3Tutorial/commit/a29605d099ef952b351d2e514fa5612afb5ca573
plot examples:
<img width="1366" height="1333" alt="image" src="https://github.com/user-attachments/assets/5149a560-9ae4-4372-966d-4731e415139f" />
<img width="1353" height="1328" alt="image" src="https://github.com/user-attachments/assets/1ed419e2-aea3-4c97-9c10-8a86e3b5026c" />
<img width="1336" height="1330" alt="image" src="https://github.com/user-attachments/assets/28ff74c9-71fd-42a9-b175-e5eced929fc4" />


---
- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
