### PR TITLE
tidy: Use TH1 inheritance when grabbing TAxis in Spline Code

### DIFF
--- a/Splines/BinnedSplineHandler.cpp
+++ b/Splines/BinnedSplineHandler.cpp
@@ -352,16 +352,11 @@ void BinnedSplineHandler::BuildSampleIndexingArray(const std::string& SampleTitl
 }
 
 //****************************************
-std::vector<TAxis *> BinnedSplineHandler::FindSplineBinning(const std::string& FileName, const std::string& SampleTitle) {
+std::vector<TAxis *> BinnedSplineHandler::FindSplineBinning(const std::string& FileName,
+                                                            const std::string& SampleTitle) {
 //****************************************
   int iSample = GetSampleIndex(SampleTitle);
-
-  //Try declaring these outside of TFile so they aren't owned by File
-  constexpr int nDummyBins = 1;
-  constexpr double DummyEdges[2] = {-1e15, 1e15};
-  TAxis* DummyAxis = new TAxis(nDummyBins, DummyEdges);
-  TH2F* Hist2D = nullptr;
-  TH3F* Hist3D = nullptr;
+  TH1* Axis_Hist = nullptr;
 
   auto File = std::unique_ptr<TFile>(TFile::Open(FileName.c_str(), "READ"));
   if (!File || File->IsZombie())
@@ -406,39 +401,29 @@ std::vector<TAxis *> BinnedSplineHandler::FindSplineBinning(const std::string& F
       MACH3LOG_ERROR("Trying to load a 2D spline template when nDim={}", Dimensions[iSample]);
       throw MaCh3Exception(__FILE__, __LINE__);
     }
-    Hist2D = File->Get<TH2F>(TemplateName.c_str());
+    Axis_Hist = File->Get<TH2F>(TemplateName.c_str());
   }
 
   if (isHist3D)
   {
-    Hist3D = File->Get<TH3F>((TemplateName.c_str()));
-    if (Dimensions[iSample] != 3 && Hist3D->GetZaxis()->GetNbins() != 1)
+    Axis_Hist = File->Get<TH3F>((TemplateName.c_str()));
+    if (Dimensions[iSample] != 3 && Axis_Hist->GetZaxis()->GetNbins() != 1)
     {
       MACH3LOG_ERROR("Trying to load a 3D spline template when nDim={}", Dimensions[iSample]);
       throw MaCh3Exception(__FILE__ , __LINE__ );
     }
   }
+  /// @todo KS: we should remove this hardcoding in future.
+  std::vector<TAxis*> ReturnVec(3);
+  ReturnVec[0] = static_cast<TAxis*>(Axis_Hist->GetXaxis()->Clone());
+  ReturnVec[1] = static_cast<TAxis*>(Axis_Hist->GetYaxis()->Clone());
 
-  std::vector<TAxis*> ReturnVec;
-  // KS: Resize to reduce impact of push back and memory fragmentation
-  ReturnVec.resize(3);
-  if (Dimensions[iSample] == 2) {
-    if (isHist2D) {
-      ReturnVec[0] = static_cast<TAxis*>(Hist2D->GetXaxis()->Clone());
-      ReturnVec[1] = static_cast<TAxis*>(Hist2D->GetYaxis()->Clone());
-      ReturnVec[2] = static_cast<TAxis*>(DummyAxis->Clone());
-    } else if (isHist3D) {
-      ReturnVec[0] = static_cast<TAxis*>(Hist3D->GetXaxis()->Clone());
-      ReturnVec[1] = static_cast<TAxis*>(Hist3D->GetYaxis()->Clone());
-      ReturnVec[2] = static_cast<TAxis*>(DummyAxis->Clone());
-    }
-  } else if (Dimensions[iSample] == 3) {
-    ReturnVec[0] = static_cast<TAxis*>(Hist3D->GetXaxis()->Clone());
-    ReturnVec[1] = static_cast<TAxis*>(Hist3D->GetYaxis()->Clone());
-    ReturnVec[2] = static_cast<TAxis*>(Hist3D->GetZaxis()->Clone());
+  if (Dimensions[iSample] == 3) {
+    ReturnVec[2] = static_cast<TAxis*>(Axis_Hist->GetZaxis()->Clone());
   } else {
-    MACH3LOG_ERROR("Number of dimensions not valid! Given: {}", Dimensions[iSample]);
-    throw MaCh3Exception(__FILE__, __LINE__);
+    // creating dummy binning
+    constexpr double DummyEdges[2] = {-1e15, 1e15};
+    ReturnVec[2] = new TAxis(1, DummyEdges);
   }
 
   for (unsigned int iAxis = 0; iAxis < ReturnVec.size(); ++iAxis) {
@@ -446,8 +431,6 @@ std::vector<TAxis *> BinnedSplineHandler::FindSplineBinning(const std::string& F
   }
 
   MACH3LOG_INFO("Left PrintBinning now tidying up");
-  delete DummyAxis;
-
   return ReturnVec;
 }
 

--- a/Splines/BinnedSplineHandler.h
+++ b/Splines/BinnedSplineHandler.h
@@ -15,9 +15,7 @@ class BinnedSplineHandler : public SplineBase {
     /// @brief Destructor
     virtual ~BinnedSplineHandler();
 
-    /// @brief CW: This Eval should be used when using two separate x,{y,a,b,c,d} arrays
-    /// to store the weights; probably the best one here! Same thing but pass parameter
-    /// spline segments instead of variations
+    /// @copydoc SplineBase::Evaluate
     void Evaluate() final;
 
     /// @brief add oscillation channel to spline monolith
@@ -35,22 +33,20 @@ class BinnedSplineHandler : public SplineBase {
     virtual void FillSampleArray(const std::string& SampleTitle, const std::vector<std::string>& OscChanFileNames);
     /// @brief Return the splines which affect a given event
     std::vector<SplineIndex> GetEventSplines(const std::string& SampleTitle, int iOscChan, int EventMode, const std::vector<double>& VarVals);
-    /// @brief KS: After calculations are done on GPU we copy memory to CPU. This operation is asynchronous meaning while memory is being copied some operations are being carried. Memory must be copied before actual reweight. This function make sure all has been copied.
-    /// @note now is empty but once we add GPU support it will actually do something
+    /// @copydoc SplineBase::SynchroniseMemTransfer
     void SynchroniseMemTransfer() const final {return;}
     /// @brief Count how many splines we have
     int CountNumberOfLoadedSplines(bool NonFlat=false, int Verbosity=0) const;
 
     /// @brief get pointer to spline weight based on bin variables
     const M3::float_t* RetPointer(const SplineIndex& Variables) const;
-    /// @brief KS: Prepare spline file that can be used for fast loading
+    /// @copydoc SplineBase::PrepareSplineFile
     void PrepareSplineFile(std::string FileName) final;
-    /// @brief KS: Load preprocessed spline file
-    /// @param FileName Path to ROOT file with predefined reduced Spline Monolith
+    /// @copydoc SplineBase::LoadSplineFile
     void LoadSplineFile(std::string FileName) final;
 
   protected:
-    /// @brief CPU based code which eval weight for each spline
+    /// @copydoc SplineBase::CalcSplineWeights
     void CalcSplineWeights() final;
     /// @brief Initialise flat structure
     void PrepForReweight();

--- a/Splines/SplineBase.h
+++ b/Splines/SplineBase.h
@@ -53,6 +53,33 @@ class SplineBase {
     /// @brief CW:Code used in step by step reweighting, Find Spline Segment for each param
     void FindSplineSegment();
     /// @brief CPU based code which eval weight for each spline
+    ///
+    /// @details
+    ///
+    /// Splines are stored using a flat monolithic structure.
+    /// The monolith is organised as follows:
+    /// @code
+    ///   Spline 0
+    ///     Segment 0: [ Y | B | C | D ]
+    ///     Segment 1: [ Y | B | C | D ]
+    ///     Segment 2: [ Y | B | C | D ]
+    ///
+    ///   Spline 1
+    ///     Segment 0: [ Y | B | C | D ]
+    ///     Segment 1: [ Y | B | C | D ]
+    ///     Segment 2: [ Y | B | C | D ]
+    ///
+    ///   Spline 2
+    ///     Segment 0: [ Y | B | C | D ]
+    ///     Segment 1: [ Y | B | C | D ]
+    ///     Segment 2: [ Y | B | C | D ]
+    ///     ...
+    /// @endcode
+    ///
+    /// Once coefficient are grabbed we calculate weight using:
+    /// @code
+    /// weight = Y + B*dx + C*dx^2 + D*dx^3;
+    /// @endcode
     virtual void CalcSplineWeights() = 0;
 
     /// @brief KS: Prepare Fast Spline Info within SplineFile

--- a/Splines/UnbinnedSplineHandler.h
+++ b/Splines/UnbinnedSplineHandler.h
@@ -25,13 +25,12 @@ class UnbinnedSplineHandler : public SplineBase {
     /// @brief Destructor for UnbinnedSplineHandler class.
     virtual ~UnbinnedSplineHandler();
 
-    /// @brief  CW: This Eval should be used when using two separate x,{y,a,b,c,d} arrays to store the weights; probably the best one here! Same thing but pass parameter spline segments instead of variations
+    /// @copydoc SplineBase::Evaluate
     void Evaluate() final;
 
     /// @brief Get class name
     std::string GetName() const override {return "SplineMonolith";};
-
-    /// @brief KS: After calculations are done on GPU we copy memory to CPU. This operation is asynchronous meaning while memory is being copied some operations are being carried. Memory must be copied before actual reweight. This function make sure all has been copied.
+    /// @copydoc SplineBase::SynchroniseMemTransfer
     void SynchroniseMemTransfer() const final;
 
     /// @brief KS: Get pointer to total weight to make fit faster wrooom!
@@ -45,10 +44,9 @@ class UnbinnedSplineHandler : public SplineBase {
       for (M3::int_t i = 0; i < nParams; ++i) SplineInfoArray[i].splineParsPointer = spline_ParsPointers[i];
     };
     
-    /// @brief KS: Prepare spline file that can be used for fast loading
+    /// @copydoc SplineBase::PrepareSplineFile
     void PrepareSplineFile(std::string FileName) final;
-    /// @brief KS: Load preprocessed spline file
-    /// @param FileName Path to ROOT file with predefined reduced Spline Monolith
+    /// @copydoc SplineBase::LoadSplineFile
     void LoadSplineFile(std::string FileName) final;
   private:
     /// @brief KS: Set everything to null etc.
@@ -91,7 +89,7 @@ class UnbinnedSplineHandler : public SplineBase {
     /// @param manyArray Array holding coefficients for each knot
     void GetSplineCoeff_SepMany(TSpline3_red* &spl, int &nPoints, float *&xArray, float *&manyArray) const;
 
-    /// @brief CPU based code which eval weight for each spline
+    /// @copydoc SplineBase::CalcSplineWeights
     void CalcSplineWeights() final;
     /// @brief Calc total event weight
     void CalcTotalEventWeight();


### PR DESCRIPTION
# Pull request description
`FindSplineBinning `was storing separate point to TH2F or TH3F.
Both inherit from TH1 so we can use it to simplify code.

## Changes or fixes
Use oxygen copy functionality to avoid copy pasting docs.

---
- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
