### PR TITLE
tidy: Unify fill array between MP and non MP code

### DIFF
--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -365,63 +365,17 @@ void SampleHandlerBase::Reweight() {
   //KS: If using CPU this does nothing, if on GPU need to make sure we finished copying memory from
   if(SplineHandler) SplineHandler->SynchroniseMemTransfer();
 
-  #ifdef MULTITHREAD
-  // Call entirely different routine if we're running with openMP
-  FillArray_MP();
-  #else
+  // Here we fill weights to MC predictions weights for splines and osc already have been filled
   FillArray();
-  #endif
 
   //KS: If you want to not update W2 wights then uncomment this line
   if(!UpdateW2) FirstTimeW2 = false;
 }
 
-//************************************************
-// Function which does the core reweighting. This assumes that oscillation weights have
-// already been calculated and stored in SampleHandlerBase.osc_w[iEvent]. This
-// function takes advantage of most of the things called in setupSKMC to reduce reweighting time.
-// It also follows the ND code reweighting pretty closely. This function fills the SampleHandlerBase
-// array array which is binned to match the sample binning, such that bin[1][1] is the
-// equivalent of SampleDetails._hPDF2D->GetBinContent(2,2) {Noticing the offset}
-void SampleHandlerBase::FillArray() {
-//************************************************
-  //DB Reset which cuts to apply
-  Selection = StoredSelection;
-
-  for (unsigned int iEvent = 0; iEvent < GetNEvents(); iEvent++) {
-    ApplyShifts(iEvent);
-    const EventInfo* _restrict_ MCEvent = &MCEvents[iEvent];
-
-    if (!IsEventSelected(MCEvent->NominalSample, iEvent)) {
-      continue;
-    }
-
-    // Virtual by default does nothing, has to happen before CalcWeightTotal
-    CalcWeightFunc(iEvent);
-
-    const M3::float_t totalweight = CalcWeightTotal(MCEvent);
-    //DB Catch negative total weights and skip any event with a negative weight. Previously we would set weight to zero and continue but that is inefficient
-    if (totalweight <= 0.){
-      continue;
-    }
-
-    //DB Find the relevant bin in the PDF for each event
-    const int GlobalBin = Binning->FindGlobalBin(MCEvent->NominalSample, MCEvent->KinVar, MCEvent->NomBin);
-
-    //DB Fill relevant part of thread array
-    if (GlobalBin > M3::UnderOverFlowBin) {
-      SampleHandler_array[GlobalBin] += totalweight;
-      if (FirstTimeW2) SampleHandler_array_w2[GlobalBin] += totalweight*totalweight;
-    }
-  }
-}
-
-#ifdef MULTITHREAD
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Walloca"
 // ************************************************
-/// Multithreaded version of fillArray @see fillArray()
-void SampleHandlerBase::FillArray_MP() {
+void SampleHandlerBase::FillArray() {
 // ************************************************
   //DB Reset which cuts to apply
   Selection = StoredSelection;
@@ -440,13 +394,14 @@ void SampleHandlerBase::FillArray_MP() {
   // 1. Order minituples in Y-axis variable as this will *hopefully* reduce cache misses inside SampleHandler_array_class[yBin][xBin]
   //
   // We will hit <0.1 s/step eventually! :D
-  const auto TotalBins = Binning->GetNBins();
+  [[maybe_unused]] const auto TotalBins = Binning->GetNBins();
   const unsigned int NumberOfEvents = GetNEvents();
 
   double* _restrict_ MC_Array_for_reduction = SampleHandler_array.data();
   double* _restrict_ W2_array_for_reduction = SampleHandler_array_w2.data();
-
+  #ifdef MULTITHREAD
   #pragma omp parallel for reduction(+:MC_Array_for_reduction[:TotalBins], W2_array_for_reduction[:TotalBins])
+  #endif
   for (unsigned int iEvent = 0; iEvent < NumberOfEvents; ++iEvent) {
     //ETA - generic functions to apply shifts to kinematic variables
     // Apply this before IsEventSelected is called.
@@ -481,7 +436,6 @@ void SampleHandlerBase::FillArray_MP() {
   }
 }
 #pragma GCC diagnostic pop
-#endif
 
 // **************************************************
 // Helper function to reset the data and MC histograms

--- a/Samples/SampleHandlerBase.h
+++ b/Samples/SampleHandlerBase.h
@@ -267,7 +267,7 @@ class SampleHandlerBase :  public SampleHandlerInterface
   // ----- start Functional Parameters -----
   /// @brief HH - a experiment-specific function where the maps to actual functions are set up
   virtual void RegisterFunctionalParameters(){};
-  /// @brief Update the functional parameter values to the latest proposed values. Needs to be called before every new reweight so is called in fillArray
+  /// @brief Update the functional parameter values to the latest proposed values. Needs to be called before every new reweight so is called in FillArray
   virtual void PrepFunctionalParameters(){};
 
   /// @brief LP - Registration template function for multi-dimensional functional shifts
@@ -369,14 +369,8 @@ class SampleHandlerBase :  public SampleHandlerInterface
   /// DB Replace previous implementation with reading bin contents from SampleHandler_array
   void FillHist(const int Sample, TH1* Hist, std::vector<double> &Array);
 
-  /// @brief DB Nice new multi-threaded function which calculates the event weights and fills the relevant bins of an array
-#ifdef MULTITHREAD
-  /// @brief Function which does the core reweighting, fills the @ref SampleHandlerBase::SampleHandler_array
-  /// vector with the weight calculated from reweighting but multithreaded
-  void FillArray_MP();
-#endif
-  /// @brief Function which does the core reweighting, fills the @ref SampleHandlerBase::SampleHandler_array
-  /// vector with the weight calculated from reweighting
+  /// @brief Function which does the core reweighting. This assumes that oscillation weights have
+  /// already been calculated.
   void FillArray();
 
   /// @brief Helper function to reset histograms


### PR DESCRIPTION
# Pull request description
Historically, MP and non MP code was quite different which is why we had both.

Due to recent changes code is much more similar to the point that now we completely unified.
Only different is that MP actually using multithreading but otherwise code are the same making maintenance easier.

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
