### PR TITLE
bugfix: Add a Start condition for RM

### DIFF
--- a/Parameters/AdaptiveMCMCHandler.h
+++ b/Parameters/AdaptiveMCMCHandler.h
@@ -219,8 +219,12 @@ class AdaptiveMCMCHandler
   }
 
   /// Use Robbins-Monro approach?
-  bool GetUseRobbinsMonro() const
+  bool GetStartRobbinsMonro() const
   {
+    return use_robbins_monro && total_steps>start_adaptive_throw && total_steps<end_adaptive_update;
+  }
+
+  bool GetUseRobbinsMonro() const{
     return use_robbins_monro;
   }
 
@@ -285,11 +289,11 @@ private:
   /// Acceptance rate in the current batch
   int acceptance_rate_batch_size;
 
-  /// Use Robbins Monro https://arxiv.org/pdf/1006.3690
-  bool use_robbins_monro;
-
   /// Target acceptance rate for Robbins Monro
   double target_acceptance;
+
+  /// Use Robbins Monro https://arxiv.org/pdf/1006.3690
+  bool use_robbins_monro;
 
   /// Constant "step scaling" factor for Robbins-Monro
   double c_robbins_monro;

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -1106,7 +1106,7 @@ void ParameterHandlerBase::UpdateAdaptiveCovariance() {
   }
 
   /// Need to adjust the scale every step
-  if(AdaptiveHandler->GetUseRobbinsMonro()){
+  if(AdaptiveHandler->GetStartRobbinsMonro()){
     bool verbose=false;
     #ifdef MACH3_DEBUG
     verbose=true;


### PR DESCRIPTION
# Pull request description
Robbins monro started its update when the Adaptive MCMC matrix starts updating NOT when the throws start. This can result in a rapidly deteriorating acceptance rate. 

Whilst this will eventually recover as the RM scale gets smaller it is inefficient.

---

- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
