### PR TITLE
tidy: Further reduce legacy use of xsec keyword

### DIFF
--- a/NuDock/SampleHandlerNuDockBase.cpp
+++ b/NuDock/SampleHandlerNuDockBase.cpp
@@ -5,11 +5,11 @@
 // ***************************************************************************
 /// @copydoc SampleHandlerNuDockBase::SampleHandlerNuDockBase
 // ***************************************************************************
-SampleHandlerNuDockBase::SampleHandlerNuDockBase(std::string configFile, ParameterHandlerGeneric* xsec_cov)
+SampleHandlerNuDockBase::SampleHandlerNuDockBase(std::string configFile, ParameterHandlerGeneric* par_handler)
 : SampleHandlerInterface() {
   MACH3LOG_INFO("Creating SampleHandlerNuDock object..");
   MACH3LOG_INFO("- Using NuDock sample config in this file {}", configFile);
-  ParHandler = xsec_cov;
+  ParHandler = par_handler;
   SampleManager = std::make_unique<Manager>(configFile.c_str());
   verbose = GetFromManager(SampleManager->raw()["NuDockClient"]["Verbose"], false, __FILE__, __LINE__);
 
@@ -49,13 +49,13 @@ void SampleHandlerNuDockBase::Init() {
 void SampleHandlerNuDockBase::Reweight() {
   nlohmann::json request;
   std::unordered_map<std::string, double> osc_params;
-  std::unordered_map<std::string, double> xsec_params;
+  std::unordered_map<std::string, double> sys_params;
   
   // Loop for systs
   for (const auto& iParam : nudockParamInds) {
     std::string paramName = ParHandler->GetParFancyName(iParam);
     double paramValue = ParHandler->GetParProp(iParam);
-    xsec_params[paramName] = paramValue;
+    sys_params[paramName] = paramValue;
   }
 
   // Loop over NuDockOscNameMap_r to get osc params
@@ -71,7 +71,7 @@ void SampleHandlerNuDockBase::Reweight() {
   }
 
   request["osc_pars"] = osc_params;
-  request["sys_pars"] = xsec_params;
+  request["sys_pars"] = sys_params;
 
   auto response = nudock_ptr->send_request("/set_parameters", request);
   if (verbose) {

--- a/NuDock/SampleHandlerNuDockBase.h
+++ b/NuDock/SampleHandlerNuDockBase.h
@@ -27,9 +27,9 @@ public:
   ///
   /// @param configFile Path to a YAML configuration file containing the
   ///                   NuDockClient block.
-  /// @param xsec_cov   Pointer to the cross-section parameter handler from
-  ///                   which current parameter values are read.
-  SampleHandlerNuDockBase(std::string configFile, ParameterHandlerGeneric* xsec_cov);
+  /// @param par_handler Pointer to the cross-section parameter handler from
+  ///                    which current parameter values are read.
+  SampleHandlerNuDockBase(std::string configFile, ParameterHandlerGeneric* par_handler);
 
   /// @brief Destructor.
   virtual ~SampleHandlerNuDockBase();

--- a/Parameters/ParameterHandlerBase.cpp
+++ b/Parameters/ParameterHandlerBase.cpp
@@ -798,7 +798,6 @@ void ParameterHandlerBase::SetParameters(const std::vector<double>& pars) {
   #pragma GCC diagnostic ignored "-Wuseless-cast"
   // If empty, set the proposed to prior
   if (pars.empty()) {
-    // For xsec this means setting to the prior (because prior is the prior)
     for (int i = 0; i < _fNumPar; i++) {
       _fPropVal[i] = static_cast<M3::float_t>(_fPreFitValue[i]);
     }

--- a/Samples/HistogramUtils.cpp
+++ b/Samples/HistogramUtils.cpp
@@ -499,14 +499,14 @@ void MakeFluctuatedHistogramAlternative(TH2D* FluctHist, TH2D* PolyHist) {
   }
 }
 // ****************
-//KS: ROOT developers were too lazy do develop getRanom2 for TH2Poly, this implementation is based on:
+// KS: ROOT developers were too lazy do develop getRanom2 for TH2Poly, this implementation is based on:
 // https://root.cern.ch/doc/master/classTH2.html#a883f419e1f6899f9c4255b458d2afe2e
 int GetRandomPoly2(const TH2Poly* PolyHist) {
 // ****************
   const int nbins = PolyHist->GetNumberOfBins();
   const double r1 = M3::rand::Uniform();;
 
-  double* fIntegral = new double[nbins+2];
+  std::vector<double> fIntegral(nbins+2);
   fIntegral[0] = 0.0;
 
   //KS: This is custom version of ComputeIntegral, once again ROOT was lazy :(
@@ -520,11 +520,10 @@ int GetRandomPoly2(const TH2Poly* PolyHist) {
   fIntegral[nbins+1] = PolyHist->GetEntries();
 
   //KS: We just return one rather then X and Y, this way we can use SetBinContent rather than Fill, which is faster
-  int iBin = int(TMath::BinarySearch(nbins, fIntegral, r1));
+  int iBin = int(TMath::BinarySearch(nbins, fIntegral.data(), r1));
   //KS: Have to increment because TH2Poly has stupid offset arghh
   iBin += 1;
 
-  delete[] fIntegral;
   return iBin;
 }
 

--- a/Samples/SampleHandlerBase.cpp
+++ b/Samples/SampleHandlerBase.cpp
@@ -17,7 +17,7 @@ SampleHandlerBase::SampleHandlerBase(std::string ConfigFileName, ParameterHandle
 
   //ETA - safety feature so you can't pass a NULL _ParHandler
   if(!_ParHandler) {
-    MACH3LOG_WARN("You've passed me a nullptr ParameterHandler so I will not use any xsec parameters");
+    MACH3LOG_WARN("You've passed me a nullptr ParameterHandler so I will not use any model parameter");
   }
   ParHandler = _ParHandler;
   nEvents = 0;
@@ -570,7 +570,7 @@ void SampleHandlerBase::CalcNormsBins(std::vector <std::vector<NormParameter>>& 
       auto& NormParam = norm_parameters[SampleId];
       // Skip oscillated NC events
       // Not strictly needed, but these events don't get included in oscillated predictions, so
-      // no need to waste our time calculating and storing information about xsec parameters
+      // no need to waste our time calculating and storing information about xsec/flux etc. parameters
       // that will never be used.
       if (MCEvents[iEvent].isNC && (MCEvents[iEvent].nupdg != MCEvents[iEvent].nupdgUnosc) ) {
         MACH3LOG_TRACE("Event {}, missed NC/signal check", iEvent);

--- a/Splines/SplineBase.h
+++ b/Splines/SplineBase.h
@@ -101,7 +101,7 @@ class SplineBase {
     /// @brief Since we find segment before actual reweight and sometimes we want to copy it to GPU we have different functionality depending if GPU or CPU
     void SetupSegments();
 
-    /// Array of FastSplineInfo structs: keeps information on each xsec spline for fast evaluation
+    /// Array of FastSplineInfo structs: keeps information on each spline for fast evaluation
     /// Method identical to TSpline3::Eval(double) but faster because less operations
     std::vector<FastSplineInfo> SplineInfoArray;
     /// Store currently found segment they are not in FastSplineInfo as in case of GPU we need to copy paste it to GPU


### PR DESCRIPTION
# Pull request description
In the past everything was xsec param or xsec_cov. Which is confusing so trying to update comments in the code etc.


---
- [x] I have read and followed the [contributing guidelines](https://github.com/mach3-software/MaCh3/blob/develop/.github/CONTRIBUTING.md).
