### PR TITLE
tidy: bump pybind11 version to 2.13.6

### DIFF
--- a/cmake/Modules/pyMaCh3.cmake
+++ b/cmake/Modules/pyMaCh3.cmake
@@ -14,12 +14,11 @@ function(setup_pyMaCh3)
 
   ## get pybind dependency
   set(PYBIND11_FINDPYTHON ON)
-  CPMFindPackage(
+  CPMAddPackage(
       NAME pybind11
-      VERSION 2.13.5
+      GIT_TAG v2.13.6
       GITHUB_REPOSITORY "pybind/pybind11"
       GIT_SHALLOW YES
-      GIT_TAG v2.13.5
     )
   
   cmake_parse_arguments(


### PR DESCRIPTION
# Pull request description
Simply bump pybind version which doesn't require any API changes:
https://github.com/pybind/pybind11/releases/tag/v2.13.6

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
