### PR TITLE
Feat: Update NuDock GIT_TAG to v0.0.2-mach3

### DIFF
--- a/NuDock/CMakeLists.txt
+++ b/NuDock/CMakeLists.txt
@@ -18,7 +18,7 @@ set_target_properties(MaCh3NuDock PROPERTIES
 CPMAddPackage(
     NAME NuDock
     GITHUB_REPOSITORY "NuDock/nudock"
-    GIT_TAG "0eef1a49df06b3a714ed2a9fc1cbed6f3151144d"
+    GIT_TAG "v0.0.2-mach3"
     GIT_SHALLOW NO
     GIT_SUBMODULES_RECURSE ON
 )


### PR DESCRIPTION
# Pull request description
Update NuDock GIT_TAG to v0.0.2-mach3, the commit remains the same.

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
