### PR TITLE
feat: Decouple float double between MaCh3 and NuOsc

### DIFF
--- a/.github/workflows/CIBuild.yml
+++ b/.github/workflows/CIBuild.yml
@@ -66,6 +66,15 @@ jobs:
             file: Doc/MaCh3DockerFiles/Ubuntu25.10/Dockerfile
             tag: ubuntu25.10latest
             cmakeoptions: -DMaCh3_PYTHON_ENABLED=ON -DMaCh3_NUDOCK_ENABLED=ON
+          - os: Alma9 MaCh3=Double, NuOsc Float
+            file: Doc/MaCh3DockerFiles/Alma9/Dockerfile
+            tag: alma9latest
+            cmakeoptions: -DMaCh3_NuOsc_DOUBLE_ENABLED=False
+          - os: Alma9 MaCh3=Float, NuOsc Double
+            file: Doc/MaCh3DockerFiles/Alma9/Dockerfile
+            tag: alma9latest
+            cmakeoptions: -DMaCh3_NuOsc_DOUBLE_ENABLED=True -DMaCh3_LOW_MEMORY_STRUCTS_ENABLED=ON
+
 
     name: Build CI ${{ matrix.os }}
 

--- a/cmake/Modules/NuOscillatorSetup.cmake
+++ b/cmake/Modules/NuOscillatorSetup.cmake
@@ -51,6 +51,11 @@ IsTrue(MaCh3_MULTITHREAD_ENABLED DAN_USE_MULTITHREAD)
 IsTrue(MaCh3_LOW_MEMORY_STRUCTS_ENABLED DAN_DOUBLE)
 SwitchLogic(DAN_DOUBLE)
 
+# Override: If MaCh3_NuOsc_DOUBLE_ENABLED is explicitly set, use it to override DAN_DOUBLE
+if(DEFINED MaCh3_NuOsc_DOUBLE_ENABLED)
+  IsTrue(MaCh3_NuOsc_DOUBLE_ENABLED DAN_DOUBLE)
+endif()
+
 # Disable GPU at NuOsc
 if(NOT MaCh3_NuOsc_GPU_ENABLED)
   set(DAN_USE_GPU 0)


### PR DESCRIPTION
# Pull request description
If MaCh3 is using double then NuOsc is using double and vice versa.
In future it could be beneficial to use float at MaCh3 but still perform calculations at NuOsc with double precision.
Hence added new cmake options and appropriate bots 

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
